### PR TITLE
Promise speed optimizations

### DIFF
--- a/core/promise.js
+++ b/core/promise.js
@@ -5,7 +5,7 @@
  </copyright> */
 
 // Scope:
-//  * ES5, W3C setImmediate (shimmed if necessary)
+//  * ES5, nextTick
 //  * speed and economy of memory before safety and securability
 //  * run-time compatibility via thenability
 
@@ -32,10 +32,10 @@
 
 try {
     // bootstrapping can't handle relative identifiers
-    require("core/shim/timers"); // setImmediate
+    require("core/shim/timers"); // nextTick
 } catch (exception) {
     // in this case, node can't handle absolute identifiers
-    require("./shim/timers"); // setImmediate
+    require("./shim/timers"); // nextTick
 }
 
 // merely ensures that the returned value can respond to
@@ -107,17 +107,10 @@ var PrimordialPromise = Creatable.create({
         value: function (descriptor, promiseDescriptor) {
 
             // automatically subcreate each of the contained promise types
-            var creation = Object.create(this, {
-                DeferredPromise: {
-                    value: this.DeferredPromise.create(promiseDescriptor)
-                },
-                FulfilledPromise: {
-                    value: this.FulfilledPromise.create(promiseDescriptor)
-                },
-                RejectedPromise: {
-                    value: this.RejectedPromise.create(promiseDescriptor)
-                }
-            });
+            var creation = Object.create(this);
+            creation.DeferredPromise = this.DeferredPromise.create(promiseDescriptor);
+            creation.FulfilledPromise = this.FulfilledPromise.create(promiseDescriptor);
+            creation.RejectedPromise = this.RejectedPromise.create(promiseDescriptor);
 
             if (descriptor) {
                 Object.defineProperties(creation, descriptor);
@@ -125,17 +118,13 @@ var PrimordialPromise = Creatable.create({
 
             // create static reflections of all new promise methods
             if (promiseDescriptor) {
-                var statics = {};
                 Object.keys(promiseDescriptor).forEach(function (name) {
-                    statics[name] = {
-                        value: function (value) {
-                            var args = Array.prototype.slice.call(arguments, 1);
-                            var promise = this.ref(value);
-                            return promise[name].apply(promise, args);
-                        }
+                    creation[name] = function (value) {
+                        var args = Array.prototype.slice.call(arguments, 1);
+                        var promise = this.ref(value);
+                        return promise[name].apply(promise, args);
                     };
                 });
-                Object.defineProperties(creation, statics);
             }
 
             return creation;
@@ -182,15 +171,10 @@ var PrimordialPromise = Creatable.create({
 
     fulfill: {
         value: function (value) {
-            return this.FulfilledPromise.create({
-                _value: {
-                    value: value,
-                    writable: true
-                },
-                Promise: {
-                    value: this
-                }
-            });
+            var self = Object.create(this.FulfilledPromise);
+            self._value = value;
+            self.Promise = this;
+            return self;
         }
     },
 
@@ -246,17 +230,10 @@ var PrimordialPromise = Creatable.create({
 
     reject: {
         value: function (reason, error) {
-            var self = this.RejectedPromise.create({
-                _reason: {
-                    value: reason
-                },
-                _error: {
-                    value: error
-                },
-                Promise: {
-                    value: this
-                }
-            });
+            var self = Object.create(this.RejectedPromise);
+            self._reason = reason;
+            self._error = error;
+            self.Promise = this;
             errors.push(error && error.stack || self);
             return self;
         }
@@ -310,31 +287,13 @@ var PrimordialPromise = Creatable.create({
     defer: {
         value: function () {
             var deferred;
-            var promise = this.DeferredPromise.create({
-                _pending: {
-                    value: [],
-                    writable: true
-                },
-                _value: {
-                    value: undefined,
-                    writable: true
-                },
-                Promise: {
-                    value: this
-                }
-            });
-            deferred = this.Deferred.create({
-                promise: {
-                    value: promise,
-                    enumerable: true
-                },
-                Promise: {
-                    value: this
-                }
-            });
-            Object.defineProperty(promise, "_deferred", {
-                value: deferred
-            });
+            var promise = Object.create(this.DeferredPromise);
+            promise._pending = [];
+            promise.Promise = this;
+            deferred = Object.create(this.Deferred);
+            deferred.promise = promise;
+            deferred.Promise = this;
+            promise._deferred = deferred;
             return deferred;
         }
     },
@@ -349,7 +308,7 @@ var PrimordialPromise = Creatable.create({
                     }
                     this.promise._value = value = toPromise(value);
                     this.promise._pending.forEach(function (pending) {
-                        setImmediate(function () {
+                        nextTick(function () {
                             value.sendPromise.apply(value, pending);
                         });
                     });
@@ -380,7 +339,7 @@ var PrimordialPromise = Creatable.create({
                     } else {
                         var args = arguments,
                             value = this._value;
-                        setImmediate(function () {
+                        nextTick(function () {
                             value.sendPromise.apply(value, args);
                         });
                     }
@@ -453,7 +412,7 @@ var Promise = PrimordialPromise.create({}, { // Descriptor for each of the three
                 }
             }
 
-            setImmediate(function () {
+            nextTick(function () {
                 self.sendPromise(
                     function (value) {
                         if (done) {
@@ -486,7 +445,7 @@ var Promise = PrimordialPromise.create({}, { // Descriptor for each of the three
         value: function (name, args) {
             var deferred = Promise.defer();
             var self = this;
-            setImmediate(function () {
+            nextTick(function () {
                 self.sendPromise.apply(
                     self,
                     [
@@ -640,7 +599,7 @@ var Promise = PrimordialPromise.create({}, { // Descriptor for each of the three
             this.then(void 0, function (reason, error) {
                 // forward to a future turn so that ``when``
                 // does not catch it and turn it into a rejection.
-                setImmediate(function () {
+                nextTick(function () {
                     console.error(error && error.stack || error || reason);
                     throw error;
                 });

--- a/core/shim/timers.js
+++ b/core/shim/timers.js
@@ -46,18 +46,16 @@ if (typeof process !== "undefined") {
         channel.port2.postMessage(void 0);
     }
 } else if (typeof setTimeout !== "undefined") {
-
     nextTick = function (callback) {
         setTimeout(callback, 0);
     };
-} else {
+} else if (typeof setImmediate === "undefined") {
     throw new Error("Can't shim setImmediate.");
 }
 
 if (typeof setImmediate === "undefined") {
     var nextHandle = 0;
     var handles = {};
-
 
     global.setImmediate = function setImmediate(callback) {
         var handle = nextHandle++;
@@ -77,7 +75,17 @@ if (typeof setImmediate === "undefined") {
     global.clearImmediate = function clearImmediate(handle) {
         delete handles[handle];
     };
+} else {
+    // If setImmediate is native, use it as nextTick since
+    // that should have less overhead than the nextTick
+    // shim
+    nextTick = setImmediate;
 }
+
+// Publish nextTick because it either is setImmediate or it
+// is a shim that has less overhead than the setImmediate
+// shim.
+global.nextTick = nextTick;
 
 // Make this work as a <script> for bootstrapping montage.js
 if (typeof bootstrap !== "undefined") {


### PR DESCRIPTION
Per @marchant this morning, this eliminates the use of descriptors in constructor/initializer code. Descriptors remain in subtype definition.  This does not make use of Montage’s "distinct" feature because this module is loaded in the bootstrapping process, so Montage is not yet available.  Also, it would probably add some overhead.

I also bypass some overhead of setImmediate shims, going straight to nextTick, so there’s no clearImmediate handler tracking or arguments array processing.
