### PR TITLE
Allow returned exports in bootstrapping.

### DIFF
--- a/montage.js
+++ b/montage.js
@@ -500,7 +500,7 @@ if (typeof window !== "undefined") {
             function bootRequire(id) {
                 if (!bootModules[id] && definitions[id]) {
                     var exports = bootModules[id] = {};
-                    definitions[id](bootRequire, exports);
+                    bootModules[id] = definitions[id](bootRequire, exports) || exports;
                 }
                 return bootModules[id];
             }


### PR DESCRIPTION
This _should_ allow us to upgrade to Q v0.9, which exports the Q()
function, without modification. Emphasis that we should hold this until we've verified that q/master works in packages/mr/packages/q.
