### PR TITLE
Request for Comments: Inherit window title from loader’s main component

### DIFF
--- a/examples/app-template/index.html
+++ b/examples/app-template/index.html
@@ -7,14 +7,13 @@
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <title>Loader Example</title>
-    <script src="../../montage.js" data-package="."></script>
+    <title>Loading…</title>
+    <script src="../../montage.js"></script>
 
     <script type="text/montage-serialization">
         {
             "owner": {
-                "module": "montage/ui/loader.reel",
-                "name": "Loader"
+                "prototype": "montage/ui/loader.reel"
             }
         }
     </script>
@@ -22,59 +21,31 @@
     <style type="text/css">
 
         html {
-            background-color: hsl(0,0%,95%);
             font: 20px/1.5em "Helvetica Neue", Arial, Helvetica, Geneva, sans-serif;
-        }
-        body {
-            padding: 50px;
-        }
-        div {
-            width: 500px;
-            margin: 0 auto;
-        }
-        h1 {
-            margin: 40px 0 0 0;
         }
 
         #montage-app-bootstrapper {
-            display: none;
-            color: red;
         }
         .montage-app-bootstrapping #montage-app-bootstrapper {
-            display: block;
         }
 
         #montage-app-loader {
-            color: green;
             display: none;
         }
         .montage-app-loading #montage-app-loader {
-            display: block;
-        }
-
-        .main {
-            display: none;
-        }
-        .montage-app-loaded .main {
-            display: block;
         }
 
     </style>
 
 </head>
 <body>
-    <!--<div>
-        <h1>Loader Example</h1>
-        <p>This is the loader example. This text here will be present until the main component is drawn as it is not part
-            of any of the loader elements. If the main component is not drawable within <strong>1000ms</strong> you'll see the bootstrapper.</p>
-    </div>-->
     <div id="montage-app-bootstrapper">
-        <h1>Bootstrapper</h1>
-        <p>This is the bootstrapper content which will now be shown for at least <strong>1500ms</strong>.</p>
+        Loading framework…
+        <!-- This is the bootstrapper content which will now be shown for at least 1500ms -->
     </div>
     <div id="montage-app-loader">
-        <h1>Loader</h1>
-        <p>This is the loader content which will now be shown for at least <strong>2000ms</strong>.</p>
+        Loading application…
+        <!-- This is the loader content which will now be shown for at least 2000ms -->
     </div>
 </body>
 </html>

--- a/examples/app-template/main.reel/main.css
+++ b/examples/app-template/main.reel/main.css
@@ -1,5 +1,0 @@
-.main {
-    padding: 100px;
-}
-
-

--- a/examples/app-template/main.reel/main.html
+++ b/examples/app-template/main.reel/main.html
@@ -10,6 +10,16 @@
     <title>Main Component</title>
 
     <style type="text/css">
+        body {
+            padding: 50px;
+        }
+        div {
+            width: 500px;
+            margin: 0 auto;
+        }
+        h1 {
+            margin: 40px 0 0 0;
+        }
         .main {
             background: hsl(0,0%,90%);
         }

--- a/examples/app-template/package.json
+++ b/examples/app-template/package.json
@@ -1,10 +1,7 @@
 {
-    "name": "loader",
+    "name": "montage-loader-example",
     "version": "0.0.0",
-    "mappings": {
-        "montage": "../../"
-    },
-    "directories": {
-        "lib": ""
+    "dependencies": {
+        "montage": "*"
     }
 }

--- a/ui/loader.reel/loader.js
+++ b/ui/loader.reel/loader.js
@@ -216,7 +216,7 @@ exports.Loader = Montage.create(Component, /** @lends module:montage/ui/loader.L
     // Implementation
 
     templateDidLoad: {
-        value: function() {
+        value: function(template) {
 
             if (logger.isDebug) {
                 logger.debug(this, "templateDidLoad");
@@ -343,6 +343,13 @@ exports.Loader = Montage.create(Component, /** @lends module:montage/ui/loader.L
             this.childComponents.push(this._mainComponent);
             this._mainComponent.setElementWithParentComponent(document.createElement("div"), this);
             this._mainComponent.needsDraw = true;
+            this._mainComponent.templateDidLoad = (function (previous) {
+                return function () {
+                    if (previous)
+                        previous.apply(this, arguments);
+                    window.document.title = this._template.title;
+                };
+            })(this._mainComponent.templateDidLoad);
         }
     },
 

--- a/ui/template.js
+++ b/ui/template.js
@@ -396,10 +396,10 @@ var Template = exports.Template = Montage.create(Montage, /** @lends module:mont
 
             if (owner) {
                 if (typeof owner._templateDidLoad === "function") {
-                    owner._templateDidLoad();
+                    owner._templateDidLoad(this);
                 }
                 if (typeof owner.templateDidLoad === "function") {
-                    owner.templateDidLoad();
+                    owner.templateDidLoad(this);
                 }
             }
         }
@@ -967,5 +967,12 @@ var Template = exports.Template = Montage.create(Montage, /** @lends module:mont
         if (_extends) {
             this._extends = _extends;
         }
-    }}
+    }},
+
+    title: {
+        get: function () {
+            return this._document.querySelector("head title").innerHTML;
+        }
+    }
+
 });


### PR DESCRIPTION
The purpose of this modification is to make the window title reflect the title of the main component, from the `<title>` tag. This is probably the first step in a campaign to give every component a meaningful title, particularly in the substitution et al, so that the window title gets updated.

I suspect several things are wrong with this pull request and could use some education.

For one, I know this is bad: https://github.com/kriskowal/montage/pull/new/improve-loader-example#L4R346

I replace the templateDidLoad method of the component so I can observe that the title property is ready for harvest. I trap the old method in a closure so I can handle both the case where there was a previous handler and the case that there was none.  This is the kind of thing that smacks of the bad old days before event listeners.  Is it possible to register a listener?  I don’t think so.  Is there an alternative?

For two, could I use bindings, from the main component to the window?
