### PR TITLE
[gh-631] Fix a bug in SerializationCompiler

### DIFF
--- a/montage.js
+++ b/montage.js
@@ -149,7 +149,7 @@ if (typeof window !== "undefined") {
                     // avoid attempting to initialize a non-object
                     if (!(object instanceof Object)) {
                     // avoid attempting to reinitialize an aliased property
-                    } else if (object.hasOwnProperty("_montage_metadata")) {
+                    } else if (object.hasOwnProperty("_montage_metadata") && !object._montage_metadata.isInstance) {
                         object._montage_metadata.aliases.push(name);
                         object._montage_metadata.objectName = name;
                     } else if (!Object.isSealed(object)) {

--- a/test/core/core-require-spec.js
+++ b/test/core/core-require-spec.js
@@ -45,5 +45,14 @@ function() {
             expect(info.isInstance).toBeTruthy();
             expect(info.moduleId).toBe("core/testobjects");
         });
+
+        it("should describe a class object that accessed getInfoForObject before being exported",
+        function() {
+            var info = Montage.getInfoForObject(objects.FunkyProto);
+
+            expect(info.objectName).toBe("FunkyProto");
+            expect(info.isInstance).toBeFalsy();
+            expect(info.moduleId).toBe("core/testobjects");
+        });
     });
 });

--- a/test/core/testobjects.js
+++ b/test/core/testobjects.js
@@ -15,6 +15,11 @@ var Proto = exports.Proto = Montage.create(Montage, {
     prototypeUuid: {value: "b"}
 }, module);
 
+var FunkyProto = exports.FunkyProto = Montage.create(Montage, {
+    firstUuid: {value: null},
+});
+Montage.getInfoForObject(FunkyProto);
+
 var SubProto = exports.SubProto = Montage.create(Proto, {
     subProto: {value: null},
     prototypeUuid: {value: "c"}


### PR DESCRIPTION
It was not installing _montage_metadata correctly if getInfoForObject had already been called on the exported object.
