### PR TITLE
Fix for setting element on a native control

### DIFF
--- a/ui/native-control.js
+++ b/ui/native-control.js
@@ -188,7 +188,7 @@ var NativeControl = exports.NativeControl = Montage.create(Component, {
                     this["_"+attributeName] = this._elementAttributeDescriptors[attributeName].value;
                 }
             }
-
+            this.needsDraw = true;
         }
     },
 


### PR DESCRIPTION
Without this prepareForDraw never gets called on components created
in JS.

Relates to gh-216
