### PR TITLE
Remove pointer and interaction handling from native-control

### DIFF
--- a/ui/native-control.js
+++ b/ui/native-control.js
@@ -241,7 +241,7 @@ NativeControl.addAttributes({
     contextmenu: null,
     'class': null,
     dir: null,
-    draggable: {dataType: 'boolean'},
+    draggable: null,
     dropzone: null, // copy/move/link
     hidden: {dataType: 'boolean'},
     //id: null,


### PR DESCRIPTION
Has been replaced by the press-composer.

Fixes gh-115
