### PR TITLE
[gh-129] Fix issue when using the repetition programmatically

### DIFF
--- a/test/ui/repetition-spec.js
+++ b/test/ui/repetition-spec.js
@@ -135,6 +135,23 @@ var testPage = TestPageLoader.queueTest("repetition", function() {
                     });
                 });
             });
+
+            it("should create a repetition programmatically", function() {
+                var Repetition = testPage.window.require("montage/ui/repetition.reel").Repetition,
+                    repetition = Repetition.create();
+
+                repetition.element = querySelector(".list12");
+                repetition.objects = [1, 2, 3];
+                repetition.needsDraw = true;
+
+                testPage.waitForDraw();
+
+                runs(function() {
+                    // sanity test
+                    var lis = repetition.element.querySelectorAll("li");
+                    expect(lis.length).toBe(3);
+                });
+            });
         });
 
         describe("The component repetition", function() {
@@ -571,17 +588,17 @@ var testPage = TestPageLoader.queueTest("repetition", function() {
             it("should rebuild the repetition", function() {
                 var list11 = querySelector(".list11").controller,
                     content = querySelectorAll(".list11 > li");
-                
+
                 expect(content.length).toBe(3);
                 for (var i = 0; i < content.length; i++) {
                     expect(content[i].textContent).toBe("X");
                 }
-                
+
                 var newContent = content[0].ownerDocument.createElement("div");
                 newContent.textContent = "Y";
-                
+
                 list11.content = newContent;
-                
+
                 testPage.waitForDraw();
 
                 // it requires 2 draws for the change to take effect, one for changing the contents and another to recreate the repetition

--- a/test/ui/repetition/repetition.html
+++ b/test/ui/repetition/repetition.html
@@ -546,5 +546,10 @@
     <ul data-montage-id="list11" class="list11">
         <li>X</li>
     </ul>
+
+    <h2>Repetition created programmatically</h2>
+    <ul class="list12" data-montage-id="list12">
+        <li>A</li>
+    </ul>
 </body>
 </html>

--- a/ui/repetition.reel/repetition.js
+++ b/ui/repetition.reel/repetition.js
@@ -440,6 +440,7 @@ var Repetition = exports.Repetition = Montage.create(Component, /** @lends modul
                 childComponent;
 
             this.setupIterationSerialization();
+            this.setupIterationDeserialization();
             this._iterationChildComponentsCount = childComponents.length;
             this._iterationChildCount = element.childNodes.length;
             this._iterationChildElementCount = element.children.length;
@@ -506,7 +507,6 @@ var Repetition = exports.Repetition = Montage.create(Component, /** @lends modul
     },
 
     deserializedFromTemplate: {value: function deserializedFromTemplate() {
-        this.setupIterationDeserialization();
         if (this._isComponentExpanded) {
             // this is setup just for the flattening of the template iteration, the iteration needs to be serialized once it's completely flatten.
             this.setupIterationSerialization();


### PR DESCRIPTION
There was a vital operation (setupIterationDeserialization) that was being done only at deserializedFromTemplate time so it would never be executed when created programmatically.
