### PR TITLE
Fix for setting element on a native control

### DIFF
--- a/ui/component.js
+++ b/ui/component.js
@@ -136,7 +136,7 @@ var Component = exports.Component = Montage.create(Montage,/** @lends module:mon
         },
         set: function(value) {
             if (value == null) {
-                console.log("Warning: Tried to set element of ", this, " as " + value + ".");
+                console.warn("Warning: Tried to set element of ", this, " to null.");
                 return;
             }
 

--- a/ui/native-control.js
+++ b/ui/native-control.js
@@ -188,7 +188,7 @@ var NativeControl = exports.NativeControl = Montage.create(Component, {
                     this["_"+attributeName] = this._elementAttributeDescriptors[attributeName].value;
                 }
             }
-
+            this.needsDraw = true;
         }
     },
 


### PR DESCRIPTION
Without this prepareForDraw never gets called on components created
in JS sometimes.

Relates to gh-216
