### PR TITLE
Disable and fix broken popup tests

### DIFF
--- a/test/ui/popup-in-window-spec.js
+++ b/test/ui/popup-in-window-spec.js
@@ -28,17 +28,25 @@ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 </copyright> */
+/*global require,exports,describe,it,expect,runs */
+
 var Montage = require("montage").Montage,
     TestPageLoader = require("support/testpageloader").TestPageLoader,
     EventInfo = require("support/testpageloader").EventInfo,
-    Popup = Popup = require("montage/ui/popup/popup.reel").Popup,
+    Popup = require("montage/ui/popup/popup.reel").Popup,
     ActionEventListener = require("montage/core/event/action-event-listener").ActionEventListener;
-
 
 var testPage = TestPageLoader.queueTest("popup-in-window-test", {newWindow: true}, function() {
     var test = testPage.test;
 
     describe("ui/popup-in-window-spec", function() {
+        if (!testPage.loaded) {
+            it("TODO DISABLE POPUP BLOCKER TO RUN POPUP IN WINDOW TESTS", function() {
+                expect(testPage.loaded).toBeTruthy();
+            });
+            return;
+        }
+
         it("should load", function() {
             expect(testPage.loaded).toBeTruthy();
         });
@@ -61,7 +69,7 @@ var testPage = TestPageLoader.queueTest("popup-in-window-test", {newWindow: true
                     testPage.waitForDraw(1);
                     runs(function() {
                         var element = test.testPopup.popup.element;
-                        popupPosition = EventInfo.positionOfElement(element);
+                        var popupPosition = EventInfo.positionOfElement(element);
                         //console.log('popupPosition with 800,400', popupPosition);
                         expect(element.offsetHeight).toBe(118);
                         expect(popupPosition.y).toBe(222);

--- a/test/ui/popup-spec.js
+++ b/test/ui/popup-spec.js
@@ -28,10 +28,11 @@ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 </copyright> */
+/*global require,exports,describe,it,expect,runs */
 var Montage = require("montage").Montage,
     TestPageLoader = require("support/testpageloader").TestPageLoader,
     EventInfo = require("support/testpageloader").EventInfo,
-    Popup = Popup = require("montage/ui/popup/popup.reel").Popup,
+    Popup = require("montage/ui/popup/popup.reel").Popup,
     ActionEventListener = require("montage/core/event/action-event-listener").ActionEventListener;
 
 
@@ -66,7 +67,7 @@ var testPage = TestPageLoader.queueTest("popup-test", function() {
 
             describe("Popup", function() {
 
-                it("show/hide works", function() {
+                it("TODO show/hide works", function() {
 
                     var popup = test.popup;
                     expect(popup.displayed).toBe(false);

--- a/test/ui/popup-test/popup-test.html
+++ b/test/ui/popup-test/popup-test.html
@@ -38,7 +38,7 @@ POSSIBILITY OF SUCH DAMAGE.
 {
     "test": {
         "prototype": "ui/popup-test/popup-test",
-        "properties": {            
+        "properties": {
             "popupContent": {"@": "popupContent"},
             "popupButton": {"@": "popupButton"},
             "popup": {"@": "popup"}
@@ -64,7 +64,10 @@ POSSIBILITY OF SUCH DAMAGE.
         "properties": {
             "element": {"#": "popupButton"},
             "identifier": "popupButton"
-        }
+        },
+        "listeners": [
+            {"type": "action", "listener": {"@": "test"}}
+        ]
     },
     "application": {
         "prototype": "montage/ui/application",

--- a/test/ui/popup-test/popup-test.js
+++ b/test/ui/popup-test/popup-test.js
@@ -76,6 +76,11 @@ var PopupTest = exports.PopupTest = Montage.create(Montage, {
         value: null
     },
 
+    handlePopupButtonAction: {
+        value: function() {
+            this.showPopup();
+        }
+    },
 
     /**
 


### PR DESCRIPTION
Mark broken test as TODO
Skip test if the popup doesn't open
Make button in popup test open popup for manual testing
