### PR TITLE
Change readyState needed to "interactive"

### DIFF
--- a/montage.js
+++ b/montage.js
@@ -450,7 +450,7 @@ if (typeof window !== "undefined") {
             }
 
             // this permits montage.js to be injected after domready
-            if (document.readyState === "complete") {
+            if (document.readyState === "interactive") {
                 domLoad();
             } else {
                 document.addEventListener("DOMContentLoaded", domLoad, true);


### PR DESCRIPTION
The document readyState is "interactive" after DOMContentLoaded, and "complete" after load.

If montage.js loaded after DOMContentLoaded/"interactive" but before load/"complete", then domLoad would never be called. This commit fixes this.

Note: this change would allow the montage.js script tag to use the `async` attribute. See gh-1090
