### PR TITLE
Make Montage.{create,defineProperty,defineProperties} throw errors...

### DIFF
--- a/core/core.js
+++ b/core/core.js
@@ -95,7 +95,7 @@ Object.defineProperty(Montage, "create", {
     value: function(aPrototype, propertyDescriptor) {
         // Allow aPrototype to be undefined to create() this
         if (aPrototype !== undefined && typeof aPrototype !== "object") {
-            throw new TypeError("Object prototype may only be an Object or null, not " + aPrototype);
+            throw new TypeError("Object prototype may only be an Object or null, not '" + aPrototype + "'");
         }
         if (!propertyDescriptor) {
             var newObject = Object.create(typeof aPrototype === "undefined" ? this : aPrototype);
@@ -145,8 +145,8 @@ extendedPropertyAttributes.forEach(function(name) {
 Object.defineProperty(Montage, "defineProperty", {
 
     value: function(obj, prop, descriptor) {
-        if (typeof obj !== "object") {
-            throw new TypeError("Object must be an object, not " + obj);
+        if (typeof obj !== "object" || obj === null) {
+            throw new TypeError("Object must be an object, not '" + obj + "'");
         }
 
         var dependencies = descriptor.dependencies,
@@ -397,8 +397,8 @@ Object.defineProperty(Montage, "defineProperty", {
     @param {Object} properties An object that contains one or more property descriptor objects.
 */
 Object.defineProperty(Montage, "defineProperties", {value: function(obj, properties) {
-    if (typeof properties !== "object") {
-        throw new TypeError("Properties must be an object, not " + properties);
+    if (typeof properties !== "object" || properties === null) {
+        throw new TypeError("Properties must be an object, not '" + properties + "'");
     }
     for (var property in properties) {
         if ("_bindingDescriptors" !== property) {

--- a/test/core/core-spec.js
+++ b/test/core/core-spec.js
@@ -144,9 +144,39 @@ describe("core/core-spec", function() {
                 expect(Object.getPropertyDescriptor(Montage, "_bindingDescriptors")).toBeTruthy();
             });
 
+            describe("create", function() {
+                it("must be given an object, null or undefined as the first agument", function() {
+                    expect(function(){
+                        Montage.create("string", {});
+                    }).toThrow(new TypeError("Object prototype may only be an Object or null, not 'string'"));
+
+                    expect(Montage.create()).toEqual(Montage);
+
+                    expect(Montage.create(null)).toEqual(Object.create(null));
+
+                    expect(Montage.create({a: 1}, {b: { value: 2 }})).toEqual({a: 1, b: 2});
+                });
+            });
+
             describe("defineProperty", function() {
 
                 var foo;
+
+                it("must be given an object as the first argument", function() {
+                    expect(function(){
+                        Montage.defineProperty(null, "b", { value: null });
+                    }).toThrow(new TypeError("Object must be an object, not 'null'"));
+
+                    expect(function(){
+                        Montage.defineProperty(undefined, "b", { value: null });
+                    }).toThrow(new TypeError("Object must be an object, not 'undefined'"));
+
+                    expect(function(){
+                        Montage.defineProperty("string", "b", { value: null });
+                    }).toThrow(new TypeError("Object must be an object, not 'string'"));
+
+                    expect(Montage.defineProperty({a: 1}, "b", { value: 2 })).toEqual({a: 1, b: 2});
+                });
 
                 describe("object value", function () {
 
@@ -220,6 +250,24 @@ describe("core/core-spec", function() {
                 });
             });
 
+        });
+
+        describe("defineProperties", function() {
+            it("must be given an object as the second argument", function() {
+                expect(function(){
+                    Montage.defineProperties({}, null);
+                }).toThrow(new TypeError("Properties must be an object, not 'null'"));
+
+                expect(function(){
+                    Montage.defineProperties({}, undefined);
+                }).toThrow(new TypeError("Properties must be an object, not 'undefined'"));
+
+                expect(function(){
+                    Montage.defineProperties({}, "string");
+                }).toThrow(new TypeError("Properties must be an object, not 'string'"));
+
+                expect(Montage.defineProperties({a: 1}, { b: { value: 2 }})).toEqual({a: 1, b: 2});
+            });
         });
 
         describe("serializable property attribute", function() {


### PR DESCRIPTION
...when arguments are not of the correct type. Follows the ES spec more closely.

http://www.ecma-international.org/ecma-262/5.1/#sec-15.2.3.5
