### PR TITLE
[gh-59] Prevent Component.cleanupDeletedComponentTree to clear the canDr...

### DIFF
--- a/test/ui/component-spec.js
+++ b/test/ui/component-spec.js
@@ -443,6 +443,16 @@ var testPage = TestPageLoader.queueTest("draw", function() {
                     expect(branchLeaf2.ownerComponent).toBe(branch);
                 });
             });
+
+            it("should be able to draw a component after being cleaned up", function() {
+                testPage.test.componentToBeCleaned.cleanupDeletedComponentTree();
+                testPage.test.componentToBeCleaned.text.value = "New Text";
+
+                testPage.waitForDraw();
+                runs(function() {
+                    expect(testPage.test.componentToBeCleaned.text._element.textContent).toBe("New Text");
+                })
+            })
         });
     });
 });

--- a/test/ui/draw/draw.html
+++ b/test/ui/draw/draw.html
@@ -28,7 +28,8 @@
             "componentWithoutIdentifier": {"@": "componentWithoutIdentifier"},
             "componentWithIdentifier": {"@": "componentWithIdentifier"},
             "componentOwner": {"@": "componentOwner"},
-            "componentLayout": {"@": "componentLayout"}
+            "componentLayout": {"@": "componentLayout"},
+            "componentToBeCleaned": {"@": "componentToBeCleaned"}
         }
     },
     "repetition": {
@@ -153,6 +154,21 @@
             "hasTemplate": false
         }
     },
+    "componentToBeCleaned": {
+        "prototype": "montage/ui/component",
+        "properties": {
+            "element": {"#": "component-tobeclean"},
+            "hasTemplate": false,
+            "text": {"@": "text1"}
+        }
+    },
+    "text1": {
+        "prototype": "montage/ui/dynamic-text.reel",
+        "properties": {
+            "element": {"#": "text1"},
+            "value": "Text"
+        }
+    },
     "owner": {
         "module": "montage/ui/application",
         "name": "Application",
@@ -193,5 +209,9 @@
 <div id="component-layout"></div>
 <div id="component-layout-left">Left</div>
 <div id="component-layout-right">Right</div>
+<div id="component-tobeclean">
+    To Be Clean
+    <span data-montage-id="text1"></span>
+</div>
 </body>
 </html>

--- a/ui/component.js
+++ b/ui/component.js
@@ -526,9 +526,6 @@ var Component = exports.Component = Montage.create(Montage,/** @lends module:mon
             this.needsDraw = false;
             this.traverseComponentTree(function(component) {
                 Object.deleteBindings(component);
-                component.canDrawGate.setField("componentTreeLoaded", false);
-                component.blockDrawGate.setField("element", false);
-                component.blockDrawGate.setField("drawRequested", false);
                 component.needsDraw = false;
             });
         }


### PR DESCRIPTION
...aw and blockDraw gates.

This was being problematic when the element wanted to be reused since needsDraw = true was being ignored after clearing the gates.
