### PR TITLE
JSDoc: Removed empty comments that were breaking JSDoc build

### DIFF
--- a/ui/condition.reel/condition.js
+++ b/ui/condition.reel/condition.js
@@ -110,9 +110,6 @@ exports.Condition = Montage.create(Component, /** @lends module:"montage/ui/cond
         enumerable:false
     },
 
-    /**
-
-     */
     // TODO should this strategy be part of another class?
     // TODO expose the options as an exported enum
     removalStrategy:{
@@ -132,11 +129,6 @@ exports.Condition = Montage.create(Component, /** @lends module:"montage/ui/cond
     },
 
 
-    /**
-
-     @param
-         @returns
-     */
     didCreate:{
         value:function () {
             this._slot = Slot.create();


### PR DESCRIPTION
To avoid this, make sure all JSDoc comments you contain some descriptive text at the very top of the comment before any other JSDoc tags appear.

/**
@private
This will break JSDoc.
*/

/**
This will not break JSDoc.
@private
*/

And no empty comments, eg:

/**

*/
