### PR TITLE
Remove support for name@version mappings

### DIFF
--- a/require/require.js
+++ b/require/require.js
@@ -372,17 +372,9 @@
     function normalizeDependency(dependency, config, name) {
         config = config || {};
         if (typeof dependency === "string") {
-            if (dependency.indexOf("@") >= 0) {
-                var parts = dependency.split("@");
-                dependency = {
-                    name: parts[0] || name,
-                    version: parts[1]
-                };
-            } else {
-                dependency = {
-                    location: dependency
-                };
-            }
+            dependency = {
+                location: dependency
+            };
         }
         // if the named dependency has already been found at another
         // location, refer to the same eventual instance

--- a/test/require/load-package-name/program.js
+++ b/test/require/load-package-name/program.js
@@ -1,5 +1,5 @@
 var test = require("test");
-module.exports = require.loadPackage("a@0.0.0")
+module.exports = require.loadPackage({name: "a"})
 .then(function (a) {
     return a.async("");
 })

--- a/test/require/named-mappings/package.json
+++ b/test/require/named-mappings/package.json
@@ -1,7 +1,7 @@
 {
     "mappings": {
-        "bar": "bar@0.0.0",
-        "foo": "@"
+        "bar": {"name": "bar"},
+        "foo": {"name": "foo"}
     },
     "directories": {
         "packages": "."


### PR DESCRIPTION
@tstatler found, as I should have recalled, that the Montage Optimizer
(mop) generates valid relative package locations with the form
name@hash that are indistinguishable from name@version mappings.  We
will need to use the NPM "dependencies" property for this form, or the
verbose {name, version} mapping objects.

Fixes gh-419
