### PR TITLE
Fix promise library for Firefox

### DIFF
--- a/core/promise.js
+++ b/core/promise.js
@@ -67,7 +67,9 @@ var Creatable = Object.create(Object.prototype, {
         value: function (descriptor) {
             for (var name in descriptor) {
                 var property = descriptor[name];
-                property.writable = true;
+                if (!property.set && !property.get) {
+                    property.writable = true
+                }
                 property.configurable = true;
             }
             return Object.create(this, descriptor);


### PR DESCRIPTION
Promises need to have some writable properties. Rather than explicate
every property, and because we can’t import Montage during
bootstrapping, just default all properties to writable and configurable.
These problems go unnoticed in engines that do not implement strict mode
fully.
