### PR TITLE
Fix to stop a MutableEvent from wrapping another

### DIFF
--- a/core/event/mutable-event.js
+++ b/core/event/mutable-event.js
@@ -51,6 +51,9 @@ var MutableEvent = exports.MutableEvent = Montage.create(Montage,/** @lends modu
      */
     fromEvent: {
         value: function(event) {
+            if (typeof event._event !== "undefined") {
+                return event;
+            }
             var type = event.type,
                 constructor = _eventConstructorsByType[type],
                 newEvent;


### PR DESCRIPTION
Bailing out early so that we don't wrap the event many times
