### PR TITLE
Make didCreate to be called after _dependencyListeners is created

### DIFF
--- a/core/core.js
+++ b/core/core.js
@@ -71,12 +71,12 @@ Object.defineProperty(M, "create", {
 
             var newObject = Object.create(typeof aPrototype === "undefined" ? this : aPrototype);
 
-            if (typeof newObject.didCreate === "function") {
-                newObject.didCreate();
-            }
-
             if (newObject._dependenciesForProperty) {
                 newObject._dependencyListeners = {};
+            }
+
+            if (typeof newObject.didCreate === "function") {
+                newObject.didCreate();
             }
 
             return newObject;


### PR DESCRIPTION
This fixes an issue with change listeners being installed at didCreate time since they rely on the existence of _dependencyListeners.
