### PR TITLE
Add fix for value being reset after setting type

### DIFF
--- a/test/ui/range-input-spec.js
+++ b/test/ui/range-input-spec.js
@@ -21,6 +21,13 @@ var testPage = TestPageLoader.queueTest("range-input-test", function() {
                 expect(test.range_input1).toBeDefined();
             });
 
+            describe("value", function() {
+                it("can be set from the serialization", function() {
+                    expect(test.range_input2.value).toBe(1);
+                    expect(test.range_input2.element.value).toBe("1");
+                });
+            });
+
             it("can be changed", function() {
                 expect(test.range_input1.value).toBe("0");
 

--- a/test/ui/range-input-test/range-input-test.html
+++ b/test/ui/range-input-test/range-input-test.html
@@ -18,6 +18,14 @@
             "element": {"#": "range_input1"}
         }
     },
+    "range_input2": {
+        "module": "montage/ui/range-input.reel",
+        "name": "RangeInput",
+        "properties": {
+            "element": {"#": "range_input2"},
+            "value": 1
+        }
+    },
     "output": {
         "module": "montage/ui/dynamic-text.reel",
         "name": "DynamicText",
@@ -54,6 +62,7 @@
         "name": "RangeInputTest",
         "properties": {
             "range_input1": {"@": "range_input1"},
+            "range_input2": {"@": "range_input2"},
             "scroll": {"@": "scroll"},
             "scroll_range": {"@": "scroll_range"}
         }
@@ -72,8 +81,14 @@
 <body>
     <h1>RangeInput test</h1>
 
-    <input type="range" data-montage-id="range_input1" value="0"/>
-    <span data-montage-id="output">0</span>
+    <p>
+        <input type="range" data-montage-id="range_input1" value="0"/>
+        <span data-montage-id="output">0</span>
+    </p>
+
+    <p>
+        <input type="range" id="hello" data-montage-id="range_input2"/>
+    </p>
 
     <h2>Scroll</h2>
     <form action="" method="get">

--- a/ui/text-input.js
+++ b/ui/text-input.js
@@ -184,25 +184,21 @@ var TextInput = exports.TextInput =  Montage.create(NativeControl, {
     draw: {
         enumerable: false,
         value: function() {
+            Object.getPrototypeOf(TextInput).draw.call(this);
 
-            var t = this.element;
+            var el = this.element;
 
             if (!this._valueSyncedWithInputField) {
                 this._setElementValue(this.converter ? this.converter.convert(this._value) : this._value);
             }
 
-
             if (this.error) {
-                t.classList.add('montage-text-invalid');
-                t.title = this.error.message || '';
+                el.classList.add('montage-text-invalid');
+                el.title = this.error.message || '';
             } else {
-                t.classList.remove("montage-text-invalid");
-                t.title = '';
+                el.classList.remove("montage-text-invalid");
+                el.title = '';
             }
-
-            var fn = Object.getPrototypeOf(TextInput).draw;
-            fn.call(this);
-
         }
     },
 /**


### PR DESCRIPTION
When the type attribute is set on an input element then the value
gets reset. Fix so the value gets set after the type attr of the
element is set.

Adds test for range-input which was exhibiting this problem
