### PR TITLE
Stop using notification.uuid when propagating changes

### DIFF
--- a/core/change-notification.js
+++ b/core/change-notification.js
@@ -206,14 +206,11 @@ var ChangeNotificationDescriptor = Montage.create(Montage, {
     mutationDependencyIndex: {value: null},
     mutationListenersCount: {value: 0},
     observedDependentProperties: {value: null},
-    _isHandlingNotification: {value: null},
 
     initWithTargetPath: {
         value: function(target, path) {
             this.target = target;
             this.propertyPath = path;
-            // TODO: this probably should be in didCreate...
-            this._isHandlingNotification = {};
 
             return this;
         }
@@ -540,12 +537,11 @@ var ChangeNotificationDescriptor = Montage.create(Montage, {
                 dependentDescriptorsIndex = this.dependentDescriptorsIndex,
                 dependenciesIndex = notification._dependenciesIndex,
                 isMutationNotification,
-                isHandlingNotification = this._isHandlingNotification,
-                notificationUuid = notification.uuid;
+                uuid = this.uuid;
 
             // we need to stop circular property dependencies.
             // e.g.: object.foo depends on object.bar and object.bar depends on object.foo.
-            if (notificationUuid in isHandlingNotification) {
+            if (notification[uuid]) {
                 return;
             }
 
@@ -577,9 +573,9 @@ var ChangeNotificationDescriptor = Montage.create(Montage, {
                         if (dependentDescriptorsIndex) {
                             notification._dependenciesIndex = dependentDescriptorsIndex[key];
                         }
-                        isHandlingNotification[notificationUuid] = true;
+                        notification[uuid] = true;
                         listener.listenerFunction.call(listener.listenerTarget, notification);
-                        delete isHandlingNotification[notificationUuid];
+                        notification[uuid] = false;
                     }
                 }
                 notification._dependenciesIndex = dependenciesIndex;


### PR DESCRIPTION
[gh-665]
Mike should look into this.

Still not the 61/62fps we were able to get at db70ca63bd7106a2ec34eb0d1ea53ee10e36d74d but this improves from the 52fps to 60fps, it's hard to go faster with these cycle checks that always need to happen.
Maybe in the future we can change the way we have property dependencies set up, which are the causes of the infinite propagation.

The fix to stop infinite loops while propagating notifications introduced a performance issue by calculating a uuid for every single notification.
As a way to work around this problem we are now doing storing the uuid of the descriptor (as a new property) in the notification instead.
The only problem is that the notification will have garbage properties inside it, we don't delete them because that's slightly slower than just changing the new property to false.
