### PR TITLE
[gh-571] token-field shows [object Object] instead of the value

### DIFF
--- a/ui/token-field/token.reel/token.js
+++ b/ui/token-field/token.reel/token.js
@@ -8,29 +8,51 @@ var Montage = require("montage").Montage,
 
 exports.Token = Montage.create(Component, {
 
-    text: {value: null},
+    _text: {
+        value: null
+    },
+
+    text: {
+        dependencies: ["value", "textPropertyPath"],
+        get: function() {
+            var textPropertyPath,
+                value,
+                text;
+
+            if (this._text == null) {
+                this._adHoc = false;
+                textPropertyPath = this.textPropertyPath;
+                value = this.value;
+
+                if (textPropertyPath != null && value != null) {
+                    if (typeof value[textPropertyPath] === 'undefined' && this.allowAdHocValues) {
+                        this._adHoc = true;
+                        this._text = value;
+                    } else {
+                        this._text = value[textPropertyPath];
+                    }
+                } else {
+                    this._text = value;
+                }
+            }
+
+            return this._text;
+        }
+    },
 
     allowAdHocValues: {value: null},
+
+    _value: {
+        value: null
+    },
 
     value: {
         get: function() {
             return this._value;
         },
         set: function(aValue) {
-            this._adHoc = false;
-            if(aValue) {
-               this._value = aValue;
-               if(this.textPropertyPath) {
-                   if(typeof aValue[this.textPropertyPath] == 'undefined' && this.allowAdHocValues) {
-                       this.text = aValue;
-                       this._adHoc = true;
-                   } else {
-                       this.text = this.value[this.textPropertyPath];
-                   }
-               } else {
-                   this.text = this.value;
-               }
-            }
+            this._value = aValue;
+            this._text = null;
         }
     },
 


### PR DESCRIPTION
This was happening because the text property didn't depend on the value/textPropertyPath property.
In the case of the kitchen sink the text was being retrieved before the textPropertyPath was set hence returning value as default instead of value[textPropertyPath]
