### PR TITLE
[gh-104] Stop Component.removeChildComponent from removing the component...

### DIFF
--- a/test/ui/component-spec.js
+++ b/test/ui/component-spec.js
@@ -70,6 +70,17 @@ var testPage = TestPageLoader.queueTest("draw", function() {
                         expect(componentC.content[0].controller).toBe(componentC1);
                     });
                 });
+
+                it("should change the content of the component for another component with root elements that are not components themselves", function() {
+                    var originalContent = testPage.test.componentD.originalContent,
+                        componentDtarget = testPage.test.componentDtarget;
+
+                    componentDtarget.content = originalContent;
+                    testPage.waitForDraw();
+                    runs(function() {
+                        expect(componentDtarget._element.innerHTML).toBe("\n    <h1>\n        <div>D1</div>\n    </h1>\n");
+                    });
+                })
             });
 
             describe("calling willDraw prior to drawing", function() {

--- a/test/ui/draw/draw.html
+++ b/test/ui/draw/draw.html
@@ -19,7 +19,9 @@
             "repetition": {"@": "repetition"},
             "componentC": {"@": "componentC"},
             "componentC1": {"@": "componentC1"},
-            "componentNoelement": {"@": "componentNoelement"}
+            "componentNoelement": {"@": "componentNoelement"},
+            "componentD": {"@": "componentD"},
+            "componentDtarget": {"@": "componentDtarget"}
         }
     },
     "repetition": {
@@ -46,7 +48,7 @@
             "hasTemplate": false
         }
     },
-    
+
     "componentNoelement": {
         "module": "ui/draw/component-noelement.reel",
         "name": "ComponentNoelement",
@@ -54,7 +56,32 @@
             "value": "componentNoelement"
         }
     },
-    
+
+    "componentD": {
+        "module": "montage/ui/component",
+        "name": "Component",
+        "properties": {
+            "element": {"#": "componentD"},
+            "hasTemplate": false
+        }
+    },
+    "componentD1": {
+        "module": "montage/ui/component",
+        "name": "Component",
+        "properties": {
+            "element": {"#": "componentD1"},
+            "hasTemplate": false
+        }
+    },
+    "componentDtarget": {
+        "module": "montage/ui/component",
+        "name": "Component",
+        "properties": {
+            "element": {"#": "componentDtarget"},
+            "hasTemplate": false
+        }
+    },
+
     "owner": {
         "module": "montage/ui/application",
         "name": "Application",
@@ -78,6 +105,12 @@
     <div id="fakeComponentC1"></div>
 </div>
 <div data-montage-id="componentC1">C1</div>
+<div id="componentD">
+    <h1>
+        <div id="componentD1">D1</div>
+    </h1>
+</div>
+<div id="componentDtarget"></div>
 <div id="repetition"><h3>Original Content</h3><p>here</p></div>
 </body>
 </html>

--- a/ui/component.js
+++ b/ui/component.js
@@ -439,10 +439,6 @@ var Component = exports.Component = Montage.create(Montage,/** @lends module:mon
                 childComponents.splice(ix, 1);
                 childComponent._cachedParentComponent = null;
             }
-
-            if (element && element.parentNode) {
-                element.parentNode.removeChild(element);
-            }
         }
     },
 /**


### PR DESCRIPTION
...'s element from the DOM tree

This should be the responsibility of whoever is removing the component from the component tree.
This function should be free of DOM changes, otherwise it can only be called during the draw cycle.
