### PR TITLE
Clean up array of promise errors

### DIFF
--- a/core/promise.js
+++ b/core/promise.js
@@ -236,7 +236,8 @@ var PrimordialPromise = Creatable.create({
             self._reason = reason;
             self._error = error;
             self.Promise = this;
-            errors.push(error && error.stack || self);
+            rejections.push(self);
+            errors.push(error ? (error.stack ? error.stack : error) : reason);
             return self;
         }
     },
@@ -249,8 +250,9 @@ var PrimordialPromise = Creatable.create({
                     then: function (r, o, rejected) {
                         // remove this error from the list of unhandled errors on the console
                         if (rejected) {
-                            var at = errors.indexOf(this._error && this._error.stack || this);
+                            var at = rejections.indexOf(this);
                             if (at !== -1) {
+                                rejections.splice(at, 1);
                                 errors.splice(at, 1);
                             }
                         }
@@ -640,6 +642,7 @@ var Promise = PrimordialPromise.create({}, { // Descriptor for each of the three
 
 });
 
+var rejections = [];
 var errors = [];
 // Live console objects are not handled on tablets
 if (typeof window !== "undefined" && !window.Touch) {


### PR DESCRIPTION
We use a console log "Should be empty:" to surface errors that have not
yet been handled asynchronously in the promise system.  This array would
contain a stack trace, an error message, an error, or a rejected promise
depending on what was available.  This caused the array to be doing two
functions, neither well: identify a rejection and visualize a rejection.
This patch splits these purposes into two, parallel arrays.  The one
contains the rejection and is suitable for finding the index of the
corresponding stack trace, error, or message in the other.  The arrays
are maintained in tandem.
