### PR TITLE
Overall refractor and bug fix of popcorn

### DIFF
--- a/samples/popcorn/package.json
+++ b/samples/popcorn/package.json
@@ -1,10 +1,9 @@
 {
     "name": "mediadiscovery",
     "version": "0.0.2",
-    "mapping": {
-        "montage" : "../../"
-    },
     "dependencies": {
         "montage" : "0.10.x - 0.11.x"
-    }
+    },
+    "bundle": ["ui/main.reel"],
+    "shard": 4
 }

--- a/samples/popcorn/ui/facadeflow.reel/facadeflow.js
+++ b/samples/popcorn/ui/facadeflow.reel/facadeflow.js
@@ -44,6 +44,7 @@ exports.Facadeflow = Montage.create( Component, {
                 oneway: true
             });
             this.buttonController = controller;
+            this.application.addEventListener( "dataReceived", this, false);
         }
     },
 
@@ -117,6 +118,21 @@ exports.Facadeflow = Montage.create( Component, {
         }
     },
 
+    _categoryId: {
+        value: null
+    },
+    categoryId: {
+        get: function() {
+            return this._categoryId;
+        },
+        set: function(value) {
+            if (value) {
+                this._categoryId = value;
+                this._changeCategory(value);
+            }
+        }
+    },
+
     pointInCircleAt: { // returns a point in a unit radius circle with center at origin for a given angle
         value: function (angle) {
             return [Math.cos(angle), Math.sin(angle)];
@@ -138,34 +154,33 @@ exports.Facadeflow = Montage.create( Component, {
         }
     },
 
-    templateDidLoad: {
-        value: function () {
-            this.application.addEventListener( "dataReceived", this, false);
-        }
-    },
-
-    changeCategory: {
-        value: function(category) {
+    _changeCategory: {
+        value: function(categoryId) {
             var self = this;
 
             this.detailsFadeOut = true;
             this._fadeOut = true;
             this.needsDraw = true;
-
             // wait .5s until the fade out effect is completed
-            setTimeout( function(){
-                self.templateObjects.flow.scroll = 0;
-                self.category = self[category];
+            setTimeout( function() {
+                if (self.templateObjects && self.templateObjects.flow) {
+                    self.templateObjects.flow.scroll = 0;
+                }
+
+                self.category = self[categoryId];
                 self.selectedMovie = self.category[0];
 
                 self._fadeIn = true;
+                self._fadeOut = false;
                 self.detailsFadeIn = true;
+                self.detailsFadeOut = false;
                 self.needsDraw = true;
+
             }, 500 );
         }
     },
 
-    handleLaunchApp: {
+    handleDataReceived: {
         value: function (event) {
             // do it manually to avoid fade out effect
             this.category = this.latestBoxofficeMovies;

--- a/samples/popcorn/ui/main.reel/main.html
+++ b/samples/popcorn/ui/main.reel/main.html
@@ -53,7 +53,8 @@ POSSIBILITY OF SUCH DAMAGE.
                     "latestBoxofficeMovies": {"<-": "@owner.appData.latestBoxofficeMovies" },
                     "upcomingMovies": {"<-": "@owner.appData.upcomingMovies" },
                     "topDvdRentals": {"<-": "@owner.appData.topDvdRentals" },
-                    "inTheaters": {"<-": "@owner.appData.inTheaters" }
+                    "inTheaters": {"<-": "@owner.appData.inTheaters" },
+                    "categoryId": {"<-": "@owner.categoryId"}
                 }
             },
 

--- a/samples/popcorn/ui/main.reel/main.js
+++ b/samples/popcorn/ui/main.reel/main.js
@@ -42,6 +42,10 @@ exports.Main = Montage.create(Component, {
         value: Remotemediator.create()
     },
 
+    categoryId: {
+        value: null
+    },
+
     _categoryButtonGroup: {
         value: null
     },
@@ -106,7 +110,7 @@ exports.Main = Montage.create(Component, {
         value: function(category) {
             var buttons = this._categoryButtonGroup;
 
-            this.templateObjects.facadeflow.changeCategory(category);
+            this.categoryId = category;
             for (var i = 0; i < buttons.length; i++) {
                 buttons[i].pressed = (buttons[i].category === category);
             }


### PR DESCRIPTION
- Change changeCategory call to a categoryId binding
- Change a missed LaunchApp do DataReceived
- Change dataReceived from templateDidLoad to didCreate
- Fix a race condition in facadeflow._changeCategory
  Make sure the template has been loaded already and that fadeOut is set to false when setting fadeIn to true.
- Add mop configuration to package.json
