### PR TITLE
Fix for gh-14 slider jumps to max value after changing value in textbox

### DIFF
--- a/ui/slider.reel/slider.js
+++ b/ui/slider.reel/slider.js
@@ -289,7 +289,7 @@ exports.Slider = Montage.create(Component,/** @lends module:"montage/ui/slider.r
         set: function (value) {
             if (!isNaN(value)) {
                 if (value !== this._value) {
-                    this._value = value;
+                    this._value = parseFloat(value);
                     this.needsDraw = true;
                 }
             }


### PR DESCRIPTION
The value set by the text box was a string so the calculations were
not being done correctly.
