### PR TITLE
Merge nextTick events

### DIFF
--- a/core/shim/timers.js
+++ b/core/shim/timers.js
@@ -31,17 +31,27 @@ if (typeof process !== "undefined") {
 } else if (typeof MessageChannel !== "undefined") {
     // http://www.nonblocking.io/2011/06/windownexttick.html
     var channel = new MessageChannel();
-    // linked list of tasks (single, with head node)
+    // queue of tasks implemented as a singly linked list with a head node
     var head = {}, tail = head, pending;
 
     channel.port1.onmessage = function () {
-        while (head.next) {
-            var next = head.next;
-            var task = next.task;
-            head = next;
-            task();
+        try {
+            // unroll all pending events
+            while (head.next) {
+                head = head.next;
+                // guarantee consistent queue state
+                // before task, because it may throw
+                head.task(); // may throw
+            }
+            pending = false;
+        } finally {
+            // if a task throws an exception and
+            // there are more pending tasks, dispatch
+            // another event
+            if (pending) {
+                channel.port2.postMessage(void 0);
+            }
         }
-        pending = false;
     };
 
     nextTick = function (task) {


### PR DESCRIPTION
This patch unrolls all pending nextTick callbacks in a single event, which decreases timeline chatter and improves performance.
