### PR TITLE
Added lab/tools to package exclude list

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
             "exclude": [
                 "lab/benchmarks",
                 "lab/sandbox",
+                "lab/tools",
                 "examples",
                 "require/test",
                 "require/tests",


### PR DESCRIPTION
mop was throwing an error on some of the files inside it. This allows mop to run correctly again.
