### PR TITLE
Allow script data-package to specify package.json

### DIFF
--- a/montage.js
+++ b/montage.js
@@ -41,11 +41,8 @@ if (typeof window !== "undefined") {
     }
 })(function (require, exports, module) {
 
-    // The global context object, works for the browser and for node.
-    // XXX Will not work in strict mode
-    var global = (function() {
-        return this;
-    })();
+    // The global context object
+    var global = new Function("return this")();
 
     /**
      * Initializes Montage and creates the application singleton if
@@ -106,12 +103,22 @@ if (typeof window !== "undefined") {
                     });
                 };
 
-                if ('autoPackage' in params) {
+                if ("autoPackage" in params) {
                     montageRequire.injectPackageDescription(location, {
                         dependencies: {
                             montage: "*"
                         }
                     });
+                }
+
+                // handle explicit package.json location
+                if (location.slice(location.length - 5) === ".json") {
+                    var packageDescriptionLocation = location;
+                    location = URL.resolve(location, ".");
+                    montageRequire.injectPackageDescriptionLocation(
+                        location,
+                        packageDescriptionLocation
+                    );
                 }
 
                 return montageRequire.loadPackage(location)
@@ -269,7 +276,7 @@ if (typeof window !== "undefined") {
 
         getConfig: function() {
             return {
-                location: '' + window.location
+                location: "" + window.location
             };
         },
 
@@ -379,7 +386,7 @@ if (typeof window !== "undefined") {
                 }
             };
 
-            global.bootstrap('core/mini-url', urlModuleFactory);
+            global.bootstrap("core/mini-url", urlModuleFactory);
 
             // miniature module system
             var bootModules = {};

--- a/require/require.js
+++ b/require/require.js
@@ -183,8 +183,8 @@
             // Modules should never have a return value.
             if (returnValue !== void 0) {
                 console.warn(
-                    'require: module ' + JSON.stringify(topId) +
-                    ' returned a value.'
+                    "require: module " + JSON.stringify(topId) +
+                    " returned a value."
                 );
             }
 
@@ -273,6 +273,10 @@
                 Require.injectPackageDescription(location, description, config);
             };
 
+            require.injectPackageDescriptionLocation = function (location, descriptionLocation) {
+                Require.injectPackageDescriptionLocation(location, descriptionLocation, config);
+            };
+
             require.identify = identify;
             require.inject = inject;
             require.progress = Require.progress;
@@ -297,17 +301,35 @@
     };
 
     Require.injectPackageDescription = function (location, description, config) {
-        var descriptions = config.descriptions = config.descriptions || {};
+        var descriptions =
+            config.descriptions =
+                config.descriptions || {};
         descriptions[location] = Promise.call(function () {
             return description;
         });
     };
 
+    Require.injectPackageDescriptionLocation = function (location, descriptionLocation, config) {
+        var descriptionLocations =
+            config.descriptionLocations =
+                config.descriptionLocations || {};
+        descriptionLocations[location] = descriptionLocation;
+    };
+
     Require.loadPackageDescription = function (location, config) {
-        var descriptions = config.descriptions = config.descriptions || {};
+        var descriptions =
+            config.descriptions =
+                config.descriptions || {};
         if (descriptions[location] === void 0) {
-            var jsonPath = URL.resolve(location, 'package.json');
-            descriptions[location] = Require.read(jsonPath)
+            var descriptionLocations =
+                config.descriptionLocations =
+                    config.descriptionLocations || {};
+            if (descriptionLocations[location]) {
+                descriptionLocation = descriptionLocations[location];
+            } else {
+                descriptionLocation = URL.resolve(location, "package.json");
+            }
+            descriptions[location] = Require.read(descriptionLocation)
             .then(function (json) {
                 try {
                     return JSON.parse(json);


### PR DESCRIPTION
This permits multiple alternative packages to exist in the same
directory.

```
<script src="montage.js" data-package="alternate.json">
```

At run-time, there is only one package per _directory_, so the first
package to be loaded with a particular package description wins for the
parent directory of the description.  Also, the Montage Optimizer only
recognizes the package declared with `package.json`.

Fixes gh-598
