### PR TITLE
Set the Loader element before it's being attached to the component tree

### DIFF
--- a/ui/loader.reel/loader.js
+++ b/ui/loader.reel/loader.js
@@ -229,6 +229,7 @@ exports.Loader = Montage.create(Component, /** @lends module:montage/ui/loader.L
 
             if (!this.element) {
                 this.element = document.documentElement;
+                this.attachToParentComponent();
             }
             this.readyToShowLoader = true;
 


### PR DESCRIPTION
The element was being set too late for the Loader to be added to the component tree.
