### PR TITLE
Do not allow a component's element to be changed

### DIFF
--- a/test/ui/component-spec.js
+++ b/test/ui/component-spec.js
@@ -453,6 +453,13 @@ var testPage = TestPageLoader.queueTest("draw", function() {
                     expect(testPage.test.componentToBeCleaned.text._element.textContent).toBe("New Text");
                 })
             })
+
         });
+
+        it("does not allow the element to be changed", function() {
+            var oldElement = testPage.test.text1.element;
+            testPage.test.text1.element = testPage.document.createElement("div");
+            expect(testPage.test.text1.element).toBe(oldElement);
+        })
     });
 });

--- a/test/ui/draw/draw.html
+++ b/test/ui/draw/draw.html
@@ -29,7 +29,8 @@
             "componentWithIdentifier": {"@": "componentWithIdentifier"},
             "componentOwner": {"@": "componentOwner"},
             "componentLayout": {"@": "componentLayout"},
-            "componentToBeCleaned": {"@": "componentToBeCleaned"}
+            "componentToBeCleaned": {"@": "componentToBeCleaned"},
+            "text1": {"@": "text1"}
         }
     },
     "repetition": {

--- a/ui/component.js
+++ b/ui/component.js
@@ -136,13 +136,13 @@ var Component = exports.Component = Montage.create(Montage,/** @lends module:mon
         },
         set: function(value) {
             if (value == null) {
-                console.log("Warning: Tried to set element of ", this, " as " + value + ".");
+                console.warn("Tried to set element of ", this, " to ", value);
                 return;
             }
 
-            this.eventManager.registerEventHandlerForElement(this, value);
-
             if (this.isDeserializing) {
+                this.eventManager.registerEventHandlerForElement(this, value);
+
                 // if this component has a template and has been already instantiated then assume the value is the template.
                 if (this._isTemplateInstantiated) {
                     // this is important for component extension, we don't want to override template element
@@ -155,7 +155,13 @@ var Component = exports.Component = Montage.create(Montage,/** @lends module:mon
                         this.blockDrawGate.setField("element", true);
                     }
                 }
+            } else if (!this._firstDraw) {
+                // If a draw has happened then at some point the element has been set
+                console.error("Cannot change element of ", this, " after it has been set");
+                return;
             } else {
+                this.eventManager.registerEventHandlerForElement(this, value);
+
                 this._element = value;
                 if (!this.blockDrawGate.value && this._element) {
                     this.blockDrawGate.setField("element", true);


### PR DESCRIPTION
Only allow the element of a component to be changed before its first draw.
After this point anything could have been done to it, references to it from
many places created, making clean up and another set up near impossible.

See gh-323.
