### PR TITLE
Toggle Button hover state

### DIFF
--- a/examples/sink/components/toggle-button-example.reel/toggle-button-example.html
+++ b/examples/sink/components/toggle-button-example.reel/toggle-button-example.html
@@ -103,10 +103,22 @@
     }</script>
     <style type="text/css">
         .values-btn {
+            background-color: hsl(0,100%,82%);
+        }
+        .values-btn:hover {
+            background-color: hsl(0,100%,84%);
+        }
+        .values-btn.montage-button:active {
             background-color: hsl(0,100%,80%);
         }
         .values-btn.success {
             background-color: hsl(100,100%,80%);
+        }
+        .values-btn.success:hover {
+            background-color: hsl(100,100%,88%);
+        }
+        .values-btn.success:active {
+            background-color: hsl(100,90%,80%);
         }
     </style>
     </head>
@@ -311,10 +323,22 @@ exports.StyleElement = Montage.create(Component, {
                                                 <div class="accordion-inner montage-hidden">
                                                     <pre class="prettyprint" >
 .values-btn {
+    background-color: hsl(0,100%,82%);
+}
+.values-btn:hover {
+    background-color: hsl(0,100%,84%);
+}
+.values-btn.montage-button:active {
     background-color: hsl(0,100%,80%);
 }
 .values-btn.success {
     background-color: hsl(100,100%,80%);
+}
+.values-btn.success:hover {
+    background-color: hsl(100,100%,88%);
+}
+.values-btn.success:active {
+    background-color: hsl(100,90%,80%);
 }
                                                     </pre>
                                                 </div>

--- a/ui/toggle-button.reel/toggle-button.css
+++ b/ui/toggle-button.reel/toggle-button.css
@@ -5,9 +5,9 @@
  </copyright> */
 
 .montage-button.active {
-    background-color: #d0d0d0;
+    background-color: #cccccc;
 }
 
 .montage-button.active:hover {
-    background-color: #dfdfdf;
+    background-color: #d8d8d8;
 }


### PR DESCRIPTION
Made the contrast a bit higher when hovering the active state. #766

Something we might wanna change.. currently when you click on a toggle button it gets the class `active`, but in the 2nd example in the sink (Different pressed and unpressed values) the class is called `success` which is a bit confusing. Also "active" is used for the normal buttons while you keep pressing.

Suggestion: Use the class `checked`. It would be similar to a checkbox, which kinda has the same functionality.
