### PR TITLE
Add bin/montage

### DIFF
--- a/bin/montage
+++ b/bin/montage
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+// --harmony_weakmaps --harmony_proxies
+require("../montage.js").initMontage();

--- a/require/node.js
+++ b/require/node.js
@@ -65,7 +65,7 @@ Require.DefaultLoaderConstructor = function(config) {
             config,
             Require.PathsLoader(
                 config,
-                Require.CachingLoader(
+                Require.MemoizedLoader(
                     config,
                     Require.Loader(
                         config,


### PR DESCRIPTION
And get it working with the new MemoizedLoader nomenclature.
`bin/montage` was missed in a previous push that added the bin to the
list of executables that NPM installs with the -g --global option.
