### PR TITLE
Declare variable in _dispatchArrayChangeNotification()

### DIFF
--- a/core/change-notification.js
+++ b/core/change-notification.js
@@ -918,6 +918,7 @@ Object.defineProperty(ChangeNotificationDispatchingArray, "_dispatchArrayChangeN
     configurable: false,
     value: function(methodName, methodArguments, index, howManyToRemove, newValues) {
         var descriptor = ChangeNotification.getPropertyChangeDescriptor(this, null),
+            result,
             notification,
             indexNotification = Object.create(PropertyChangeNotification),
             delta,


### PR DESCRIPTION
The variable was being created in the global scope making observed array operations to return the wrong value sometimes.
