### PR TITLE
Change the behaviour of text-slider to not enter edit on focus

### DIFF
--- a/test/ui/text-slider-spec.js
+++ b/test/ui/text-slider-spec.js
@@ -105,7 +105,7 @@ var testPage = TestPageLoader.queueTest("text-slider-test", function() {
                     });
                 });
                 it("increases when the up arrow is pressed", function() {
-                    test.hex.handleKeydown({target: test.hex._inputElement, keyCode: 38});
+                    test.hex.handleInputKeydown({target: test.hex._inputElement, keyCode: 38});
                     expect(test.hex.value).toBe(161);
                     testPage.waitForDraw();
                     runs(function() {
@@ -113,7 +113,7 @@ var testPage = TestPageLoader.queueTest("text-slider-test", function() {
                     });
                 });
                 it("decreases when the down arrow is pressed", function() {
-                    test.hex.handleKeydown({target: test.hex._inputElement, keyCode: 40});
+                    test.hex.handleInputKeydown({target: test.hex._inputElement, keyCode: 40});
                     expect(test.hex.value).toBe(160);
                     testPage.waitForDraw();
                     runs(function() {
@@ -122,14 +122,14 @@ var testPage = TestPageLoader.queueTest("text-slider-test", function() {
                 });
                 it("sets the value when enter is set", function() {
                     test.hex._inputElement.value = "2A";
-                    test.hex.handleKeydown({target: test.hex._inputElement, keyCode: 13});
+                    test.hex.handleInputKeydown({target: test.hex._inputElement, keyCode: 13});
                     expect(test.hex.value).toBe(42);
                 });
                 it("ignored any entered value when Esc is pressed", function() {
                     test.hex.value = 160;
                     test.hex.handlePress();
                     test.hex._inputElement.value = "00";
-                    test.hex.handleKeydown({target: test.hex._inputElement, keyCode: 27});
+                    test.hex.handleInputKeydown({target: test.hex._inputElement, keyCode: 27});
                     expect(test.hex.value).toBe(160);
                 });
             });

--- a/ui/text-slider.reel/text-slider.js
+++ b/ui/text-slider.reel/text-slider.js
@@ -298,8 +298,7 @@ var TextSlider = exports.TextSlider = Montage.create(Component, /** @lends modul
 
     didCreate: {
         value: function() {
-            this.handlePress = this.handleFocus;
-            this.handleClick = this.handleFocus;
+            this.handlePress = this.handleClick;
         }
     },
 
@@ -313,27 +312,35 @@ var TextSlider = exports.TextSlider = Montage.create(Component, /** @lends modul
 
     prepareForDraw: {
         value: function() {
+            this._element.identifier = "text";
+            this._inputElement.identifier = "input";
+
             this._element.addEventListener("focus", this, false);
             this._inputElement.addEventListener("blur", this, false);
+            this._element.addEventListener("keydown", this, false);
             this._inputElement.addEventListener("keydown", this, false);
         }
     },
 
     draw: {
         value: function() {
+            var wasEditing = this._element.classList.contains("montage-text-slider-editing");
+
             if (this._isEditing) {
-                this._element.classList.add("montage-text-slider-editing");
+                // if we're entering the editing state...
+                if (!wasEditing) {
+                    // ...add the class and focus the input
+                    this._element.classList.add("montage-text-slider-editing");
+                    this._inputElement.focus();
+                }
+
                 this._inputElement.value = this.convertedValue + ((this._unit) ? " " + this._unit : "");
-                // Replace this with just focus when merged
-                this._inputElement.focus();
-                // When _element gets focus we focus the input. Because of this
-                // shift+tab stops working, so prevent _element getting
-                // focus while editing
-                this._element.tabIndex = -1;
-            } else {
+            } else if (wasEditing) {
+                // remove class list, blur the input element and focus the
+                // TextSlider for further editing
                 this._element.classList.remove("montage-text-slider-editing");
                 this._inputElement.blur();
-                this._element.tabIndex = 0;
+                this._element.focus();
             }
 
             if (this._direction === "horizontal") {
@@ -356,11 +363,10 @@ var TextSlider = exports.TextSlider = Montage.create(Component, /** @lends modul
         }
     },
 
-    // handlePress and handleClick are set to equal handleFocus in didCreate
+    // handlePress and handleClick are set to equal in didCreate
     // handlePress: edit on touch
     // handleClick: edit when parent <label> element is clicked/touched
-    // handleFocus: edit when tabbed to
-    handleFocus: {
+    handleClick: {
         value: function(event) {
             if (!this._isEditing) {
                 this.isEditing = true;
@@ -377,36 +383,42 @@ var TextSlider = exports.TextSlider = Montage.create(Component, /** @lends modul
         }
     },
 
-    handleKeydown: {
+    handleInputKeydown: {
         value: function(event) {
-            if (event.target === this._inputElement) {
-                var value;
-                if (event.keyCode === 38) {
-                    // up
-                    this.convertedValue = this._inputElement.value;
-                    value = Math.round(((event.shiftKey) ? this.largeStepSize : (event.ctrlKey) ? this.smallStepSize : this.stepSize) / this.smallStepSize) * this.smallStepSize;
-                    this.value += value;
-                    this.needsDraw = true;
-                } else if (event.keyCode === 40) {
-                    // down
-                    this.convertedValue = this._inputElement.value;
-                    value = Math.round(((event.shiftKey) ? this.largeStepSize : (event.ctrlKey) ? this.smallStepSize : this.stepSize) / this.smallStepSize) * this.smallStepSize;
-                    this.value -= value;
-                    this.needsDraw = true;
-                } else if (event.keyCode === 13) {
-                    // enter
-                    this.convertedValue = this._inputElement.value;
-                    this.isEditing = false;
-                } else if (event.keyCode === 27) {
-                    // esc
-                    this.isEditing = false;
-                }
-            } else {
-                if (event.shiftKey || event.keyCode === 16) {
-                    this._translateComposer.pointerSpeedMultiplier = this.largeStepSize / this.stepSize;
-                } else if (event.ctrlKey || event.keyCode === 17) {
-                    this._translateComposer.pointerSpeedMultiplier = this.smallStepSize / this.stepSize;
-                }
+            var value;
+            if (event.keyCode === 38) {
+                // up
+                this.convertedValue = this._inputElement.value;
+                value = Math.round(((event.shiftKey) ? this.largeStepSize : (event.ctrlKey) ? this.smallStepSize : this.stepSize) / this.smallStepSize) * this.smallStepSize;
+                this.value += value;
+                this.needsDraw = true;
+            } else if (event.keyCode === 40) {
+                // down
+                this.convertedValue = this._inputElement.value;
+                value = Math.round(((event.shiftKey) ? this.largeStepSize : (event.ctrlKey) ? this.smallStepSize : this.stepSize) / this.smallStepSize) * this.smallStepSize;
+                this.value -= value;
+                this.needsDraw = true;
+            } else if (event.keyCode === 13) {
+                // enter
+                this.convertedValue = this._inputElement.value;
+                this.isEditing = false;
+            } else if (event.keyCode === 27) {
+                // esc
+                this.isEditing = false;
+            }
+        }
+    },
+    handleTextKeydown: {
+        value: function(event) {
+            if (event.keyCode === 13) {
+                // enter
+                this.isEditing = true;
+            }
+
+            if (event.shiftKey || event.keyCode === 16) {
+                this._translateComposer.pointerSpeedMultiplier = this.largeStepSize / this.stepSize;
+            } else if (event.ctrlKey || event.keyCode === 17) {
+                this._translateComposer.pointerSpeedMultiplier = this.smallStepSize / this.stepSize;
             }
         }
     },


### PR DESCRIPTION
To enter edit mode the user must either click on the text-slider
or focus it and press enter.

This allows faster keyboard editing because changes can be made
in input mode, committed by pressing enter, and then edit mode
can be entered by pressing enter again.

gh-802
