### PR TITLE
Fix for SP-404: RTE prevents other input fields in the same page from getting the focus

### DIFF
--- a/ui/rich-text-editor/rich-text-editor.reel/rich-text-editor-base.js
+++ b/ui/rich-text-editor/rich-text-editor.reel/rich-text-editor-base.js
@@ -934,8 +934,10 @@ exports.RichTextEditorBase = Montage.create(Component,/** @lends module:"montage
                 });
             }
 
-            // Force a selectionchange when we lose the focus
-            this.handleSelectionchange();
+            // As we lost focus, we need to prevent the selection change timer to fired, else it will cause the RTE to regain focus
+            if (this._selectionChangeTimer) {
+                clearTimeout(this._selectionChangeTimer);
+            }
 
             el.removeEventListener("blur", this, true);
             el.removeEventListener("input", this);


### PR DESCRIPTION
This is for https://github.com/Motorola-Mobility/scratchpad/issues/404

The kitchen sink (with RTE) has the same issue.
