### PR TITLE
gh-565, Fix slot content API

### DIFF
--- a/test/ui/slot-spec.js
+++ b/test/ui/slot-spec.js
@@ -22,7 +22,7 @@ var testPage = TestPageLoader.queueTest("slot-test", function() {
 
         describe("when first loaded", function() {
             it("it should have no initial content", function() {
-                expect(slot.content).toEqual([]);
+                expect(slot.content).toEqual(null);
                 expect(slot.element.childNodes.length).toEqual(0);
             });
         });
@@ -111,6 +111,36 @@ var testPage = TestPageLoader.queueTest("slot-test", function() {
 
                     runs(function() {
                         expect(slot.childComponents).toContain(content);
+                    });
+                });
+            });
+
+            it("accessing the content property should return an element if an element was initially set", function() {
+                testPage.waitForDraw();
+                runs(function() {
+                    var content = testPage.test.bazContent;
+
+                    slot.content = content;
+
+                    testPage.waitForDraw();
+
+                    runs(function() {
+                        expect(slot.content).toEqual(content);
+                    });
+                });
+            });
+
+            it("accessing the content property should return a component if a component was initially set", function() {
+                testPage.waitForDraw();
+                runs(function() {
+                    var content = testPage.test.componentInPageWithElement;
+
+                    slot.content = content;
+
+                    testPage.waitForDraw();
+
+                    runs(function() {
+                        expect(slot.content).toEqual(content);
                     });
                 });
             });

--- a/ui/slot.reel/slot.js
+++ b/ui/slot.reel/slot.js
@@ -21,6 +21,12 @@ exports.Slot = Montage.create(Component, /** @lends module:"montage/ui/slot.reel
         value: false
     },
 
+    didCreate: {
+        value: function() {
+            this.content = null;
+        }
+    },
+
 /**
         Description TODO
         @type {Property}
@@ -32,6 +38,10 @@ exports.Slot = Montage.create(Component, /** @lends module:"montage/ui/slot.reel
         serializable: true
     },
 
+    _content: {
+        value: null
+    },
+
 /**
         Description TODO
         @type {Function}
@@ -40,7 +50,7 @@ exports.Slot = Montage.create(Component, /** @lends module:"montage/ui/slot.reel
     content: {
         enumerable: false,
         get: function() {
-            return Object.getPropertyDescriptor(Component, "domContent").get.call(this);
+            return this._content;
         },
         set: function(value) {
             var element;
@@ -63,6 +73,7 @@ exports.Slot = Montage.create(Component, /** @lends module:"montage/ui/slot.reel
             } else {
                 Object.getPropertyDescriptor(Component, "domContent").set.call(this, value);
             }
+            this._content = value;
             this.needsDraw = true;
         }
     },


### PR DESCRIPTION
- Fix the slot content property so that it returns whatever content was initially set on the slot.  If a component is set, then it returns the component.  If an element was set then it returns the element.
- Add tests to show that accessing the content property returns the exact content that was set
- Fix the initial load behavior to clear out the children of the slot's element, this was the behavior before the recent content changes
