### PR TITLE
Fix promise delay and add Jasmine promise support

### DIFF
--- a/core/promise.js
+++ b/core/promise.js
@@ -556,18 +556,21 @@ var Promise = PrimordialPromise.create({}, { // Descriptor for each of the three
 
     delay: {
         value: function (timeout) {
-            var deferred = this.Promise.defer();
-            this.then(function (value) {
-                clearTimeout(handle);
-                deferred.resolve(value);
-            }, function (reason, error, rejection) {
-                clearTimeout(handle);
-                deferred.resolve(rejection);
+            var self = this;
+            var promise;
+            if (arguments.length === 0) {
+                timeout = this;
+            } else {
+                promise = this;
+            }
+            return Promise.ref(timeout)
+            .then(function (timeout) {
+                var deferred = self.Promise.defer();
+                setTimeout(function () {
+                    deferred.resolve(promise);
+                }, timeout);
+                return deferred.promise;
             });
-            var handle = setTimeout(function () {
-                deferred.reject("Timed out");
-            }, timeout);
-            return deferred.promise;
         }
     },
 
@@ -582,7 +585,7 @@ var Promise = PrimordialPromise.create({}, { // Descriptor for each of the three
                 deferred.resolve(rejection);
             }).end();
             var handle = setTimeout(function () {
-                deferred.reject("Timed out");
+                deferred.reject("Timed out", new Error("Timed out"));
             }, timeout);
             return deferred.promise;
         }

--- a/test/core/promise-spec.js
+++ b/test/core/promise-spec.js
@@ -121,7 +121,7 @@ describe("core/promise-spec", function () {
 
     describe("delayed promise", function () {
 
-        var delayed = Promise.ref(10).delay(1000);
+        var delayed = Promise.ref(10).delay(100);
         var value;
 
         delayed.then(function (_value) {
@@ -135,6 +135,16 @@ describe("core/promise-spec", function () {
             runs(function () {
                 expect(value).toBe(10);
             });
+        });
+
+        it("can time out", function () {
+            return Promise.delay(100)
+            .timeout(50)
+            .then(function () {
+                expect(true).toBe(false);
+            }, function (reason) {
+                expect(reason).toBe("Timed out");
+            })
         });
 
     });

--- a/test/run.html
+++ b/test/run.html
@@ -6,6 +6,7 @@
     <!-- <meta http-equiv="refresh" content="1"> -->
     <script src="../montage.js" data-module="run"></script>
     <script src="support/jasmine-1.1.0.rc1/jasmine.js"></script>
+    <script src="support/jasmine-promise.js"></script>
     <script src="support/reporters/trivial-html.js"></script>
     <script src="support/js-beautify/beautify.js"></script>
     <script src="support/spec-helper.js"></script>

--- a/test/support/jasmine-promise.js
+++ b/test/support/jasmine-promise.js
@@ -1,0 +1,48 @@
+/* <copyright>
+ This file contains proprietary software owned by Motorola Mobility, Inc.<br/>
+ No rights, expressed or implied, whatsoever to this software are provided by Motorola Mobility, Inc. hereunder.<br/>
+ (c) Copyright 2011 Motorola Mobility, Inc.  All Rights Reserved.
+ </copyright> */
+
+/**
+Monkey-patches support for promises in Jasmine test blocks.
+@fileoverview
+@example
+describe("promise", function () {
+    it("times out", function () {
+        return Promise.delay(100).timeout(50)
+        .then(function (value) {
+            expect(true).toBe(false);
+        }, function (error) {
+            expect(error).toBe("Timed out");
+        })
+    });
+});
+*/
+
+jasmine.Block.prototype.execute = function (onComplete) {
+    var spec = this.spec;
+    var result;
+    try {
+        result = this.func.apply(spec);
+    } catch (error) {
+        spec.fail(error);
+    }
+    if (typeof result === 'undefined') {
+        onComplete();
+    } else if (typeof result !== 'object' || typeof result.then !== 'function') {
+        spec.fail('`it` block returns non-promise: ' + result);
+        onComplete();
+    } else {
+        result.then(function (value) {
+            if (value !== undefined) {
+                spec.fail('Promise fulfilled with unexpected value: ' + value);
+            }
+            onComplete();
+        }, function (error) {
+            spec.fail(error);
+            onComplete();
+        });
+    }
+};
+


### PR DESCRIPTION
-   The delay function was a copy+paste of timeout.
-   Jasmine "it" blocks may now return a "thenable" promise.
