### PR TITLE
Disabling the deletion of bindings

### DIFF
--- a/ui/component.js
+++ b/ui/component.js
@@ -538,14 +538,19 @@ var Component = exports.Component = Montage.create(Montage,/** @lends module:mon
      * @function
      */
     cleanupDeletedComponentTree: {
-        value: function() {
-            // This was causing the symptoms expressed in gh-603
-            // Until we have a more granular way we shouldn't do this.
-            //Object.deleteBindings(this);
+        value: function(deleteBindings) {
+            // Deleting bindings in all cases was causing the symptoms expressed in gh-603
+            // Until we have a more granular way we shouldn't do this,
+            // the deleteBindings parameter is a short term fix.
+            if (deleteBindings) {
+                Object.deleteBindings(this);
+            }
             this.needsDraw = false;
             this.traverseComponentTree(function(component) {
                 // See above comment
-                //Object.deleteBindings(component);
+                if (deleteBindings) {
+                    Object.deleteBindings(component);
+                }
                 component.needsDraw = false;
             });
         }
@@ -1775,7 +1780,7 @@ var rootComponent = Montage.create(Component, /** @lends module:montage/ui/compo
         enumerable: false,
         value: 0
     },
-    
+
     drawTree: {
         value: function drawTree() {
             if (this.requestedAnimationFrame === null) { // 0 is a valid requestedAnimationFrame value
@@ -1829,7 +1834,7 @@ var rootComponent = Montage.create(Component, /** @lends module:montage/ui/compo
                     // http://my.opera.com/emoller/blog/2011/12/20/requestanimationframe-for-smart-er-animating
                     var currentDate = Date.now(),
                         miliseconds = 17 - currentDate + this._previousDrawDate;
-                    
+
                     if (miliseconds < 0) {
                         miliseconds = 0;
                     }

--- a/ui/repetition.reel/repetition.js
+++ b/ui/repetition.reel/repetition.js
@@ -759,7 +759,7 @@ var Repetition = exports.Repetition = Montage.create(Component, /** @lends modul
                 this._expectedChildComponentsCount -= childComponentsCount;
 //console.log("this._expectedChildComponentsCount: ", this._expectedChildComponentsCount);
                 for (var i = 0, l = removedComponents.length; i < l; i++) {
-                    removedComponents[i].cleanupDeletedComponentTree();
+                    removedComponents[i].cleanupDeletedComponentTree(true);
                 }
             } else {
                 this._childLoadedCount--;


### PR DESCRIPTION
Temporary fix for gh-603

In Component's cleanupDeletedComponentTree() we were deleting all
the bindings of the outgoing domContent. This is good if we wanted
to trash the content but it causes issues when it is reused in the 
condition.
