### PR TITLE
Adding the plus property

### DIFF
--- a/core/event/mutable-event.js
+++ b/core/event/mutable-event.js
@@ -105,6 +105,7 @@ var MutableEvent = exports.MutableEvent = Montage.create(Montage,/** @lends modu
             var changeEvent = new _changeEventConstructor();
             changeEvent.type = "change@" + key;
             changeEvent.minus = minus;
+            changeEvent.plus = undefined;
             changeEvent.propertyChange = ChangeTypes.MODIFICATION;
             return changeEvent;
         }


### PR DESCRIPTION
Since MutableEvent.fromEvent depends on all events
of a type having the same keys we need to add the
plus property immediately.
