### PR TITLE
V0.6

### DIFF
--- a/ui/slot.reel/slot.js
+++ b/ui/slot.reel/slot.js
@@ -247,7 +247,10 @@ var Slot = exports.Slot = Montage.create(Component, /** @lends module:"montage/u
 
                 // Introduce to the componentTree if content appended was a component
                 if (this._contentToAppend && (typeof this._contentToAppend.element !== "undefined")) {
-                    this.childComponents = [this._contentToAppend];
+                    this._contentToAppend.attachToParentComponent();
+                    // HACK: gets around the issue of the component never being part of the draw loop again because of the idempotence of the needsDraw = true.
+                    this._contentToAppend.needsDraw = false;
+                    this._contentToAppend.needsDraw = true;
                 }
             }
 


### PR DESCRIPTION
...ent

When the content of the slot is needsDraw=true and set an element it is not being added to the draw loop because it is not part of the component tree since its element isn't in the DOM yet.

When the content is finally added to the component tree needsDraw=true doesn't have any effect anymore because it is already in that state, never making it to the draw cycle ever again.

This will be correctly addressed in master.
