### PR TITLE
Fix bootstrapping in Chrome extensions

### DIFF
--- a/montage.js
+++ b/montage.js
@@ -220,8 +220,8 @@ if (typeof window !== "undefined") {
         var relativeElement = document.createElement("a");
         exports.resolve = function (base, relative) {
             base = String(base);
-            if (!/^\w+:/.test(base))
-                throw new Error("Can't resolve from relative base");
+            if (!/^[\w\-]+:/.test(base))
+                throw new Error("Can't resolve from relative base:" + JSON.stringify(base) + " " + JSON.stringify(relative));
             var restore = baseElement.href;
             baseElement.href = base;
             relativeElement.href = relative;

--- a/require/require.js
+++ b/require/require.js
@@ -449,6 +449,8 @@
         });
         Object.keys(mappings).forEach(function (name) {
             var mapping = mappings[name] = Dependency(mappings[name]);
+            if (!/\/$/.test(mapping.location))
+                mapping.location += "/";
             if (!Require.isAbsolute(mapping.location))
                 mapping.location = URL.resolve(location, mapping.location);
         });
@@ -645,7 +647,7 @@
             return config.loadPackage(mapping)
             .then(function (pkg) {
                 var rest = id.slice(prefix.length + 1);
-                return pkg.deepLoad(rest)
+                return pkg.deepLoad(rest, config.location)
                 .then(function () {
                     return {
                         factory: function (require, exports, module) {
@@ -716,7 +718,7 @@
                 });
             };
         }, function (id) {
-            throw new Error("Can't find " + JSON.stringify(id));
+            throw new Error("Can't find " + JSON.stringify(id) + " from paths " + JSON.stringify(config.paths) + " in package at " + JSON.stringify(config.location));
         });
         return function(id, module) {
             if (Require.isAbsolute(id)) {


### PR DESCRIPTION
Chrome extensions have a hyphen in the protocol, which complicates
quickly identifying protocol schemes.

The native URL resolver is fickle. It doesn’t normalize double slashes
(so I had previously removed explicit final-slashes).  This patch
ascertains that mappings have a final slash in their location property.
