### PR TITLE
[gh-65] Memoize URL.resolve

### DIFF
--- a/montage.js
+++ b/montage.js
@@ -223,17 +223,23 @@ if (typeof window !== "undefined") {
         baseElement.href = "";
         document.querySelector("head").appendChild(baseElement);
         var relativeElement = document.createElement("a");
+        var memo = {};
         exports.resolve = function (base, relative) {
+            var key, resolved, restore;
             base = String(base);
-            if (!/^[\w\-]+:/.test(base)) { // isAbsolute(base)
-                throw new Error("Can't resolve from a relative location: " + JSON.stringify(base) + " " + JSON.stringify(relative));
+            key = base + "\0" + relative;
+            if (!memo[key]) {
+                if (!/^[\w\-]+:/.test(base)) { // isAbsolute(base)
+                    throw new Error("Can't resolve from a relative location: " + JSON.stringify(base) + " " + JSON.stringify(relative));
+                }
+                restore = baseElement.href;
+                baseElement.href = base;
+                relativeElement.href = relative;
+                resolved = relativeElement.href;
+                baseElement.href = restore;
+                memo[key] = resolved;
             }
-            var restore = baseElement.href;
-            baseElement.href = base;
-            relativeElement.href = relative;
-            var resolved = relativeElement.href;
-            baseElement.href = restore;
-            return resolved;
+            return resolved || memo[key];
         };
     };
 


### PR DESCRIPTION
Instrumentation revealed that 10% of resolve calls during startup were
duplicates, with on the order of hundreds of calls.

Profiling produces too much noise to be conclusive on whether this change is an improvement, but since the memo requires relatively little effort, we can speculate that this should speed load times by about 0.005% based on clocking in at 0.05% of profiled time while loading the temperature converter (dominated by load time), and shortcutting 10% of calls.

Fixes gh-65.
