### PR TITLE
[gh-554] Fix serialization of null objects

### DIFF
--- a/core/serializer.js
+++ b/core/serializer.js
@@ -89,7 +89,8 @@ var Serializer = Montage.create(Montage, /** @lends module:montage/serializer.Se
         value: function(objects) {
             var serialization,
                 valueSerialization,
-                label;
+                label,
+                serializeNullValues = this.serializeNullValues;
 
             this._serializedObjects = {};
             this._serializedReferences = {};
@@ -100,14 +101,18 @@ var Serializer = Montage.create(Montage, /** @lends module:montage/serializer.Se
             this._objectReferences = {};
 
             for (label in objects) {
-                this._objectLabels[objects[label].uuid] = label;
+                if (objects[label] != null) {
+                    this._objectLabels[objects[label].uuid] = label;
+                }
             }
 
             for (label in objects) {
-                valueSerialization = this._serializeValue(objects[label], null, 2);
-                // objects are automatically inserted as top level objects after calling _serializeValue, but native objects have to be manually inserted them.
-                if (!(label in this._serializedObjects)) {
-                    this._serializedObjects[label] = {value: valueSerialization};
+                if (objects[label] != null || serializeNullValues) {
+                    valueSerialization = this._serializeValue(objects[label], null, 2);
+                    // objects are automatically inserted as top level objects after calling _serializeValue, but native objects have to be manually inserted them.
+                    if (!(label in this._serializedObjects)) {
+                        this._serializedObjects[label] = {value: valueSerialization};
+                    }
                 }
             }
 

--- a/test/serialization/serializer-spec.js
+++ b/test/serialization/serializer-spec.js
@@ -113,6 +113,21 @@ describe("serialization/serializer-spec", function() {
             expect((new Function(object.arguments, object.body))(2)).toBe(4);
         });
 
+        it("should not serialize objects with a null value", function() {
+            var object = {number: 42, nil: null};
+            var serialization = serializer.serialize(object);
+
+            expect(stripPP(serialization)).toBe('{"number":{"value":42}}');
+        });
+
+        it("should serialize objects with a null value", function() {
+            var object = {number: 42, nil: null};
+            serializer.serializeNullValues = true;
+            var serialization = serializer.serialize(object);
+
+            expect(stripPP(serialization)).toBe('{"number":{"value":42},"nil":{"value":null}}');
+        });
+
         it("should serialize array with shorthand", function() {
             expect(JSON.parse(serialize([1, 2, 3]))).toEqual({
                 root: {


### PR DESCRIPTION
They were making the .serialize() function crash.
