### PR TITLE
Error in console when expanding object

### DIFF
--- a/core/core.js
+++ b/core/core.js
@@ -456,7 +456,7 @@ Montage.defineProperty(Montage, "getInfoForObject", {
         var metadata;
         var instanceMetadataDescriptor;
 
-        if (object.hasOwnProperty("_montage_metadata")) {
+        if (hasOwnProperty.call(object, "_montage_metadata")) {
             return object._montage_metadata;
         } else {
             metadata = object._montage_metadata || (object.constructor && object.constructor._montage_metadata) || null;
@@ -516,6 +516,8 @@ Object.defineProperty(Montage, "__OBJECT_COUNT", {
 
 var UUID = require("core/uuid");
 
+var hasOwnProperty = Object.prototype.hasOwnProperty;
+
 var uuidGetGenerator = function() {
 
     var uuid = UUID.generate(),
@@ -561,7 +563,7 @@ var uuidGetGenerator = function() {
 };
 
 var defaultUuidGet = function defaultUuidGet() {
-    return (this.hasOwnProperty("_uuid") ? this._uuid : uuidGetGenerator.call(this));
+    return (hasOwnProperty.call(this, "_uuid") ? this._uuid : uuidGetGenerator.call(this));
 };
 
 /**


### PR DESCRIPTION
This is a random thing I found and might mean nothing...here are the weird steps to reproduce:
1. Load any Montage app in the browser
2. Open the JavaScript console and copy/paste the following code and hit return:

```
var obj = {};
Object.defineProperty( obj, "value", {
  value: true,
  writable: false,
  enumerable: true,
  configurable: true
});
```
1. In the console, click on the "Object" item that was returned to expand it, then click on "**proto**" below that to expand that item.

Results:  The console display the following error:

```
Uncaught TypeError: Property 'hasOwnProperty' of object #<error> is not a function
defaultUuidGet:8000/core/core.js:593
InjectedScript._propertyDescriptors
InjectedScript.getProperties
```

Here's a screen shot:

https://docs.google.com/a/motorola.com/document/d/1dveUC16rAzGPinjfLm2lS_ODL9nHBwITpR1RGNh7hNs/edit

If you do the same steps without Montage loaded, then there's no error.  I guess I would expect the same behavior with or without Montage loaded.
