### PR TITLE
Fix Bluemoon Slider mouse drag and drop

### DIFF
--- a/ui/bluemoon/slider.reel/slider.js
+++ b/ui/bluemoon/slider.reel/slider.js
@@ -397,7 +397,7 @@ exports.Slider = Montage.create(Component,/** @lends module:"montage/ui/bluemoon
     */
     handleMousemove: {
         value: function (event) {
-            this.value = this.value + ((event.clientX - this._cursorPosition) * (this.valueRange)) / this._width;
+            this.value = this._value + ((event.clientX - this._cursorPosition) * (this.valueRange)) / this._width;
 
             this._cursorPosition = event.clientX;
             event.preventDefault();


### PR DESCRIPTION
This commit fixes an undesired offset between the slider's handler and
the mouse pointer that happens while dragging the handler beyond the
slider's boundaries and then re-entering inside the slider's boundaries.
