### PR TITLE
Support bundle optimization

### DIFF
--- a/node.js
+++ b/node.js
@@ -13,6 +13,10 @@ var Require = require("./require/require");
 var Promise = require("./core/promise");
 var URL = require("./core/url");
 
+var jsdom = require("jsdom").jsdom;
+var Node = require("jsdom").level(1).Node;
+var domToHtml = require("jsdom/lib/jsdom/browser/domtohtml").domToHtml;
+
 exports.bootstrap = function (callback) {
     var command = process.argv.slice(0, 3);
     var args = process.argv.slice(2);
@@ -31,27 +35,6 @@ exports.bootstrap = function (callback) {
             }
         });
     });
-};
-
-MontageBoot.loadPackage = function (location, config) {
-    var config = {};
-
-    config.location = URL.resolve('file:/', location + '/');
-
-    // setup the reel loader
-    config.makeLoader = function (config) {
-        return MontageBoot.ReelLoader(config,
-            Require.DefaultLoaderConstructor(config));
-    };
-
-    // setup serialization compiler
-    config.makeCompiler = function (config) {
-        return MontageBoot.TemplateCompiler(config,
-            MontageBoot.SerializationCompiler(config,
-                Require.DefaultCompilerConstructor(config)));
-    };
-
-    return Require.PackageSandbox(config.location, config);
 };
 
 var findPackage = function (path, callback) {
@@ -80,5 +63,138 @@ var loadPackagedModule = function (directory, program, command, args) {
         return require.async(id);
     })
     .end();
+};
+
+MontageBoot.loadPackage = function (location, config) {
+    var config = {};
+
+    config.location = URL.resolve(Require.getLocation(), location + '/');
+
+    // setup the reel loader
+    config.makeLoader = function (config) {
+        return MontageBoot.ReelLoader(
+            config,
+            Require.makeLoader(config)
+        );
+    };
+
+    // setup serialization compiler
+    config.makeCompiler = function (config) {
+        return MontageBoot.TemplateCompiler(
+            config,
+            MontageBoot.SerializationCompiler(
+                config,
+                Require.makeCompiler(config)
+            )
+        );
+    };
+
+    return Require.loadPackage(config.location, config);
+};
+
+MontageBoot.TemplateLoader = function (config, load) {
+    return function(id, module) {
+        var html = id.match(/(.*\/)?(?=[^\/]+\.html$)/);
+        var serialization = id.match(/(?=[^\/]+\.json$)/); // XXX this is not necessarily a strong indicator of a serialization alone
+        if (html) {
+            return load(id, module)
+            .then(function () {
+                module.dependencies = parseHtmlDependencies(module.text, module.location);
+                return module;
+            });
+        } else if (serialization) {
+            return load(id, module)
+            .then(function () {
+                module.dependencies = collectSerializationDependencies(module.text, []);
+                return module;
+            });
+        } else {
+            return load(id, module);
+        }
+    };
+};
+
+// add the TemplateLoader to the middleware chain
+Require.makeLoader = (function (makeLoader) {
+    return function (config) {
+        return MontageBoot.TemplateLoader(config, makeLoader(config));
+    };
+})(Require.makeLoader);
+
+MontageBoot.JsonCompiler = function (config, compile) {
+    return function (module) {
+        var json = module.id.match(/\.json$/);
+        if (json) {
+            module.exports = JSON.parse(module.text);
+            return module;
+        } else {
+            return compile(module);
+        }
+    };
+};
+
+Require.makeCompiler = (function (makeCompiler) {
+    return function (config) {
+        return MontageBoot.JsonCompiler(config, makeCompiler(config));
+    };
+})(Require.makeCompiler);
+
+var parseHtmlDependencies = function (text, location) {
+    var dependencies = [];
+    var document = jsdom(text, null, {
+        "features": {
+            "FetchExternalResources": false,
+            "ProcessExternalResources": false
+        }
+    });
+    collectHtmlDependencies(document, dependencies);
+    return dependencies;
+};
+
+var collectHtmlDependencies = function (document, dependencies) {
+    visit(document, function (element) {
+        if (element.nodeType == Node.ELEMENT_NODE) {
+            if (element.tagName === "SCRIPT") {
+                if (element.getAttribute("type") === "text/montage-serialization") {
+                    collectSerializationDependencies(getText(element), dependencies);
+                }
+            } else if (element.tagName === "LINK") {
+                if (element.getAttribute("type") === "text/montage-serialization") {
+                    dependencies.push(element.getAttribute("href"));
+                }
+            }
+        }
+    });
+};
+
+function visit(element, visitor) {
+    var pruned;
+    var prune = function () {
+        pruned = true;
+    };
+    visitor(element, prune);
+    if (pruned) {
+        return;
+    }
+    element = element.firstChild;
+    while (element) {
+        visit(element, visitor);
+        element = element.nextSibling;
+    }
+}
+
+function getText(element) {
+    return domToHtml(element._childNodes, true, true);
+}
+
+var collectSerializationDependencies = function (text, dependencies) {
+    var serialization = JSON.parse(text);
+    Object.keys(serialization).forEach(function (label) {
+        var description = serialization[label];
+        if (typeof description.module === "string") {
+            dependencies.push(description.module);
+        }
+    });
+    return dependencies;
 };
 

