### PR TITLE
Improve console messages for promise-caught errors

### DIFF
--- a/core/promise.js
+++ b/core/promise.js
@@ -394,7 +394,7 @@ var Promise = PrimordialPromise.create({}, { // Descriptor for each of the three
                 try {
                     deferred.resolve(fulfilled ? fulfilled(value) : value);
                 } catch (error) {
-                    console.error(error.stack);
+                    console.error(error.stack || error, fulfilled);
                     deferred.reject(error.message, error);
                 }
             }


### PR DESCRIPTION
Sometimes an error doesn’t have a stack, for example the RangeError that
gets thrown if you bottom out the stack, perhaps with infinite
recursion.  If we’re going to log at all, we should try to log the error
proper if it doesn’t have a stack property.
