### PR TITLE
Various bug fixes exposed by Mop and CSP

### DIFF
--- a/core/deserializer.js
+++ b/core/deserializer.js
@@ -740,7 +740,8 @@ var Deserializer = exports.Deserializer = Montage.create(Montage, /** @lends mod
                 moduleId = desc.module;
                 objectName = name = desc.name;
             } else  if ("prototype" in desc || "object" in desc) {
-                bracketIndex = (desc.prototype || desc.object).indexOf("[");
+                name = desc.prototype || desc.object;
+                bracketIndex = name.indexOf("[");
                 // this code is actually only used when canEval == false,
                 // module+name are added when the modules are parsed but it's
                 // slow to redo the _serializationString in order to keep the

--- a/montage.js
+++ b/montage.js
@@ -59,7 +59,12 @@ if (typeof window !== "undefined") {
 (function (definition) {
     if (typeof require !== "undefined") {
         // CommonJS / NodeJS
-        definition(require, exports, module);
+        definition.call(
+            typeof global !== "undefined" ? global : this,
+            require,
+            exports,
+            module
+        );
     } else {
         // <script>
         definition({}, {}, {});
@@ -67,7 +72,7 @@ if (typeof window !== "undefined") {
 })(function (require, exports, module) {
 
     // The global context object
-    var global = new Function("return this")();
+    var global = this;
 
     /**
      * Initializes Montage and creates the application singleton if
@@ -562,4 +567,4 @@ if (typeof window !== "undefined") {
         exports.getPlatform();
     }
 
-});
+})

--- a/node.js
+++ b/node.js
@@ -126,7 +126,7 @@ MontageBoot.TemplateLoader = function (config, load) {
     return function(id, module) {
         var html = id.match(/(.*\/)?(?=[^\/]+\.html$)/);
         var serialization = id.match(/(?=[^\/]+\.json$)/); // XXX this is not necessarily a strong indicator of a serialization alone
-        var reelModule = id.match(/(.*\/)?([^\/]+)\.reel\/\2/);
+        var reelModule = id.match(/(.*\/)?([^\/]+)\.reel\/\2$/);
         if (html) {
             return load(id, module)
             .then(function () {

--- a/require/browser.js
+++ b/require/browser.js
@@ -115,10 +115,14 @@ var __FILE__String = "__FILE__",
 
 Require.Compiler = function (config) {
     return function(module) {
-        if (module.exports || module.factory || module.text === void 0)
+        if (
+            module.exports !== void 0 || // already exports
+            module.factory !== void 0 || // already compiled
+            module.type !== "javascript" // not javascript
+        )
             return module;
         if (config.define)
-            throw new Error("Can't use eval to compile " + JSON.stringify(module.id));
+            throw new Error("Can't use eval to compile " + JSON.stringify(module));
 
         // Here we use a couple tricks to make debugging better in various browsers:
         // TODO: determine if these are all necessary / the best options

--- a/require/require.js
+++ b/require/require.js
@@ -103,7 +103,7 @@ POSSIBILITY OF SUCH DAMAGE.
             if (!has(modules, id)) {
                 modules[id] = {
                     id: id,
-                    display: config.location + "#" + id, // EXTENSION
+                    display: (config.name || config.location) + "#" + id, // EXTENSION
                     require: require
                 };
             }
@@ -706,11 +706,15 @@ POSSIBILITY OF SUCH DAMAGE.
             return compile;
         }
         return function(module) {
-            try {
+            if (module.type === "javascript") {
+                try {
+                    compile(module);
+                } catch (error) {
+                    config.lint(module);
+                    throw error;
+                }
+            } else {
                 compile(module);
-            } catch (error) {
-                config.lint(module);
-                throw error;
             }
         };
     };


### PR DESCRIPTION
After optimizing an application and running it as a Chrome extension
with a no-eval Content Security Policy, these fixes were necessary.
-   Bug in bootstrapping, when eval is forbidden, while attempting to
  infer the global variable in the most general fashion.
-   Bug in bootstrapping, where script injected templates are not
  recognized as templates.
-   Bug (fixed upstream) where the module loader fails to recognize that
  a package is using script-injection form.
-   Bug in deserializer where names are not properly unpacked from the
  "package" or "object" reference.
-   Enhancement, module display names can be based on package name
  instead of location.
