### PR TITLE
Add test case for components assigned an element that resides outside th...

### DIFF
--- a/test/ui/component-spec.js
+++ b/test/ui/component-spec.js
@@ -258,6 +258,19 @@ var testPage = TestPageLoader.queueTest("draw", function() {
                         });
                     });
                 });
+                
+                it("TODO: should draw a component that was assigned an element not part of the DOM tree when it's added to the DOM tree", function() {
+                    var component = testPage.test.componentNoelement,
+                        element = component.element;
+                    
+                    testPage.window.document.body.appendChild(element);
+                    component.needsDraw = true;
+                    
+                    testPage.waitForDraw();
+                    runs(function() {
+                        expect(element.textContent).toBe(component.value);
+                    });
+                });
             });
 
             describe("didDraw calling after draw", function() {

--- a/test/ui/draw/component-noelement.reel/component-noelement.js
+++ b/test/ui/draw/component-noelement.reel/component-noelement.js
@@ -1,0 +1,21 @@
+var Montage = require("montage").Montage,
+    Component = require("montage/ui/component").Component;
+
+exports.ComponentNoelement = Montage.create(Component, {
+    hasTemplate: {value: false},
+    
+    deserializedFromSerialization: {
+        value: function() {
+            var element = document.createElement("div");
+            
+            this.element = element;
+            this.needsDraw = true;
+        }
+    },
+    
+    draw: {
+        value: function() {
+            this.element.textContent = this.value;
+        }
+    }
+});

--- a/test/ui/draw/draw.html
+++ b/test/ui/draw/draw.html
@@ -18,7 +18,8 @@
         "properties": {
             "repetition": {"@": "repetition"},
             "componentC": {"@": "componentC"},
-            "componentC1": {"@": "componentC1"}
+            "componentC1": {"@": "componentC1"},
+            "componentNoelement": {"@": "componentNoelement"}
         }
     },
     "repetition": {
@@ -45,6 +46,15 @@
             "hasTemplate": false
         }
     },
+    
+    "componentNoelement": {
+        "module": "ui/draw/component-noelement.reel",
+        "name": "ComponentNoelement",
+        "properties": {
+            "value": "componentNoelement"
+        }
+    },
+    
     "owner": {
         "module": "montage/ui/application",
         "name": "Application",


### PR DESCRIPTION
...e DOM tree

A component that has an element outside of the DOM tree and was asked to draw will not get drawn after the element is attached to the DOM tree. Not even if a draw is requested again because needsDraw is idempotent.
