### PR TITLE
Minit updates

### DIFF
--- a/tools/minit/templates/component/__name__.reel/__name__.js
+++ b/tools/minit/templates/component/__name__.reel/__name__.js
@@ -6,7 +6,7 @@
     @requires montage/ui/component
 */
 var Montage = require("montage").Montage,
-    Component = require("ui/component").Component;
+    Component = require("montage/ui/component").Component;
 
 /**
     Description TODO


### PR DESCRIPTION
make component template work outside of Montage
replace path.existsSync with fs.existsSync (path.existsSync is deprecated)
