### PR TITLE
[gh-657] Serialization detects object literals created in different docu...

### DIFF
--- a/core/serializer.js
+++ b/core/serializer.js
@@ -529,10 +529,10 @@ var Serializer = Montage.create(Montage, /** @lends module:montage/serializer.Se
                     return this._serializeElement(value);
                 } else if (Array.isArray(value)) {
                     return this._serializeArray(value, indent + 1);
-                } else if (Object.getPrototypeOf(value) === Object.prototype) {
-                    return this._serializeObjectLiteral(value, null, indent + 1);
                 } else if (value.constructor === Function) {
                     return this._serializeFunction(value, indent);
+                } else if (!("getInfoForObject" in value)) { // we consider object literals the ones who aren't a Montage object
+                    return this._serializeObjectLiteral(value, null, indent + 1);
                 } else {
                     // TODO: should refactor this to handle references here, doesn't make
                     //       sense to wait until it hits _serializeObject for that to happen

--- a/test/serialization/serializer-spec.js
+++ b/test/serialization/serializer-spec.js
@@ -102,6 +102,20 @@ describe("serialization/serializer-spec", function() {
             expect(stripPP(serialization)).toBe('{"number":' + object.number + ',"string":"' + object.string + '","regexp":' + object.regexp + '}');
         });
 
+        it("should serialize an Object literal created in a different document", function() {
+            var iframe = document.createElement("iframe");
+            iframe.style.display = "none";
+            window.document.body.appendChild(iframe);
+
+            var object = new iframe.contentWindow.Object;
+            object.number = 42;
+            object.string = "string";
+            var serialization = serializer.serializeObject(object);
+
+            expect(stripPP(serialization)).toBe('{"root":{"value":{"number":42,"string":"string"}}}');
+
+        });
+
         it("should serialize a function", function() {
             var funktion = function square(x) {
                 return x*x;


### PR DESCRIPTION
...ments

An object literal created in a different document than the one where the Serializer instance was created wasn't being correctly serialized.
