### PR TITLE
[gh-1084] Serializer switch to Object.create(null)

### DIFF
--- a/core/deserializer.js
+++ b/core/deserializer.js
@@ -64,7 +64,7 @@ var Deserializer = exports.Deserializer = Montage.create(Montage, /** @lends mod
   @private
 */
     _objectStack: {value: []},
-    _modules: {value: {}},
+    _modules: {value: Object.create(null)},
  /**
   @private
 */
@@ -97,7 +97,7 @@ var Deserializer = exports.Deserializer = Montage.create(Montage, /** @lends mod
     // list of ids that were just created for optimization
     _optimizedIds: {value: Object.create(null)},
 
-    _indexedDeserializationUnits: {value: {}},
+    _indexedDeserializationUnits: {value: Object.create(null)},
 
     __sharedDocument: {
         value: null
@@ -214,7 +214,7 @@ var Deserializer = exports.Deserializer = Montage.create(Montage, /** @lends mod
         var objectsArray = [];
 
         for (var key in objects) {
-            if (objects.hasOwnProperty(key)) {
+            if (Object.hasOwnProperty.call(objects, key)) {
                 objectsArray.push(objects[key]);
             }
         }
@@ -241,7 +241,7 @@ var Deserializer = exports.Deserializer = Montage.create(Montage, /** @lends mod
             chainedOptimizedIds = deserializer._optimizedIds;
             if (chainedOptimizedIds) {
                 if (!optimizedIds) {
-                    this._optimizedIds = optimizedIds = {};
+                    this._optimizedIds = optimizedIds = Object.create(null);
                 }
                 for (var id in chainedOptimizedIds) {
                     optimizedIds[id] = chainedOptimizedIds[id];
@@ -305,7 +305,7 @@ var Deserializer = exports.Deserializer = Montage.create(Montage, /** @lends mod
             if (desc._units) {
                 units = desc._units;
             } else {
-                desc._units = units = {};
+                desc._units = units = Object.create(null);
             }
 
             units[name] = this._indexedDeserializationUnits[name];
@@ -415,7 +415,7 @@ var Deserializer = exports.Deserializer = Montage.create(Montage, /** @lends mod
             }
 
             var modulesLoaded = 0,
-                modules = {},
+                modules = Object.create(null),
                 _require = this._require;
 
             moduleIds.forEach(function(moduleId) {
@@ -479,10 +479,10 @@ var Deserializer = exports.Deserializer = Montage.create(Montage, /** @lends mod
                     var modules = self._modules;
 
                     if (!modules) {
-                        modules = self._modules = {};
+                        modules = self._modules = Object.create(null);
                     }
                     for (var moduleId in newModules) {
-                        if (newModules.hasOwnProperty(moduleId)) {
+                        if (Object.hasOwnProperty.call(newModules, moduleId)) {
                             modules[moduleId] = newModules[moduleId];
                         }
                     }
@@ -588,7 +588,7 @@ var Deserializer = exports.Deserializer = Montage.create(Montage, /** @lends mod
             var bracketIndex;
 
             if (typeof desc === "undefined") {
-                desc = {};
+                desc = Object.create(null);
             }
             bracketIndex = name.indexOf("[");
             if (bracketIndex > 0) {
@@ -647,13 +647,13 @@ var Deserializer = exports.Deserializer = Montage.create(Montage, /** @lends mod
             objectsStrings = "",
             cleanupStrings = "",
             valueString,
-            deserialized = {},
+            deserialized = Object.create(null),
             modules = this._modules,
             idsToRemove = [],
             optimizedIds = this._optimizedIds,
             compiledDeserializationFunctionString,
             requireStrings = [],
-            objectNamesCounter = {},
+            objectNamesCounter = Object.create(null),
             label,
             labelRegexp = this._labelRegexp,
             object;
@@ -816,7 +816,7 @@ var Deserializer = exports.Deserializer = Montage.create(Montage, /** @lends mod
             objectsStrings += label + '.isDeserializing = true;\n';
             cleanupStrings += 'delete ' + label + '.isDeserializing;\n';
             objectsStrings += 'if (typeof ' + label + '.deserializeSelf === "function") {\n';
-            objectsStrings += '  ' + label + 'Serialization._units = {};\n';
+            objectsStrings += '  ' + label + 'Serialization._units = Object.create(null);\n';
             objectsStrings += '  this._customDeserialization(' + label + ', ' + descString + ');\n';
             objectsStrings += '} else {\n';
             objectsStrings += '  this._deserializeProperties(' + label + ', ' + label + 'Serialization.properties);\n';
@@ -825,7 +825,7 @@ var Deserializer = exports.Deserializer = Montage.create(Montage, /** @lends mod
             if (deserialize) {
                 object.isDeserializing = true;
                 if (typeof object.deserializeSelf === "function") {
-                    desc._units = {};
+                    desc._units = Object.create(null);
                     self._customDeserialization(object, desc);
                 } else {
                     self._deserializeProperties(object, desc.properties, false);
@@ -989,7 +989,7 @@ var Deserializer = exports.Deserializer = Montage.create(Montage, /** @lends mod
      */
     _deserialize: {
         value: function(sourceDocument, targetDocument) {
-            var exports = this._objects = {},
+            var exports = this._objects = Object.create(null),
                 chainedSerializations = this._chainedSerializations;
 
             // third and next runs, execute the compiled deserialization function
@@ -1102,8 +1102,8 @@ var Deserializer = exports.Deserializer = Montage.create(Montage, /** @lends mod
                     body = sharedDocument.body;
 
 
-                self._objects = {};
-                self._objectLabels = instances || {};
+                self._objects = Object.create(null);
+                self._objectLabels = instances || Object.create(null);
 
                 if (element) {
                     body.appendChild(sharedDocument.importNode(element, true));
@@ -1130,8 +1130,8 @@ var Deserializer = exports.Deserializer = Montage.create(Montage, /** @lends mod
             var self = this;
 
             this._prepareForDeserialization(function() {
-                self._objects = {};
-                self._objectLabels = instances || {};
+                self._objects = Object.create(null);
+                self._objectLabels = instances || Object.create(null);
 
                 var exports = self._deserialize(sourceDocument);
 

--- a/core/serializer.js
+++ b/core/serializer.js
@@ -54,8 +54,8 @@ if (typeof window !== "undefined") {
 var Serializer = Montage.create(Montage, /** @lends module:montage/core/serializer.Serializer# */ {
     _INITIAL_LABEL_SEQUENCE_NUMBER: {value: 2}, // labels generation sequence is "label", "label2", "label3", ..., hence starting at 2
     _MONTAGE_ID_ATTRIBUTE: {value: "data-montage-id"},
-    _serializedObjects: {value: {}}, // label -> string
-    _serializedReferences: {value: {}}, // uuid -> string
+    _serializedObjects: {value: Object.create(null)}, // label -> string
+    _serializedReferences: {value: Object.create(null)}, // uuid -> string
     _externalObjects: {value: null}, // label -> object
     _externalElements: {value: null},
     _objectStack: {value: null},
@@ -64,7 +64,7 @@ var Serializer = Montage.create(Montage, /** @lends module:montage/core/serializ
     _objectNamesIndex: {value: null},
     _objectLabels: {value: null}, // uuid -> label
     _serializationUnits: {value: []},
-    _serializationUnitsIndex: {value: {}},
+    _serializationUnitsIndex: {value: Object.create(null)},
 
     serializeNullValues: {value: false},
 
@@ -120,13 +120,13 @@ var Serializer = Montage.create(Montage, /** @lends module:montage/core/serializ
                 label,
                 serializeNullValues = this.serializeNullValues;
 
-            this._serializedObjects = {};
-            this._serializedReferences = {};
-            this._externalObjects = {};
+            this._serializedObjects = Object.create(null);
+            this._serializedReferences = Object.create(null);
+            this._externalObjects = Object.create(null);
             this._externalElements = [];
-            this._objectNamesIndex = {};
-            this._objectLabels = {};
-            this._objectReferences = {};
+            this._objectNamesIndex = Object.create(null);
+            this._objectLabels = Object.create(null);
+            this._objectReferences = Object.create(null);
 
             for (label in objects) {
                 if (objects[label] != null) {
@@ -174,7 +174,7 @@ var Serializer = Montage.create(Montage, /** @lends module:montage/core/serializ
             uuid = stackElement.uuid;
             objectReferences = this._objectReferences;
             if (!(uuid in objectReferences)) {
-                objectReferences[uuid] = {};
+                objectReferences[uuid] = Object.create(null);
             }
             objectReferences[uuid][name] = true;
         }
@@ -211,7 +211,7 @@ var Serializer = Montage.create(Montage, /** @lends module:montage/core/serializ
                 objectReferences = this._objectReferences,
                 uuid = stackElement.properties.uuid;
                 if (!(uuid in objectReferences)) {
-                    objectReferences[uuid] = {};
+                    objectReferences[uuid] = Object.create(null);
                 }
                 objectReferences[uuid][name] = true;
             }
@@ -505,7 +505,7 @@ var Serializer = Montage.create(Montage, /** @lends module:montage/core/serializ
             delegate = this.delegate;
             this._serializedReferences[uuid] = serializedReference;
 
-            serializedUnits = {};
+            serializedUnits = Object.create(null);
             objectInfo = Montage.getInfoForObject(object);
 
             if (!this._require) {
@@ -535,7 +535,7 @@ var Serializer = Montage.create(Montage, /** @lends module:montage/core/serializ
 
             if (typeof object.serializeProperties === "function") {
                 this._pushContextObject(object);
-                this._pushContextObject({});
+                this._pushContextObject(Object.create(null));
                 object.serializeProperties(this, Montage.getSerializablePropertyNames(object));
                 // handle delegate.serializeProperties for objects that
                 // implement their own serializeProperties
@@ -555,7 +555,7 @@ var Serializer = Montage.create(Montage, /** @lends module:montage/core/serializ
                 // do NOT implement their own serializeProperties
                 if (delegate && typeof delegate.serializeObjectProperties === "function") {
                     this._pushContextObject(object);
-                    this._pushContextObject({});
+                    this._pushContextObject(Object.create(null));
                     this.setAll(propertyNames);
                     delegate.serializeObjectProperties(this, object, propertyNames);
                     serializedUnits.properties = this._serializeObjectLiteral(this._popContextObject(), null, 3);
@@ -613,7 +613,7 @@ var Serializer = Montage.create(Montage, /** @lends module:montage/core/serializ
     _customSerialization: {
         value: function(object, indent) {
             this._pushContextObject(object);
-            this._pushContextObject({properties: {}, _units: []});
+            this._pushContextObject({properties: Object.create(null), _units: []});
             var newObject = object.serializeSelf(this);
             var objectDescriptor = this._popContextObject();
             this._popContextObject();
@@ -670,7 +670,7 @@ var Serializer = Montage.create(Montage, /** @lends module:montage/core/serializ
             value = object[key];
 
             if (typeof value !== "undefined" && (this.serializeNullValues || value !== null)) {
-                serializationType = Montage.getPropertyAttribute(object, key, "serializable") || ((serializedReferenceProperties && serializedReferenceProperties.hasOwnProperty(key)) ? "reference" : "auto");
+                serializationType = Montage.getPropertyAttribute(object, key, "serializable") || ((serializedReferenceProperties && Object.hasOwnProperty.call(serializedReferenceProperties, key)) ? "reference" : "auto");
                 serializedProperties.push(JSON.stringify(key) + ":" + this._serializeValue(value, serializationType, indent));
             }
         }

--- a/test/serialization/deserializer-spec.js
+++ b/test/serialization/deserializer-spec.js
@@ -130,6 +130,15 @@ describe("serialization/deserializer-spec", function() {
             });
         });
 
+        it("should deserialize an object labeled clear", function() {
+            deserializer.initWithObject({
+                clear: {
+                    value: "string"
+                }
+            }).deserialize(function(object) {
+                expect(object.clear).toBe("string");
+            });
+        });
     });
 
     describe("Native Objects Deserialization", function() {

--- a/test/serialization/serializer-spec.js
+++ b/test/serialization/serializer-spec.js
@@ -207,6 +207,12 @@ describe("serialization/serializer-spec", function() {
             });
         });
 
+        it("should serialize an Array with the label clear", function() {
+            var array = [42, "string", null];
+            var serialization = serializer.serialize({clear: array});
+            expect(stripPP(serialization)).toBe('{"clear":{"value":[42,"string",null]}}');
+        });
+
         // TODO: object literal with functions
         // TODO: object literal with references to user objects
     });
@@ -408,7 +414,7 @@ describe("serialization/serializer-spec", function() {
                 serialization = serializer.serializeObject(object);
                 externalObjects = serializer.getExternalObjects();
                 for (var uuid in externalObjects) {
-                    if (externalObjects.hasOwnProperty(uuid)) {
+                    if (Object.hasOwnProperty.call(externalObjects, uuid)) {
                         length++;
                     }
                 }
@@ -447,7 +453,7 @@ describe("serialization/serializer-spec", function() {
                 length = 0;
 
             for (var uuid in externalObjects) {
-                if (externalObjects.hasOwnProperty(uuid)) {
+                if (Object.hasOwnProperty.call(externalObjects, uuid)) {
                     length++;
                 }
             }


### PR DESCRIPTION
Collections added specific properties to Object.prototype that made the (de)serializer brake, a change to Object.create(null) fixes all those issues.
