### PR TITLE
Changed any controls with autofocus attributes to treat it as a boolean attrib.

### DIFF
--- a/ui/checkbox.reel/checkbox.js
+++ b/ui/checkbox.reel/checkbox.js
@@ -9,7 +9,7 @@ var Montage = require("montage").Montage,
 
 var Checkbox = exports.Checkbox = Montage.create(CheckInput, {});
 Checkbox.addAttributes({
-    autofocus: 'off', // on/off
+    autofocus: {value: false, dataType: 'boolean'},
     disabled: {value: false, dataType: 'boolean'},
     checked: {value: false, dataType: 'boolean'},
     form: null,

--- a/ui/radio-button.reel/radio-button.js
+++ b/ui/radio-button.reel/radio-button.js
@@ -96,7 +96,7 @@ var RadioButton = exports.RadioButton = Montage.create(CheckInput, {
     }
 });
 RadioButton.addAttributes({
-    autofocus: 'off', // on/off
+    autofocus: {value: false, dataType: 'boolean'},
     disabled: {value: false, dataType: 'boolean'},
     checked: {value: false, dataType: 'boolean'},
     form: null,

--- a/ui/select-input.reel/select-input.js
+++ b/ui/select-input.reel/select-input.js
@@ -305,7 +305,7 @@ var SelectInput = exports.SelectInput =  Montage.create(NativeControl, {
 //http://www.w3.org/TR/html5/the-button-element.html#the-select-element
 
 SelectInput.addAttributes({
-        autofocus: null,
+        autofocus: {dataType: 'boolean'},
         disabled: {dataType: 'boolean'},
         form: null,
         multiple: {dataType: 'boolean'},

--- a/ui/textarea.reel/textarea.js
+++ b/ui/textarea.reel/textarea.js
@@ -22,7 +22,7 @@ var TextArea = exports.TextArea = Montage.create(TextInput, {
 });
 
 TextArea.addAttributes({
-        autofocus: null,
+        autofocus: {dataType: 'boolean'},
         cols: null,
         dirname: null,
         disabled: {dataType: 'boolean'},


### PR DESCRIPTION
The presence of autofocus will trigger it, regardless of value, as such the previous implementation on the checkbox and radio button was breaking some applications due to unexpected focus changing. Normalized the implementation on input and text area as well.
