### PR TITLE
[gh-19] Component location serialization

### DIFF
--- a/core/deserializer.js
+++ b/core/deserializer.js
@@ -370,16 +370,40 @@ var Deserializer = Montage.create(Montage, /** @lends module:montage/core/deseri
 /**
   @private
 */
+    _findObjectNameRegExp: {
+        value: /([^\/]+?)(\.reel)?$/
+    },
+    _toCamelCaseRegExp: {
+        value: /(?:^|-)([^-])/g
+    },
+    _replaceToCamelCase: {
+        value: function(_, g1) { return g1.toUpperCase() }
+    },
     _parseForModules: {value: function() {
         var serialization = this._serialization,
             moduleIds = this._requiredModuleIds = [],
-            modules = this._modules;
+            modules = this._modules,
+            desc, moduleId;
 
         for (var label in serialization) {
-            var desc = serialization[label];
-            var moduleId = desc.module;
+            desc = serialization[label];
+            moduleId = null;
 
-            if (moduleId && moduleIds.indexOf(moduleId) == -1 && !modules[moduleId]) {
+            if ("module" in desc) {
+                moduleId = desc.module;
+            } else if (name = /*assignment*/(desc.prototype || desc.object)) {
+                objectLocation = name.split("[");
+                moduleId = objectLocation[0];
+                desc.module = moduleId;
+                if (objectLocation.length == 2) {
+                    desc.name = objectLocation[1].slice(0, -1);
+                } else {
+                    this._findObjectNameRegExp.test(moduleId);
+                    desc.name = RegExp.$1.replace(this._toCamelCaseRegExp, this._replaceToCamelCase);
+                }
+            }
+
+            if (moduleId && !modules[moduleId] && moduleIds.indexOf(moduleId) == -1) {
                 moduleIds.push(moduleId);
             }
         }
@@ -484,18 +508,44 @@ var Deserializer = Montage.create(Montage, /** @lends module:montage/core/deseri
         return exports;
 
         function deserializeObject(label, desc) {
-            var moduleId = desc.module,
-                name = desc.name,
-                objectName = name,
-                fqn = moduleId + "." + name,
+            var moduleId,
+                name,
+                instance,
+                objectName,
+                fqn,
                 properties = desc.properties,
+                isType,
                 object,
                 counter,
-                propertiesString;
+                propertiesString,
+                objectLocation;
+
+            if ("module" in desc) {
+                moduleId = desc.module;
+                objectName = name = desc.name;
+            } else {
+                objectLocation = (desc.prototype || desc.object).split("[");
+                // this code is actually only used when canEval == false,
+                // module+name are added when the modules are parsed but it's
+                // slow to redo the _serializationString in order to keep the
+                // added module+name when we do JSON.parse(_serializationString)
+                // at canEval == false.
+                moduleId = objectLocation[0];
+                if (objectLocation.length == 2) {
+                    objectName = name = objectLocation[1].slice(0, -1);
+                } else {
+                    self._findObjectNameRegExp.test(moduleId);
+                    objectName = name = RegExp.$1.replace(self._toCamelCaseRegExp, function(_, g1) { return g1.toUpperCase() });
+                }
+            }
+            isType = "object" in desc;
+            fqn = moduleId + "." + name;
 
             if (deserialize) {
                 if (self._objectLabels[label]) {
                     exports[label] = object = self._objectLabels[label];
+                } else if (isType) {
+                    exports[label] = object = modules[moduleId][name];
                 } else {
                     if (!(name in modules[moduleId])) {
                         console.log("Warning: Object \"" + name + "\" not found at \"" + moduleId + "\" referenced from " + self._origin + ".");
@@ -514,7 +564,7 @@ var Deserializer = Montage.create(Montage, /** @lends module:montage/core/deseri
             }
 
             if (fqn in requireStrings) {
-                name = requireStrings[fqn];
+                objectName = requireStrings[fqn];
             } else {
                 counter = (objectNamesCounter[name] || 0) + 1;
                 objectNamesCounter[name] = counter;
@@ -526,11 +576,15 @@ var Deserializer = Montage.create(Montage, /** @lends module:montage/core/deseri
             }
 
             exportsStrings += 'if (this._objectLabels["' + label + '"]) {\n';
-            exportsStrings += '  var ' + label + ' = exports. ' + label + ' = this._objectLabels["' + label + '"]\n';
+            exportsStrings += '  var ' + label + ' = exports.' + label + ' = this._objectLabels["' + label + '"]\n';
             exportsStrings += '} else {\n';
-            exportsStrings += '  var ' + label + ' = exports. ' + label + ' = ' + objectName + '.create();\n';
-            exportsStrings += '  Montage.getInfoForObject(' + label + ').label = "' + label + '";\n';
-            exportsStrings += '  Object.defineProperty(' + label + ', "_suuid", {enumerable: false, value: "' + self.uuid + '-' + label + '"});\n';
+            if (isType) {
+                exportsStrings += '  var ' + label + ' = exports.' + label + ' = ' + objectName + ';\n';
+            } else {
+                exportsStrings += '  var ' + label + ' = exports.' + label + ' = ' + objectName + '.create();\n';
+                exportsStrings += '  Montage.getInfoForObject(' + label + ').label = "' + label + '";\n';
+                exportsStrings += '  Object.defineProperty(' + label + ', "_suuid", {enumerable: false, value: "' + self.uuid + '-' + label + '"});\n';
+            }
             exportsStrings += '}\n';
 
             propertiesString = deserializeValue(properties);
@@ -541,6 +595,7 @@ var Deserializer = Montage.create(Montage, /** @lends module:montage/core/deseri
 
             delete desc.module;
             delete desc.name;
+            delete desc.object;
             delete desc.properties;
 
             propertiesString = deserializeValue(desc);

--- a/lab/tools/serialization/convert-module-to-prototype.js
+++ b/lab/tools/serialization/convert-module-to-prototype.js
@@ -1,0 +1,43 @@
+/* <copyright>
+ This file contains proprietary software owned by Motorola Mobility, Inc.<br/>
+ No rights, expressed or implied, whatsoever to this software are provided by Motorola Mobility, Inc. hereunder.<br/>
+ (c) Copyright 2012 Motorola Mobility, Inc.  All Rights Reserved.
+ </copyright> */
+
+var findObjectNameRegExp = /([^\/]+?)(\.reel)?$/,
+    toCamelCaseRegExp = /(?:^|-)([^-])/g,
+    replaceToCamelCase = function(_, g1) { return g1.toUpperCase() };
+
+exports.convertModuleToPrototype = function(string) {
+    var serialization = JSON.parse(string);
+
+    for (var label in serialization) {
+        var desc = serialization[label];
+
+        if ("module" in desc) {
+            var newDesc = Object.create(desc);
+            findObjectNameRegExp.test(desc.module);
+            var defaultName = RegExp.$1.replace(toCamelCaseRegExp, replaceToCamelCase);
+
+            if (defaultName === desc.name) {
+                newDesc.prototype = desc.module;
+            } else {
+                newDesc.prototype = desc.module + "[" + desc.name + "]";
+            }
+
+            delete desc.module;
+            delete desc.name;
+
+            for (var key in desc) {
+                newDesc[key] = desc[key];
+            }
+
+            serialization[label] = newDesc;
+        }
+    }
+
+    var string = JSON.stringify(serialization, null, 4);
+    string = string.replace(/\{\s*"(@|#)"\s*:\s*"([^"]+)"\s*\}/g, '{"$1": "$2"}');
+
+    return string;
+}

--- a/lab/tools/serialization/seralization-converter.js
+++ b/lab/tools/serialization/seralization-converter.js
@@ -1,0 +1,111 @@
+/* <copyright>
+ This file contains proprietary software owned by Motorola Mobility, Inc.<br/>
+ No rights, expressed or implied, whatsoever to this software are provided by Motorola Mobility, Inc. hereunder.<br/>
+ (c) Copyright 2012 Motorola Mobility, Inc.  All Rights Reserved.
+ </copyright> */
+
+var args = process.argv.slice(2);
+var options = {};
+
+do {
+    var arg = args[0],
+        argumentConsumed = false;
+
+    switch (arg) {
+        case "--dry-run":
+        argumentConsumed = true;
+        options.dryRun = true;
+        break;
+    }
+
+    if (argumentConsumed) {
+        args.shift();
+    }
+} while (argumentConsumed);
+
+
+if (args.length === 0) {
+    usage();
+    process.exit();
+}
+
+var scriptDir = process.argv[1].split("/").slice(0, -1).join("/") + "/";
+
+var fs = require("fs");
+var convertModuleToPrototype = require(scriptDir + "convert-module-to-prototype").convertModuleToPrototype;
+
+processFiles(args);
+
+function usage() {
+    console.log("Missing arguments.");
+    console.log("Usage: " + process.argv[1] + " [--dry-run] <filename.html> | <directory>");
+}
+
+function processFiles(filenames) {
+    filenames.forEach(function(filename) {
+        var stats = fs.statSync(filename);
+
+        if (stats.isFile() && /\.html$/.test(filename)) {
+            processFile(filename);
+        } else if (stats.isDirectory()) {
+            processDirectory(filename);
+        } else {
+            //console.log("Warning: " + filename + " has unknown file type.");
+        }
+    });
+}
+
+function processDirectory(dirname) {
+    fs.readdir(dirname, function(err, filenames) {
+        if (err) throw err;
+        filenames = filenames.map(function(value){return dirname+"/"+value}); // grunf..
+        processFiles(filenames);
+    });
+}
+
+function processFile(filename) {
+    convertSerialization(filename);
+}
+
+function convertSerialization(filename) {
+    var scriptRegExp = /<script\s+type="text\/montage-serialization"\s*>/ig;
+
+    fs.readFile(filename, function(err, data) {
+        if (err) throw err;
+
+        var newContents;
+        var serialization;
+        var matches;
+        var ix;
+
+        data = data.toString();
+
+        if (matches = scriptRegExp.exec(data)) {
+            ix = scriptRegExp.lastIndex;
+            serialization = data.slice(ix);
+            serialization = serialization.slice(0, serialization.search(/<\/script>/i));
+
+            var string = convertModuleToPrototype(serialization)
+                         .replace(/^.*\n|\n.*$/g, "") // strip first,last line
+                         .replace(/^/gm, "    "); // indent by 4 spaces
+
+            newContents = data.slice(0, ix) + "{\n" +
+                          string +
+                          "\n    }</script>" +
+                          data.slice(ix + serialization.length + "</script>".length);
+
+            if (options.dryRun) {
+                console.log("Will rewrite " + filename + " with:");
+                console.log(newContents);
+            } else {
+                fs.writeFile(filename, newContents, function (err) {
+                    if (err) {
+                        console.log("Error writing to " + filename + ".");
+                    } else {
+                        console.log("Converted: " + filename);
+                    }
+                });
+            }
+        }
+    });
+}

--- a/test/serialization/deserializer-spec.js
+++ b/test/serialization/deserializer-spec.js
@@ -377,6 +377,208 @@ describe("serialization/deserializer-spec", function() {
         });
     });
 
+    describe("User Objects Deserialization With Short Object Location", function() {
+        it("should deserialize using prototype: module[name]", function() {
+            var latch, objects;
+
+            deserializer.initWithObject({
+                root: {
+                    prototype: "montage[Montage]",
+                    properties: {
+                        number: 15,
+                        string: "string"
+                    }
+                }
+            }).deserialize(function(objs) {
+                latch = true;
+                objects = objs;
+            });
+
+            waitsFor(function() { return latch; });
+            runs(function() {
+                var root = objects.root,
+                    info = Montage.getInfoForObject(root);
+
+                expect(Montage.isPrototypeOf(root));
+                expect(root.instance).toBeUndefined();
+            });
+        });
+
+        it("should deserialize using prototype: module", function() {
+            var latch, objects;
+
+            deserializer.initWithObject({
+                root: {
+                    prototype: "montage",
+                    properties: {
+                        number: 15,
+                        string: "string"
+                    }
+                }
+            }).deserialize(function(objs) {
+                latch = true;
+                objects = objs;
+            });
+
+            waitsFor(function() { return latch; });
+            runs(function() {
+                var root = objects.root,
+                    info = Montage.getInfoForObject(root);
+
+                expect(Montage.isPrototypeOf(root));
+                expect(info.moduleId).toBe("core/core");
+                expect(info.objectName).toBe("Montage");
+                expect(info.isInstance).toBe(true);
+                expect(root.instance).toBeUndefined();
+            });
+        });
+
+        it("should deserialize using prototype: module-name.reel", function() {
+            var latch, objects;
+
+            deserializer.initWithObject({
+                root: {
+                    prototype: "serialization/module-name.reel",
+                    properties: {
+                        number: 15,
+                        string: "string"
+                    }
+                }
+            }).deserialize(function(objs) {
+                latch = true;
+                objects = objs;
+            });
+
+            waitsFor(function() { return latch; });
+            runs(function() {
+                var root = objects.root,
+                    info = Montage.getInfoForObject(root);
+
+                expect(info.moduleId).toBe("serialization/module-name.reel/module-name");
+                expect(info.objectName).toBe("ModuleName");
+                expect(info.isInstance).toBe(true);
+            });
+        });
+
+        it("should deserialize using object: module[name]", function() {
+            var latch, objects;
+
+            deserializer.initWithObject({
+                root: {
+                    object: "montage[Montage]",
+                    properties: {
+                        number: 15,
+                        string: "string"
+                    }
+                }
+            }).deserialize(function(objs) {
+                latch = true;
+                objects = objs;
+            });
+
+            waitsFor(function() { return latch; });
+            runs(function() {
+                var root = objects.root,
+                    info = Montage.getInfoForObject(root);
+
+                expect(root).toBe(Montage);
+                expect(info.moduleId).toBe("core/core");
+                expect(info.objectName).toBe("Montage");
+                expect(info.isInstance).toBe(false);
+                expect(root.type).toBeUndefined();
+            });
+        });
+
+        it("should deserialize using object: module", function() {
+            var latch, objects;
+
+            deserializer.initWithObject({
+                root: {
+                    object: "montage",
+                    properties: {
+                        number: 15,
+                        string: "string"
+                    }
+                }
+            }).deserialize(function(objs) {
+                latch = true;
+                objects = objs;
+            });
+
+            waitsFor(function() { return latch; });
+            runs(function() {
+                var root = objects.root,
+                    info = Montage.getInfoForObject(root);
+
+                expect(root).toBe(Montage);
+                expect(info.moduleId).toBe("core/core");
+                expect(info.objectName).toBe("Montage");
+                expect(info.isInstance).toBe(false);
+                expect(root.type).toBeUndefined();
+            });
+        });
+
+        it("should deserialize using instance after compilation", function() {
+            var latch, objects;
+
+            deserializer.initWithObject({
+                root: {
+                    prototype: "montage",
+                    properties: {
+                        number: 15,
+                        string: "string"
+                    }
+                }
+            }).deserialize(function() {
+                deserializer.deserialize(function(objs) {
+                    latch = true;
+                    objects = objs;
+                });
+            });
+
+            waitsFor(function() { return latch; });
+            runs(function() {
+                var root = objects.root,
+                    info = Montage.getInfoForObject(root);
+
+                expect(Montage.isPrototypeOf(root));
+                expect(info.moduleId).toBe("core/core");
+                expect(info.objectName).toBe("Montage");
+                expect(info.isInstance).toBe(true);
+            });
+        });
+
+        it("should deserialize using type after compilation", function() {
+            var latch, objects;
+
+            deserializer.initWithObject({
+                root: {
+                    object: "montage",
+                    properties: {
+                        number: 15,
+                        string: "string"
+                    }
+                }
+            }).deserialize(function() {
+                deserializer.deserialize(function(objs) {
+                    latch = true;
+                    objects = objs;
+                });
+            });
+
+            waitsFor(function() { return latch; });
+            runs(function() {
+                var root = objects.root,
+                    info = Montage.getInfoForObject(root);
+
+                expect(root).toBe(Montage);
+                expect(info.moduleId).toBe("core/core");
+                expect(info.objectName).toBe("Montage");
+                expect(info.isInstance).toBe(false);
+            })
+        });
+    });
+
     describe("Element Reference Deserialization", function() {
         var root = document.createElement("div");
 

--- a/test/serialization/module-name.reel/module-name.js
+++ b/test/serialization/module-name.reel/module-name.js
@@ -1,0 +1,4 @@
+var Montage = require("montage").Montage;
+
+exports.ModuleName = Montage.create(Montage, {
+});

--- a/test/serialization/serializer-spec.js
+++ b/test/serialization/serializer-spec.js
@@ -123,43 +123,42 @@ describe("serialization/serializer-spec", function() {
     });
 
     describe("Objects serialization", function(){
-        /*
         it("should serialize a class object with no properties", function() {
             var object = objects.Empty;
             serialization = stripPP(serializer.serializeObject(object));
-            expect(stripPP(serialization)).toBe('{"root":{"module":"serialization/testobjects-v2","name":"Empty","properties":{}}}');
+            expect(stripPP(serialization)).toBe('{"root":{"object":"serialization/testobjects-v2[Empty]","properties":{}}}');
         });
-        */
+
         it("should serialize an instance object with no properties", function() {
             var object = objects.Empty.create();
             serialization = serializer.serializeObject(object);
 
-            expect(stripPP(serialization)).toBe('{"root":{"module":"serialization/testobjects-v2","name":"Empty","properties":{}}}');
+            expect(stripPP(serialization)).toBe('{"root":{"prototype":"serialization/testobjects-v2[Empty]","properties":{}}}');
         });
 
         it("should serialize an instance object with an array property", function() {
             var object = objects.OneProp.create();
             object.prop = [1, 2, 3, 4, 5];
             serialization = serializer.serializeObject(object);
-            expect(stripPP(serialization)).toBe('{"root":{"module":"serialization/testobjects-v2","name":"OneProp","properties":{"prop":[1,2,3,4,5]}}}');
+            expect(stripPP(serialization)).toBe('{"root":{"prototype":"serialization/testobjects-v2[OneProp]","properties":{"prop":[1,2,3,4,5]}}}');
         });
 
         it("should serialize an instance object with a distinct array property", function() {
             var object = objects.DistinctArrayProp.create();
             serialization = serializer.serializeObject(object);
-             expect(stripPP(serialization)).toBe('{"root":{"module":"serialization/testobjects-v2","name":"DistinctArrayProp","properties":{"prop":[]}}}');
+             expect(stripPP(serialization)).toBe('{"root":{"prototype":"serialization/testobjects-v2[DistinctArrayProp]","properties":{"prop":[]}}}');
         });
 
         it("should serialize an instance object with a distinct literal property", function() {
             var object = objects.DistinctLiteralProp.create();
             serialization = serializer.serializeObject(object);
-            expect(stripPP(serialization)).toBe('{"root":{"module":"serialization/testobjects-v2","name":"DistinctLiteralProp","properties":{"prop":{}}}}');
+            expect(stripPP(serialization)).toBe('{"root":{"prototype":"serialization/testobjects-v2[DistinctLiteralProp]","properties":{"prop":{}}}}');
         });
 
         it("should serialize an instance object with no references to other objects", function() {
             var object = objects.Simple.create();
             serialization = serializer.serializeObject(object);
-            expect(stripPP(serialization)).toBe('{"root":{"module":"serialization/testobjects-v2","name":"Simple","properties":{"number":42,"string":"string"}}}');
+            expect(stripPP(serialization)).toBe('{"root":{"prototype":"serialization/testobjects-v2[Simple]","properties":{"number":42,"string":"string"}}}');
         });
 
         it("should serialize an instance object that references other objects", function() {
@@ -170,7 +169,7 @@ describe("serialization/serializer-spec", function() {
             object.prop2 = simple;
 
             serialization = serializer.serializeObject(object);
-             expect(stripPP(serialization)).toBe('{"simple1":{"module":"serialization/testobjects-v2","name":"Simple","properties":{"number":42,"string":"string"}},"root":{"module":"serialization/testobjects-v2","name":"TwoProps","properties":{"prop1":["with","a","reference"],"prop2":{"@":"simple1"}}}}');
+             expect(stripPP(serialization)).toBe('{"simple1":{"prototype":"serialization/testobjects-v2[Simple]","properties":{"number":42,"string":"string"}},"root":{"prototype":"serialization/testobjects-v2[TwoProps]","properties":{"prop1":["with","a","reference"],"prop2":{"@":"simple1"}}}}');
         });
 
         it("should serialize an instance object that references itself", function() {
@@ -179,7 +178,7 @@ describe("serialization/serializer-spec", function() {
             object.prop = object;
 
             serialization = serializer.serializeObject(object);
-            expect(stripPP(serialization)).toBe('{"root":{"module":"serialization/testobjects-v2","name":"OneProp","properties":{"prop":{"@":"root"}}}}');
+            expect(stripPP(serialization)).toBe('{"root":{"prototype":"serialization/testobjects-v2[OneProp]","properties":{"prop":{"@":"root"}}}}');
         });
 
         it("should serialize an instance object that has an indirect cycle", function() {
@@ -190,7 +189,7 @@ describe("serialization/serializer-spec", function() {
             object2.prop = object1;
 
             serialization = serializer.serializeObject(object1);
-            expect(stripPP(serialization)).toBe('{"oneprop1":{"module":"serialization/testobjects-v2","name":"OneProp","properties":{"prop":{"@":"root"}}},"root":{"module":"serialization/testobjects-v2","name":"OneProp","properties":{"prop":{"@":"oneprop1"}}}}');
+            expect(stripPP(serialization)).toBe('{"oneprop1":{"prototype":"serialization/testobjects-v2[OneProp]","properties":{"prop":{"@":"root"}}},"root":{"prototype":"serialization/testobjects-v2[OneProp]","properties":{"prop":{"@":"oneprop1"}}}}');
         });
 
         it("should serialize an instance object with a custom serialization", function() {
@@ -199,7 +198,7 @@ describe("serialization/serializer-spec", function() {
             object.prop = object;
 
             serialization = serializer.serializeObject(object);
-            expect(stripPP(serialization)).toBe('{"root":{"module":"serialization/testobjects-v2","name":"Custom","properties":{"manchete":226}}}');
+            expect(stripPP(serialization)).toBe('{"root":{"prototype":"serialization/testobjects-v2[Custom]","properties":{"manchete":226}}}');
         });
 
         it("should serialize a reference to an instance object with a custom serialization", function() {
@@ -208,7 +207,7 @@ describe("serialization/serializer-spec", function() {
             object.prop = object;
 
             serialization = serializer.serializeObject(object);
-            expect(stripPP(serialization)).toBe('{"root":{"module":"serialization/testobjects-v2","name":"CustomRef","properties":{"object":{"@":"empty1"}}}}');
+            expect(stripPP(serialization)).toBe('{"root":{"prototype":"serialization/testobjects-v2[CustomRef]","properties":{"object":{"@":"empty1"}}}}');
         });
 
         it("should serialize a function in an Object literal", function() {
@@ -229,7 +228,7 @@ describe("serialization/serializer-spec", function() {
             object.prop = simple;
 
             serialization = serializer.serialize({root: object, SimpleA: simple});
-            expect(stripPP(serialization)).toBe('{"SimpleA":{"module":"serialization/testobjects-v2","name":"Simple","properties":{"number":42,"string":"string"}},"root":{"module":"serialization/testobjects-v2","name":"OneProp","properties":{"prop":{"@":"SimpleA"}}}}');
+            expect(stripPP(serialization)).toBe('{"SimpleA":{"prototype":"serialization/testobjects-v2[Simple]","properties":{"number":42,"string":"string"}},"root":{"prototype":"serialization/testobjects-v2[OneProp]","properties":{"prop":{"@":"SimpleA"}}}}');
         });
 
         it("should serialize a group of disconnected objects", function() {
@@ -247,7 +246,7 @@ describe("serialization/serializer-spec", function() {
             };
 
             serialization = serializer.serialize(labels);
-            expect(stripPP(serialization)).toBe('{"simple1":{"module":"serialization/testobjects-v2","name":"Simple","properties":{"number":42,"string":"string"}},"graphA":{"module":"serialization/testobjects-v2","name":"OneProp","properties":{"prop":{"@":"simple1"}}},"graphB":{"module":"serialization/testobjects-v2","name":"TwoProps","properties":{"prop1":"string","prop2":42}}}');
+            expect(stripPP(serialization)).toBe('{"simple1":{"prototype":"serialization/testobjects-v2[Simple]","properties":{"number":42,"string":"string"}},"graphA":{"prototype":"serialization/testobjects-v2[OneProp]","properties":{"prop":{"@":"simple1"}}},"graphB":{"prototype":"serialization/testobjects-v2[TwoProps]","properties":{"prop1":"string","prop2":42}}}');
         });
 
         describe("Serialization options", function() {
@@ -288,7 +287,7 @@ describe("serialization/serializer-spec", function() {
                     }
                 }
 
-                expect(stripPP(serialization)).toBe('{"oneprop1":{"module":"serialization/testobjects-v2","name":"OneProp","properties":{"prop":"prop1"}},"root":{"module":"serialization/testobjects-v2","name":"SerializableAttribute","properties":{"prop1a":{"@":"oneprop1"},"prop1b":{"@":"oneprop1"},"prop2a":{"@":"oneprop2"},"prop2b":{"@":"oneprop2"}}}}');
+                expect(stripPP(serialization)).toBe('{"oneprop1":{"prototype":"serialization/testobjects-v2[OneProp]","properties":{"prop":"prop1"}},"root":{"prototype":"serialization/testobjects-v2[SerializableAttribute]","properties":{"prop1a":{"@":"oneprop1"},"prop1b":{"@":"oneprop1"},"prop2a":{"@":"oneprop2"},"prop2b":{"@":"oneprop2"}}}}');
                 expect(length).toBe(1);
             });
         });


### PR DESCRIPTION
Replaces module+name in serialization with object/prototype.

Able to reference objects in the module id string using bracket notation (e.g.: module-name[objectName]).

Name inference from the module id using CamelCase rule (e.g.: module-id/object-name => module-id/object-name[ObjectName])
