### PR TITLE
Complain when serializing objects wo package

### DIFF
--- a/core/serializer.js
+++ b/core/serializer.js
@@ -458,6 +458,10 @@ var Serializer = Montage.create(Montage, /** @lends module:montage/serializer.Se
             serializedUnits = {};
             objectInfo = Montage.getInfoForObject(object);
 
+            if (!this._require) {
+                throw new Error("Cannot serialize Montage objects without a require function to identify the corresponding package.");
+            }
+
             moduleId = this._require.identify(
                 objectInfo.moduleId,
                 objectInfo.require


### PR DESCRIPTION
Complain loudly when a user attempts to serialize non-JSON objects
without providing a "require" function to give a relative package
context to the serialization.  A serialization will have different
module identifiers depending on what package it is intended to ship in.
