### PR TITLE
Kitchen sink, TranslateComposer example

### DIFF
--- a/examples/sink/components/translate-composer-example.reel/translate-composer-example.html
+++ b/examples/sink/components/translate-composer-example.reel/translate-composer-example.html
@@ -15,8 +15,7 @@
         "properties": {
             "component": {"@": "example"},
             "maxTranslateX": 350,
-            "maxTranslateY": 150,
-            "pointerSpeedMultiplier": -1
+            "maxTranslateY": 150
         },
         "bindings": {
             "axis": {"<-": "@axisSelect.value"},


### PR DESCRIPTION
Removed `pointerSpeedMultiplier = -1` from serialized TranslateComposer instance, which was causing the dragged object to move in the opposite direction. It was a hack that accidentally worked and was forgotten.

There's a separate issue I found...when you release the drag object in the example, its momentum is applied in the opposite (backwards) direction. I'll file an issue about this.
