### PR TITLE
Mop v0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "montage",
-    "version": "0.12.1",
+    "version": "0.12.2",
     "description": "A UI Framework",
     "main": "montage",
     "bin": {
@@ -9,6 +9,16 @@
     "overlay": {
         "browser": {
             "main": "core/core",
+            "mappings": {
+                "mr": {
+                    "name": "mr",
+                    "location": "packages/mr"
+                },
+                "q": {
+                    "name": "q",
+                    "location": "packages/mr/packages/q"
+                }
+            },
             "exclude": [
                 "lab",
                 "etc",
@@ -19,14 +29,13 @@
     "dependencies": {
         "collections": "0.1.3 - 0.2"
     },
-    "mappings": {
-        "mr": {
-            "name": "mr",
-            "location": "packages/mr"
-        },
-        "q": {
-            "name": "q",
-            "location": "packages/mr/packages/q"
-        }
+    "devDependencies": {
+        "mr": "0.12 - 0.13",
+        "q": "0.8 - 0.9",
+        "q-io": "1.3 - 2",
+        "jsdom": "0.2 - 0.3"
+    },
+    "bin": {
+        "montage": "bin/montage"
     }
 }

--- a/packages/mr/bootstrap-node.js
+++ b/packages/mr/bootstrap-node.js
@@ -57,14 +57,15 @@ var loadPackagedModule = function (directory, program, command, args) {
     .end();
 };
 
-var loadPackage = function (location, config) {
+exports.loadPackage = loadPackage;
+function loadPackage(location, config) {
     if (location.slice(location.length - 1, location.length) !== "/") {
         location += "/";
     }
     config = config || {};
     config.location = URL.resolve(Require.getLocation(), location);
     return Require.loadPackage(config.location, config);
-};
+}
 
 var loadFreeModule = function (program, command, args) {
     program = URL.resolve("file:" + program, "");
@@ -81,5 +82,7 @@ var loadFreeModule = function (program, command, args) {
     .end();
 };
 
-bootstrap();
+if (require.main == module) {
+    bootstrap();
+}
 

--- a/packages/mr/package.json
+++ b/packages/mr/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mr",
-    "version": "0.0.4",
+    "version": "0.12.0",
     "main": "require",
     "bin": {
         "mr": "bin/mr"
@@ -12,9 +12,19 @@
         }
     },
     "dependencies": {
-        "q": "0.8.x >=0.8.11"
+        "q": "0.8.11 - 0.9"
     },
     "devDependencies": {
-        "qs": "0.5.x"
-    }
+        "qs": "0.5 - 0.6"
+    },
+    "exclude": [
+        "README.md",
+        "LICENSE.md",
+        "bootstrap-node.js",
+        "node.js",
+        "adhoc.*",
+        "bin",
+        "demo",
+        "spec"
+    ]
 }


### PR DESCRIPTION
These changes are needed for the next release of Mop which will be able to optimize Montage v0.12 and Mr v0.12.

This was necessitated mostly because Mr and Q are separate packages now. Also Mop is now able to use this version of Montage as a dependency to reduce redundant code for dependency analysis.

This also uses a global `montageDefine(hash, id, module)` instead of `define` for script injection, and packages that use script injection are now identified by a `useScriptInjection` property in their `package.json`. If we rename `window.require` to something else, this should make Montage play well with RequireJS.
