### PR TITLE
String constant optimizations

### DIFF
--- a/core/core.js
+++ b/core/core.js
@@ -12,6 +12,16 @@
  */
 require("core/shim");
 
+var AttributePropertiesString = "AttributeProperties",
+	UnderscoreString = "_",
+	__proto__String = "__proto__",
+	valueString = "value",
+	enumerableString = "enumerable",
+	serializableString = "serializable",
+	modifyString = "modify";
+
+
+
 /**
  @external Object
  */
@@ -78,14 +88,14 @@ Object.defineProperty(M, "create", {
     }
 });
 
-var extendedPropertyAttributes = ["serializable", "modify"];
+var extendedPropertyAttributes = [serializableString, modifyString];
 
 // Extended property attributes, the property name format is "_" + attributeName + "AttributeProperties"
 /**
 @member external:Object#extendedPropertyAttributes
 */
 extendedPropertyAttributes.forEach(function(name) {
-    Object.defineProperty(Object.prototype, "_" + name + "AttributeProperties", {
+    Object.defineProperty(Object.prototype, UnderscoreString + name + AttributePropertiesString, {
         enumerable: false,
         configurable: false,
         writable: false,
@@ -112,11 +122,11 @@ Object.defineProperty(M, "defineProperty", {
     value: function(obj, prop, descriptor) {
         var dependencies = descriptor.dependencies;
         //reset defaults appropriately for framework.
-        if ("__proto__" in descriptor) {
-            descriptor.__proto__ = ("value" in descriptor ? (typeof descriptor.value === "function" ? _defaultFunctionValueProperty : _defaultObjectValueProperty) : _defaultAccessorProperty);
+        if (__proto__String in descriptor) {
+            descriptor.__proto__ = (valueString in descriptor ? (typeof descriptor.value === "function" ? _defaultFunctionValueProperty : _defaultObjectValueProperty) : _defaultAccessorProperty);
         } else {
             var defaults;
-            if ("value" in descriptor) {
+            if (valueString in descriptor) {
                 if (typeof descriptor.value === "function") {
                     defaults = _defaultFunctionValueProperty;
                 } else {
@@ -133,7 +143,7 @@ Object.defineProperty(M, "defineProperty", {
         }
 
 
-        if (!descriptor.hasOwnProperty("enumerable") && prop.charAt(0) === "_") {
+        if (!descriptor.hasOwnProperty(enumerableString) && prop.charAt(0) === UnderscoreString) {
             descriptor.enumerable = false;
         }
         if (dependencies) {
@@ -146,13 +156,13 @@ Object.defineProperty(M, "defineProperty", {
 
         }
 
-        if ("serializable" in descriptor) {
+        if (serializableString in descriptor) {
             // get the _serializableAttributeProperties property or creates it through the entire chain if missing.
-            getAttributeProperties(obj, "serializable")[prop] = descriptor.serializable;
+            getAttributeProperties(obj, serializableString)[prop] = descriptor.serializable;
         }
 
-        if ("modify" in descriptor) {
-            getAttributeProperties(obj, "modify")[prop] = descriptor.modify;
+        if (modifyString in descriptor) {
+            getAttributeProperties(obj, modifyString)[prop] = descriptor.modify;
         }
 
         //this is added to enable value properties with [] or Objects that are new for every instance
@@ -268,7 +278,7 @@ Object.defineProperty(M, "defineProperty", {
                         }
                     });
                 }
-            })("_" + prop, descriptor.value);
+            })(UnderscoreString + prop, descriptor.value);
 
         } else {
             return Object.defineProperty(obj, prop, descriptor);
@@ -390,7 +400,7 @@ M.defineProperty(M, "removeDependencyFromProperty", {value: function(obj, indepe
 }});
 
 function getAttributeProperties(proto, attributeName) {
-    var attributePropertyName = "_" + attributeName + "AttributeProperties";
+    var attributePropertyName = UnderscoreString + attributeName + AttributePropertiesString;
 
     if (proto.hasOwnProperty(attributePropertyName)) {
         return proto[attributePropertyName];
@@ -474,7 +484,7 @@ M.defineProperty(M, "getSerializablePropertyNames", {value: function(anObject) {
      */
 M.defineProperty(M, "getPropertyAttribute", {value: function(anObject, propertyName, attributeName) {
 
-    var attributePropertyName = "_" + attributeName + "AttributeProperties",
+    var attributePropertyName = UnderscoreString + attributeName + AttributePropertiesString,
         attributes = anObject[attributePropertyName];
 
     if (attributes) {
@@ -491,7 +501,7 @@ M.defineProperty(M, "getPropertyAttribute", {value: function(anObject, propertyN
      */
 M.defineProperty(M, "getPropertyAttributes", {value: function(anObject, attributeName) {
     var attributeValues = {},
-        attributePropertyName = "_" + attributeName + "AttributeProperties",
+        attributePropertyName = UnderscoreString + attributeName + AttributePropertiesString,
         attributes = anObject[attributePropertyName];
 
     if (!attributes) {
@@ -623,7 +633,7 @@ var uuidGetGenerator = function() {
                 });
             }
             //This is really because re-defining the property on DOMWindow actually doesn't work, so the original property with the getter is still there and return this._uuid if there.
-            if (this instanceof Element || !info.isInstance || !("value" in Object.getOwnPropertyDescriptor(this, "uuid")) || !("__proto__" in this /* lame way to detect IE */)) {
+            if (this instanceof Element || !info.isInstance || !(valueString in Object.getOwnPropertyDescriptor(this, "uuid")) || !(__proto__String in this /* lame way to detect IE */)) {
                 //This is needed to workaround some bugs in Safari where re-defining uuid doesn't work for DOMWindow.
                 this._uuid = uuid;
             }
@@ -846,7 +856,7 @@ Object.defineProperty(Object.prototype, "setProperty", {
 
                 // For these mutation/addition/removal events, use the 'modify' attribute of this property's descriptor
                 if (changeEvent && (changeEvent.currentTarget === lastObjectAtPath) &&
-                    (modify = M.getPropertyAttribute(setObject, aPropertyPath, "modify"))) {
+                    (modify = M.getPropertyAttribute(setObject, aPropertyPath, modifyString))) {
                     modify.call(setObject, changeEvent.type, changeEvent.newValue, changeEvent.prevValue);
                 }
             }

--- a/core/event/binding.js
+++ b/core/event/binding.js
@@ -19,7 +19,9 @@ var Montage = require("montage").Montage,
     Serializer = require("core/serializer").Serializer,
     Deserializer = require("core/deserializer").Deserializer,
     defaultEventManager = require("core/event/event-manager").defaultEventManager,
-    AT_TARGET = 2;
+    AT_TARGET = 2,
+	UnderscoreString = "_";
+
 
 /**
     @member external:Array#dispatchChangeEvent
@@ -918,7 +920,7 @@ Object.defineProperty(Object.prototype, "addEventListener", {
                                     if ("value" in currentPropertyDescriptor) {
 
                                         //Create internal storage:
-                                        Object.defineProperty(currentObject, (internalStorageProperty = "_" + key), {
+                                        Object.defineProperty(currentObject, (internalStorageProperty = UnderscoreString + key), {
                                             value: currentObject.getProperty(key),
                                             configurable: true,
                                             writable: true
@@ -1009,7 +1011,7 @@ Object.defineProperty(Object.prototype, "addEventListener", {
                                 //TODO this is all duplicated from above, clean it up
 
                                 //Create internal storage:
-                                Object.defineProperty(currentObject, (internalStorageProperty = "_" + key), {
+                                Object.defineProperty(currentObject, (internalStorageProperty = UnderscoreString + key), {
                                     value: currentObject.getProperty(key),
                                     configurable: true,
                                     writable: true

--- a/core/promise.js
+++ b/core/promise.js
@@ -12,6 +12,16 @@
 // TODO note the comps/promiseSend/sendPromise and argument order
 //      changes from Q
 
+
+var getString = "get",
+	putString = "put",
+	deleteString = "delete",
+	postString = "post",
+	applyString = "apply",
+	keysString = "keys",
+	thenString = "then";
+
+
 // This module is used during the boot-strapping, so it can be required as
 // a normal CommonJS module, but alternately bootstraps Montage if there
 // is a bootstrap global variable.
@@ -433,11 +443,11 @@ var Promise = PrimordialPromise.create({}, { // Descriptor for each of the three
                         toPromise(value)
                             .sendPromise(
                             fulfill,
-                            "then",
+                            thenString,
                             reject
                         )
                     },
-                    "then",
+                    thenString,
                     function (reason, error, rejection) {
                         if (done) {
                             return;
@@ -473,51 +483,51 @@ var Promise = PrimordialPromise.create({}, { // Descriptor for each of the three
 
     get: {
         value: function () {
-            return this.send("get", arguments);
+            return this.send(getString, arguments);
         }
     },
 
     put: {
         value: function () {
-            return this.send("put", arguments);
+            return this.send(putString, arguments);
         }
     },
 
     "delete": {
         value: function () {
-            return this.send("delete", arguments);
+            return this.send(deleteString, arguments);
         }
     },
 
     post: {
         value: function () {
-            return this.send("post", arguments);
+            return this.send(postString, arguments);
         }
     },
 
     invoke: {
         value: function (name /*, ...args*/) {
             var args = Array.prototype.slice.call(arguments, 1);
-            return this.send("post", [name, args]);
+            return this.send(postString, [name, args]);
         }
     },
 
     apply: {
         value: function () {
-            return this.send("apply", arguments);
+            return this.send(applyString, arguments);
         }
     },
 
     call: {
         value: function (thisp /*, ...args*/) {
             var args = Array.prototype.slice.call(arguments, 1);
-            return this.send("apply", [thisp, args]);
+            return this.send(applyString, [thisp, args]);
         }
     },
 
     keys: {
         value: function () {
-            return this.send("keys", []);
+            return this.send(keysString, []);
         }
     },
 

--- a/require/browser.js
+++ b/require/browser.js
@@ -11,6 +11,10 @@ var URL = require("core/mini-url");
 
 var global = typeof global !== "undefined" ? global : window;
 
+var GETString = "GET";
+var applicationJavascriptMimeType = "application/javascript";
+var fileProtocolString = "file:";
+
 Require.getLocation = function() {
     return URL.resolve(window.location, ".");
 };
@@ -24,7 +28,11 @@ Require.overlays = ["browser", "montage"];
 // http://dl.dropbox.com/u/131998/yui/misc/get/browser-capabilities.html
 Require.read = function (url) {
 
+<<<<<<< Updated upstream
     if (URL.resolve(window.location, url).indexOf("file:") === 0) {
+=======
+    if (URL.parse(url).scheme.indexOf(fileProtocolString) === 0) {
+>>>>>>> Stashed changes
         throw new Error("XHR does not function for file: protocol");
     }
 
@@ -44,8 +52,8 @@ Require.read = function (url) {
     }
 
     try {
-        request.open("GET", url, true);
-        request.overrideMimeType("application/javascript");
+        request.open(GETString, url, true);
+        request.overrideMimeType(applicationJavascriptMimeType);
         request.onreadystatechange = function () {
             if (request.readyState === 4) {
                 onload();
@@ -77,6 +85,12 @@ if (global.navigator && global.navigator.userAgent.indexOf("Firefox") >= 0) {
     globalEval = new Function("evalString", "return eval(evalString)");
 }
 
+var __FILE__String = "__FILE__",
+	DoubleUnderscoreString = "__"
+	globalEvalConstantA = "(function ",
+	globalEvalConstantB = "(require, exports, module) {",
+	globalEvalConstantC = "//*/\n})\n//@ sourceURL=";
+	
 Require.Compiler = function (config) {
     return function(module) {
         if (module.factory || module.text === void 0)
@@ -91,10 +105,10 @@ Require.Compiler = function (config) {
         //      TODO: investigate why this isn't working in Firebug.
         // 3. set displayName property on the factory function (Safari, Chrome)
 
-        var displayName = "__FILE__"+module.location.replace(/\.\w+$|\W/g, "__");
+        var displayName = __FILE__String+module.location.replace(/\.\w+$|\W/g, DoubleUnderscoreString);
 
         try {
-            module.factory = globalEval("(function "+displayName+"(require, exports, module) {"+module.text+"//*/\n})"+"\n//@ sourceURL="+module.location);
+            module.factory = globalEval(globalEvalConstantA+displayName+globalEvalConstantB+module.text+globalEvalConstantC+module.location);
         } catch (exception) {
             throw new SyntaxError("in " + module.location + ": " + exception.message);
         }


### PR DESCRIPTION
I spent some time on Firefox doing some profiling. I was focusing on defineProperty. After experimenting a few things, I created variables that hold literal strings used frequently and used this instead. It improved performances noticeably on both Chrome and Firefox, with the exception of strings like "object", "undefined" or "function". It still helps in Chrome, but in Firefox it degrades performance as if the engine itself had internal optimizations for it.

Please take a look and make sure I didn't lose anything, I had a few merge conflicts.