--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
     },
     "devDependencies": {
         "test": ">=0.2.1"
+    },
+    "engines": {
+        "node": ">=0.6.0 <0.6.11"
     }
 }

--- a/require/browser.js
+++ b/require/browser.js
@@ -76,7 +76,7 @@ var globalEval = /*this.execScript ||*/eval;
 // For Firebug evaled code isn't debuggable otherwise
 // http://code.google.com/p/fbug/issues/detail?id=2198
 if (global.navigator && global.navigator.userAgent.indexOf("Firefox") >= 0) {
-    globalEval = new Function("evalString", "return eval(evalString)");
+    globalEval = new Function("_", "return eval(_)");
 }
 
 var __FILE__String = "__FILE__",
@@ -131,36 +131,44 @@ Require.XhrLoader = function (config) {
 };
 
 var definitions = {};
+var getDefinition = function (hash, id) {
+    definitions[hash] = definitions[hash] || {};
+    definitions[hash][id] = definitions[hash][id] || Promise.defer();
+    return definitions[hash][id];
+};
 define = function (hash, id, module) {
-    definitions[hash][id].resolve(module);
+    getDefinition(hash, id).resolve(module);
 };
 
 Require.ScriptLoader = function (config) {
     var hash = config.packageDescription.hash;
-    definitions[hash] = {};
     return function (location, module) {
+        return Promise.call(function () {
 
-        if (/\.js$/.test(location)) {
-            location = location.replace(/\.js/, ".load.js");
-        } else {
-            location += ".load.js";
-        }
+            // short-cut by predefinition
+            if (definitions[hash] && definitions[hash][module.id]) {
+                return definitions[hash][module.id].promise;
+            }
 
-        var script = document.createElement("script");
-        script.onload = function() {
-            script.parentNode.removeChild(script);
-        };
-        script.onerror = function (error) {
-            script.parentNode.removeChild(script);
-        };
-        script.src = location;
-        script.defer = true;
-        document.getElementsByTagName("head")[0].appendChild(script);
+            if (/\.js$/.test(location)) {
+                location = location.replace(/\.js/, ".load.js");
+            } else {
+                location += ".load.js";
+            }
 
-        var deferred = Promise.defer();
-        definitions[hash][module.id] = deferred;
+            var script = document.createElement("script");
+            script.onload = function() {
+                script.parentNode.removeChild(script);
+            };
+            script.onerror = function (error) {
+                script.parentNode.removeChild(script);
+            };
+            script.src = location;
+            script.defer = true;
+            document.getElementsByTagName("head")[0].appendChild(script);
 
-        return deferred.promise
+            return getDefinition(hash, module.id).promise
+        })
         .then(function (definition) {
             delete definitions[hash][module.id];
             for (var name in definition) {

--- a/require/node.js
+++ b/require/node.js
@@ -40,10 +40,13 @@ Require.Compiler = function (config) {
     var names = ["require", "exports", "module"];
     var scopeNames = Object.keys(config.scope);
     names.push.apply(names, scopeNames);
-    return function(module) {
-        if (module.factory)
+    return function (module) {
+        if (module.factory) {
             return module;
-        if (!module.factory && module.text !== void 0) {
+        } else if (
+            module.text !== void 0 &&
+            module.type === "javascript"
+        ) {
             var factory = globalEval(
                 "(function(" + names.join(",") + "){" +
                 module.text +
@@ -59,7 +62,6 @@ Require.Compiler = function (config) {
             // https://developer.mozilla.org/en/JavaScript/Reference/Functions_and_function_scope
             //module.factory = new Function("require", "exports", "module", module.text + "\n//*/\n//@ sourceURL="+module.path);
         }
-        return module;
     };
 };
 


### PR DESCRIPTION
-   Use BUNDLE global as a sentinel to indicate that the bootstrapping
  scripts do not need to be injected.
-   Use data-montage attribute on a bundle script instead of the src for
  discovering the location of the montage package.
-   Catch bundled definitions in script-injection format before or after
  request.
-   Upgrade Node engine to perform deep dependency analysis into HTML
  and serializations.
