### PR TITLE
Fixed JSDoc module ID references.

### DIFF
--- a/core/promise.js
+++ b/core/promise.js
@@ -3,6 +3,14 @@
  No rights, expressed or implied, whatsoever to this software are provided by Motorola Mobility, Inc. hereunder.<br/>
  (c) Copyright 2012 Motorola Mobility, Inc.  All Rights Reserved.
  </copyright> */
+/**
+    @module module:montage/core/promise
+*/
+
+/**
+    @class module:montage/core/promise.Promise
+*/
+
 /*global bootstrap,Q */
 // Scope:
 //  * ES5

--- a/data/nosql-access/nosql-object-id.js
+++ b/data/nosql-access/nosql-object-id.js
@@ -14,7 +14,7 @@ var ObjectId = require("data/object-id").ObjectId;
 var logger = require("core/logger").logger("nosql-object-id");
 /**
     @class module:montage/data/nosql-access/nosql-object-id.NoSqlObjectId
-    @extends module:montage/data/-object-id.ObjectId
+    @extends module:montage/data/object-id.ObjectId
 */
 var NoSqlObjectId = exports.NoSqlObjectId = Montage.create(ObjectId,/** @lends module:montage/data/nosql-access/nosql-object-id.NoSqlObjectId# */ {
 

--- a/data/operation.js
+++ b/data/operation.js
@@ -86,7 +86,7 @@ var OperationManager = exports.OperationManager = Montage.create(Montage, /** @l
 var _noopOperation = null;
 /**
  @class module:montage/data/operation.NoopOperation
- @extends module:montage/core/core.Operation
+ @extends module:montage/data/operation.Operation
  */
 var NoopOperation = exports.NoopOperation = Montage.create(Operation, /** @lends module:montage/data/operation.NoopOperation# */ {
 
@@ -95,7 +95,7 @@ var NoopOperation = exports.NoopOperation = Montage.create(Operation, /** @lends
 
 /**
  @class module:montage/data/operation.InsertOperation
- @extends module:montage/core/core.Operation
+ @extends module:montage/data/operation.Operation
  */
 var InsertOperation = exports.InsertOperation = Montage.create(Operation, /** @lends module:montage/data/operation.InsertOperation# */ {
 
@@ -104,7 +104,7 @@ var InsertOperation = exports.InsertOperation = Montage.create(Operation, /** @l
 
 /**
  @class module:montage/data/operation.DeleteOperation
- @extends module:montage/core/core.Operation
+ @extends module:montage/data/operation.Operation
  */
 var DeleteOperation = exports.DeleteOperation = Montage.create(Operation, /** @lends module:montage/data/operation.DeleteOperation# */ {
 
@@ -113,7 +113,7 @@ var DeleteOperation = exports.DeleteOperation = Montage.create(Operation, /** @l
 
 /**
  @class module:montage/data/operation.ChangeOperation
- @extends module:montage/core/core.Operation
+ @extends module:montage/data/operation.Operation
  */
 var ChangeOperation = exports.ChangeOperation = Montage.create(Operation, /** @lends module:montage/data/operation.ChangeOperation# */ {
 

--- a/data/pledge.js
+++ b/data/pledge.js
@@ -121,7 +121,7 @@ var Pledge = exports.Pledge = Montage.create(Promise, /** @lends module:montage/
 
 /**
  @class module:montage/data/pledge.PledgedSortedSet
- @extends module:montage/data/pledge.Pledged
+ @extends module:montage/data/pledge.Pledge
  */
 var PledgedSortedSet = exports.PledgedSortedSet = Montage.create(Pledge, /** @lends module:montage/data/pledge.PledgedSortedSet# */ {
 

--- a/data/rest-access/rest-object-id.js
+++ b/data/rest-access/rest-object-id.js
@@ -13,7 +13,7 @@ var ObjectId = require("data/object-id").ObjectId;
 var logger = require("core/logger").logger("rest-object-id");
 /**
     @class module:montage/data/rest-access/rest-object-id.RestObjectId
-    @extends module:montage/data/-object-id.ObjectId
+    @extends module:montage/data/object-id.ObjectId
 */
 var RestObjectId = exports.RestObjectId = Montage.create(ObjectId,/** @lends module:montage/data/rest-access/rest-object-id.RestObjectId# */ {
 


### PR DESCRIPTION
- Changed "Pledged" to "Pledge" in JSDoc comments.
- Added Promise comment
- Added Operation comment
- Fixed module ID that had errant hyphen (module:montage/data/-object-id)
