### PR TITLE
Set PhotoFX images draggable to be false

### DIFF
--- a/examples/photofx/photo-thumb.reel/photo-thumb.html
+++ b/examples/photofx/photo-thumb.reel/photo-thumb.html
@@ -16,7 +16,8 @@
                 "module": "montage/ui/image.reel",
                 "name": "Image",
                 "properties": {
-                    "element": {"#": "image"}
+                    "element": {"#": "image"},
+                    "draggable": false
                 },
                 "bindings": {
                     "src": {


### PR DESCRIPTION
Stops the images beging able to be dragged out of the browser and
associated ghosting visial effect.

Associated with gh-115
