### PR TITLE
Make originalContent use domContent if set instead of childNodes

### DIFF
--- a/test/ui/component-spec.js
+++ b/test/ui/component-spec.js
@@ -37,6 +37,13 @@ var testPage = TestPageLoader.queueTest("draw", function() {
                     expect(originalContent[0].outerHTML).toBe("<h3>Original Content</h3>");
                     expect(originalContent[1].outerHTML).toBe("<p>here</p>");
                 });
+
+                it("should set the original content to the domContent of the component before inserting the template", function() {
+                    var componentList = testPage.test.componentList,
+                        texts = componentList.element.querySelectorAll("*[data-montage-id='text2']");
+
+                    expect(texts.length).toBe(3);
+                });
             });
 
             describe("domContent", function() {

--- a/test/ui/draw/component-list.reel/component-list.html
+++ b/test/ui/draw/component-list.reel/component-list.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<!-- <copyright>
+ This file contains proprietary software owned by Motorola Mobility, Inc.<br/>
+ No rights, expressed or implied, whatsoever to this software are provided by Motorola Mobility, Inc. hereunder.<br/>
+ (c) Copyright 2012 Motorola Mobility, Inc.  All Rights Reserved.
+ </copyright> -->
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <title>Component Layout</title>
+    <script type="text/montage-serialization">{
+        "owner": {
+            "properties": {
+                "element": {"#": "component-list"}
+            }
+        },
+
+        "list": {
+            "prototype": "montage/ui/list.reel",
+            "properties": {
+                "element": {"#": "list"},
+                "objects": [1, 2, 3]
+            },
+            "bindings": {
+                "domContent": {"<->": "@owner.originalContent"}
+            }
+        }
+    }</script>
+</head>
+<body>
+<div data-montage-id="component-list">
+    <h1>Component List</h1>
+    <div data-montage-id="list"></div>
+</div>
+</body>
+</html>

--- a/test/ui/draw/component-list.reel/component-list.js
+++ b/test/ui/draw/component-list.reel/component-list.js
@@ -1,0 +1,5 @@
+var Montage = require("montage").Montage,
+    Component = require("montage/ui/component").Component;
+
+exports.ComponentList = Montage.create(Component, {
+});

--- a/test/ui/draw/draw.html
+++ b/test/ui/draw/draw.html
@@ -32,7 +32,8 @@
             "text1": {"@": "text1"},
             "componentDrawsParent": {"@": "componentDrawsParent"},
             "componentParent": {"@": "componentParent"},
-            "componentWithDelegate": {"@": "componentWithDelegate"}
+            "componentWithDelegate": {"@": "componentWithDelegate"},
+            "componentList": {"@": "componentList"}
         }
     },
     "repetition": {
@@ -181,6 +182,19 @@
             "hasTemplate": false
         }
     },
+    "componentList": {
+        "prototype": "ui/draw/component-list.reel",
+        "properties": {
+            "element": {"#": "componentList"}
+        }
+    },
+    "text2": {
+        "prototype": "montage/ui/dynamic-text.reel",
+        "properties": {
+            "element": {"#": "text2"},
+            "value": "Text 2"
+        }
+    },
     "owner": {
         "prototype": "montage/ui/application",
         "properties": {
@@ -230,6 +244,9 @@
     <div data-montage-id="componentDrawsParent">Fizz</div>
 </div>
 
+<div data-montage-id="componentList">
+    <span data-montage-id="text2"></span>
+</div>
 
 </body>
 </html>


### PR DESCRIPTION
Related to bug [gh-836]

This solves the issue of binding domContent to originalContent in a transitive way.
If domContent is set before a component's template is drawn it will be discarded since the template will have priority as the new content.
