### PR TITLE
Fix Component.templateObjects to return correct component instead of roo...

### DIFF
--- a/ui/template.js
+++ b/ui/template.js
@@ -478,9 +478,9 @@ var Template = exports.Template = Montage.create(Montage, /** @lends module:mont
                                 // that repeats its child components, we can
                                 // safely recreate this property with a static value
                                 Object.defineProperty(this, label, {
-                                    value: component
+                                    value: components[0]
                                 });
-                                return component;
+                                return components[0];
                             } else if (component.clonesChildComponents) {
                                 break;
                             }


### PR DESCRIPTION
...t component

If <label> was a component but not a child component of the owner component and was not a direct or indirect child of a component that cloned its child components (clonesChildComponents = true) then templateObjects.<label> was returning the owner component instead of the correct one.
