### PR TITLE
Change condition removal strategy in todo-mvc to 'remove'

### DIFF
--- a/examples/todo-mvc/main.reel/main.html
+++ b/examples/todo-mvc/main.reel/main.html
@@ -83,8 +83,7 @@
             "markAllCompleteConditional": {
                 "prototype": "montage/ui/condition.reel",
                 "properties": {
-                    "element": {"#": "markAllCompleteForm"},
-                    "removalStrategy": "hide"
+                    "element": {"#": "markAllCompleteForm"}
                 },
                 "bindings": {
                     "condition": {"<-": "@owner.tasksController.organizedObjects.count()"}


### PR DESCRIPTION
Now that there is a temporary fix to not delete bindings on removed content change the condition removal strategy back to 'remove' for the todo-mvc markAllCompleteConditional.  This fixes an issue with the button not disappearing due to a missing CSS class.
