### PR TITLE
Always calling the originalSetter in listeners.

### DIFF
--- a/core/change-notification.js
+++ b/core/change-notification.js
@@ -684,12 +684,14 @@ var ObjectPropertyChangeDispatcherManager = Object.create(null, {
                     notification;
 
                 if (!descriptor) {
+                    originalSetter.apply(this, arguments);
                     return;
                 }
 
                 previousValue = this[propertyName];
                 if (previousValue === value) {
-                    // Nothing to do here
+                    originalSetter.apply(this, arguments);
+                    // Nothing more to do here
                     return;
                 }
 

--- a/test/events/change-notification-spec.js
+++ b/test/events/change-notification-spec.js
@@ -1194,6 +1194,21 @@ describe("event/change-notification-spec", function() {
                 expect(listeners.listener.callCount).toBe(0);
             });
 
+            it("should remove a function listener and continue setting the value after removal", function() {
+                var object = {x: 3},
+                    listeners = {
+                        listener: function(notification) {
+                        }
+                    };
+
+                spyOn(listeners, "listener").andCallThrough();
+                object.addPropertyChangeListener("x", listeners.listener);
+                object.removePropertyChangeListener("x", listeners.listener);
+                object.x = 4;
+
+                expect(object.x).toBe(4);
+            });
+
             it("should remove a function listener after being triggered", function() {
                 var object = {x: 3},
                     listeners = {
@@ -1655,6 +1670,63 @@ describe("event/change-notification-spec", function() {
             expect(Object.getOwnPropertyDescriptor(object, "enumerable").enumerable).toBe(true);
             expect(Object.getOwnPropertyDescriptor(object, "notEnumerable").enumerable).toBe(false);
         });
+
+        it("should remove a function listener and continue calling the original setter after removal", function() {
+            var setters = {
+                 setter: function(value) {
+                     this._foo = value;
+                 }
+             };
+
+            var MeaningfulObject = Montage.create(Montage, {
+                _foo: {
+                    value: "same"
+                },
+
+                foo: {
+                    set: setters.setter,
+                    get: function() {
+                        return this._foo;
+                    }
+                }
+            });
+            var object = MeaningfulObject.create();
+
+            spyOn(setters, "setter").andCallThrough();
+            object.addPropertyChangeListener("x", function(notification) {});
+            object.removePropertyChangeListener("x", function(notification) {});
+            object.foo = "new";
+
+            expect(object.foo).toEqual("new");
+        });
+
+        it("should always call the original setter", function() {
+
+            var setterCalled = false;
+
+            var MeaningfulObject = Montage.create(Montage, {
+                _foo: {
+                    value: "same"
+                },
+
+                foo: {
+                    set: function(value) {
+                        setterCalled = true;
+                        this._foo = value;
+                    },
+                    get: function() {
+                        return this._foo;
+                    }
+                }
+            });
+            var object = MeaningfulObject.create();
+
+            object.addPropertyChangeListener("x", function(notification) {});
+            object.foo = "same";
+
+            expect(setterCalled).toBeTruthy();
+         });
+
     });
 
     describe("listener cycles", function() {


### PR DESCRIPTION
When there was no more descriptors or if the value was the same
we were not calling the original setter of the property.
