### PR TITLE
Override Worker.add/removeEventListener APIs

### DIFF
--- a/core/event/event-manager.js
+++ b/core/event/event-manager.js
@@ -419,6 +419,9 @@ var EventManager = exports.EventManager = Montage.create(Montage,/** @lends modu
             });
             Object.getPrototypeOf(aWindow.document).nativeAddEventListener = aWindow.document.addEventListener;
             XMLHttpRequest.prototype.nativeAddEventListener = XMLHttpRequest.prototype.addEventListener;
+            if (Worker) {
+                Worker.prototype.nativeAddEventListener = Worker.prototype.addEventListener;
+            }
 
             Element.prototype.nativeRemoveEventListener = Element.prototype.removeEventListener;
             Object.defineProperty(aWindow, "nativeRemoveEventListener", {
@@ -427,6 +430,9 @@ var EventManager = exports.EventManager = Montage.create(Montage,/** @lends modu
             });
             Object.getPrototypeOf(aWindow.document).nativeRemoveEventListener = aWindow.document.removeEventListener;
             XMLHttpRequest.prototype.nativeRemoveEventListener = XMLHttpRequest.prototype.removeEventListener;
+            if (Worker) {
+                Worker.prototype.nativeRemoveEventListener = Worker.prototype.removeEventListener;
+            }
 
             Object.defineProperty(aWindow, "addEventListener", {
                 enumerable: false,
@@ -438,6 +444,10 @@ var EventManager = exports.EventManager = Montage.create(Montage,/** @lends modu
                                 })
             });
 
+            if (Worker) {
+                Worker.prototype.addEventListener = aWindow.addEventListener;
+            }
+
             Object.defineProperty(aWindow, "removeEventListener", {
                 enumerable: false,
                 value: (XMLHttpRequest.prototype.removeEventListener =
@@ -447,6 +457,11 @@ var EventManager = exports.EventManager = Montage.create(Montage,/** @lends modu
                                     return defaultEventManager.unregisterEventListener(this, eventType, listener, !!useCapture);
                                 })
             });
+
+            if (Worker) {
+                Worker.prototype.removeEventListener = aWindow.removeEventListener;
+            }
+
             // In some browsers each element has their own addEventLister/removeEventListener
             // Methodology to find all elements found in Chainvas
             if(HTMLDivElement.prototype.addEventListener !== Element.prototype.nativeAddEventListener) {

--- a/test/events/eventmanager-spec.js
+++ b/test/events/eventmanager-spec.js
@@ -89,6 +89,14 @@ var testPage = TestPageLoader.queueTest("eventmanagertest", function() {
                 expect(request.nativeAddEventListener).toNotBe(request.addEventListener);
             });
 
+            if (Worker) {
+                it("should have overridden the addEventListener for Worker", function() {
+                    var worker = testDocument.defaultView.Worker.prototype;
+                    expect(worker.nativeAddEventListener).toBeTruthy();
+                    expect(worker.nativeAddEventListener).toNotBe(worker.addEventListener);
+                });
+            }
+
             it("should have overridden the removeEventListener for window", function() {
                 var testWindow = testDocument.defaultView;
                 expect(testWindow.nativeRemoveEventListener).toBeTruthy();
@@ -111,6 +119,14 @@ var testPage = TestPageLoader.queueTest("eventmanagertest", function() {
                 expect(request.nativeRemoveEventListener).toBeTruthy();
                 expect(request.nativeRemoveEventListener).toNotBe(request.removeEventListener);
             });
+
+            if (Worker) {
+                it("should have overridden the addEventListener for Worker", function() {
+                    var worker = testDocument.defaultView.Worker.prototype;
+                    expect(worker.nativeRemoveEventListener).toBeTruthy();
+                    expect(worker.nativeRemoveEventListener).toNotBe(worker.removeEventListener);
+                });
+            }
         });
 
         describe("when adding event listeners", function() {


### PR DESCRIPTION
Prior to this change we were relying on the native APIs which didn't
route through our eventManager as you'd hope, but as you'd expect.
