### PR TITLE
Workaround for photofx issue gh-635 unable to remove a photo

### DIFF
--- a/examples/photofx/main.reel/main.html
+++ b/examples/photofx/main.reel/main.html
@@ -90,7 +90,8 @@
             "removeSelectionCondition": {
                 "prototype": "montage/ui/condition.reel",
                 "properties": {
-                    "element": {"#": "removeSelectionCondition"}
+                    "element": {"#": "removeSelectionCondition"},
+                    "removalStrategy": "hide"
                 },
                 "bindings": {
                     "condition": {"<-": "@photoController.selectedObjects.0"}


### PR DESCRIPTION
Change the removal strategy for the removeSelectionCondition to "hide" in order to workaround an issue where needsDraw is set to false if the removal strategy is "remove" which causes the button to never have its listeners added.
