### PR TITLE
Fix cyclic redirect problem with packages/modules

### DIFF
--- a/require/require.js
+++ b/require/require.js
@@ -367,24 +367,25 @@
 
         // The default "main" module of a package has the same name as the
         // package.
-        if (description.main === void 0)
-            description.main = description.name;
+        if (description.main !== void 0) {
 
-        // main, injects a definition for the main module, with
-        // only its path. makeRequire goes through special effort
-        // in deepLoad to re-initialize this definition with the
-        // loaded definition from the given path.
-        modules[""] = {
-            id: "",
-            redirect: description.main,
-            location: config.location
-        };
+            // main, injects a definition for the main module, with
+            // only its path. makeRequire goes through special effort
+            // in deepLoad to re-initialize this definition with the
+            // loaded definition from the given path.
+            modules[""] = {
+                id: "",
+                redirect: description.main,
+                location: config.location
+            };
 
-        modules[description.name] = {
-            id: description.name,
-            redirect: "",
-            location: URL.resolve(location, description.name)
-        };
+            modules[description.name] = {
+                id: description.name,
+                redirect: "",
+                location: URL.resolve(location, description.name)
+            };
+
+        }
 
         // mappings, link this package to other packages.
         var mappings = description.mappings || {};


### PR DESCRIPTION
This is a regression caused by my refactor to use redirects, but pretty
easy to fix.  Instead of always creating redirects for the module with
the same name as the package and for the main module of the package, we
only create these redirects if the "main" property is configured.

Thus, examples/temp-converter, which has a package name of
"temp-converter" and a module "temp-converter", but does not define
"main" is "temp-converter", will not go into an infinite loop while
looking for that module.
