### PR TITLE
Robustifying apache-montage.conf

### DIFF
--- a/etc/apache-montage.conf
+++ b/etc/apache-montage.conf
@@ -1,16 +1,18 @@
 Listen 8081
 NameVirtualHost *:8081
 <VirtualHost *:8081>
-    DocumentRoot "/PATH/TO/PROJECTS"
+    DocumentRoot "/PATH/TO/PROJECTS/montage"
 
-    <Directory /PATH/TO/PROJECTS/montage>
+    <Directory "/PATH/TO/PROJECTS/montage">
        Options Indexes
        AllowOverride All
+       Order allow,deny
+       Allow from All
     </Directory>
 
     #Optional touch friendly index page
-    Alias /montage-index /PATH/TO/PROJECTS/montage/etc/apache-montage-index
-    Include /PATH/TO/PROJECTS/montage/etc/apache-montage-index/index.conf
+    Alias /montage-index "/PATH/TO/PROJECTS/montage/etc/apache-montage-index"
+    Include "/PATH/TO/PROJECTS/montage/etc/apache-montage-index/index.conf"
 
     <IfModule deflate_module>
         SetOutputFilter DEFLATE


### PR DESCRIPTION
This commit adds quotation marks around all paths (not always required by Apache but good practice), sets the DocumentRoot to point to the montage directory, and adds Order and Allow directives to the Directory block.
