### PR TITLE
[gh-606] Make __debugChangeNotifications__ report the correct 2way bindi...

### DIFF
--- a/core/change-notification.js
+++ b/core/change-notification.js
@@ -1367,7 +1367,12 @@ Object.defineProperty(Object.prototype, "__debugChangeNotifications__", {
                     var listenerFunctionName = changeListeners[key].listenerFunctionName;
                     var info = Montage.getInfoForObject(listenerTarget);
                     if (info.objectName === "PropertyChangeBindingListener") {
-                        bindings.push("\"" + listenerTarget.bindingPropertyPath + "\" @ " + Montage.getInfoForObject(listenerTarget.bindingOrigin).objectName + "(", listenerTarget.bindingOrigin, ")");
+                        if (listenerTarget.bindingOrigin === this && listenerTarget.bindingPropertyPath === path) {
+                            bindings.push("\"" + listenerTarget.targetPropertyPath + "\" @ " + (Montage.getInfoForObject(listenerTarget.target).objectName || "<object>") + "(", listenerTarget.target, ")");
+                        } else {
+                            bindings.push("\"" + listenerTarget.bindingPropertyPath + "\" @ " + (Montage.getInfoForObject(listenerTarget.bindingOrigin).objectName || "<object>") + "(", listenerTarget.bindingOrigin, ")");
+                        }
+
                         bindings.push("\n\t            ");
                     }
                 }


### PR DESCRIPTION
...ng information

**debugChangeNotifications** was reporting the wrong side of a 2way binding when displaying information for the left side of the binding.
