### PR TITLE
Code broken in Firefox because properties are not writable

### DIFF
--- a/core/change-notification.js
+++ b/core/change-notification.js
@@ -185,7 +185,7 @@ var ChangeNotification = exports.ChangeNotification = Object.create(Montage, {
     }
 });
 
-var ChangeNotificationDescriptor = Object.create(Object.prototype, {
+var ChangeNotificationDescriptor = Montage.create(Montage, {
     target: {value: null},
     propertyPath: {value: null},
     willChangeListeners: {value: null},


### PR DESCRIPTION
in change-notification.js, ChangeNotificationDescriptor = Object.create(..), properties definition need to use writable: true, right now setting values fail silently...
