### PR TITLE
Fix auto-package [Fixes gh-533]

### DIFF
--- a/montage.js
+++ b/montage.js
@@ -108,8 +108,8 @@ if (typeof window !== "undefined") {
 
                 if ('autoPackage' in params) {
                     montageRequire.injectPackageDescription(location, {
-                        mappings: {
-                            montage: "@"
+                        dependencies: {
+                            montage: "*"
                         }
                     });
                 }


### PR DESCRIPTION
Fixes gh-533 by using named dependencies instead of location mappings
for the implied montage dependency.  This is a regression caused by
removing support for "name@version" mappings previously, which was in
turn causing Mopped packages to confuse "name@hash" locatations for
"name@version" dependencies.
