### PR TITLE
Rename Promise.ref to Promise.resolve

### DIFF
--- a/core/promise.js
+++ b/core/promise.js
@@ -139,7 +139,14 @@ var PrimordialPromise = Creatable.create({
         }
     },
 
+    // deprecated
     ref: {
+        get: function () {
+            return this.resolve;
+        }
+    },
+
+    resolve: {
         value: function (object) {
             // if it is already a promise, wrap it to guarantee
             // the full public API of this promise variety.


### PR DESCRIPTION
This change parallels a community-driven change to the Q library.
Promise.resolve and Promise.reject are more intuitive to new users.

Keeping Promise.ref as a deprecated property.
