### PR TITLE
Support dynamic package bootstrapping

### DIFF
--- a/test/bootstrap-iframe/iframe.html
+++ b/test/bootstrap-iframe/iframe.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+    <head>
+        <script src="../../montage.js" data-auto-package data-module="iframe.js"></script>
+    </head>
+    <body>
+    </body>
+</html>

--- a/test/bootstrap-iframe/iframe.js
+++ b/test/bootstrap-iframe/iframe.js
@@ -1,0 +1,19 @@
+
+var frame = document.createElement("iframe");
+frame.src = "iframed.html";
+document.body.appendChild(frame);
+
+window.addEventListener("message", function (event) {
+    if (event.data.type === "montageReady") {
+        frame.contentWindow.postMessage({
+            type: "montageInit",
+            location: "",
+            packageDescription: {
+                dependencies: {
+                    montage: "*"
+                }
+            }
+        }, "*");
+    }
+});
+

--- a/test/bootstrap-iframe/iframed.html
+++ b/test/bootstrap-iframe/iframed.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<html>
+    <head>
+        <script src="../../montage.js" data-remote-trigger data-module="iframed.js"></script>
+    </head>
+</html>

--- a/test/bootstrap-iframe/iframed.js
+++ b/test/bootstrap-iframe/iframed.js
@@ -1,0 +1,3 @@
+
+document.body.style.backgroundColor = '#ff0000';
+


### PR DESCRIPTION
The parent window of a Montage application that specifies `data-remote-trigger` in its `montage.js` `script` line can now inject a package location and dynamically generated `package.json` into the child application.

The child window sends a `montageReady` message to the parent.

The parent may then send a `montageInit` message to the child, with an optional payload. The payload may include a package `location` or `packageDescription`.

This includes a demo.
