### PR TITLE
Option element conversion to contentController objects now honor textPro...

### DIFF
--- a/ui/native/select.reel/select.js
+++ b/ui/native/select.reel/select.js
@@ -267,16 +267,18 @@ var Select = exports.Select =  Montage.create(NativeControl, /** @lends module:"
 
                 contentController.content = [];
                 if(options && options.length > 0) {
-                    var i=0, len = options.length, selected;
+                    var i=0, len = options.length, selected, optionToAdd;
                     for(; i< len; i++) {
                         selected = options[i].getAttribute('selected');
                         if(selected) {
                             selectedIndexes.push(i);
                         }
-                        contentController.addObjects({
-                            value: options[i].value,
-                            text: options[i].textContent
-                        });
+
+                        //create objects to match provided propertyPaths, if present, otherwise default
+                        optionToAdd = {};
+                        optionToAdd[this.valuePropertyPath || 'value'] = options[i].value;
+                        optionToAdd[this.textPropertyPath || 'text'] = options[i].textContent;
+                        contentController.addObjects(optionToAdd);
                     }
 
                     this.contentController = contentController;


### PR DESCRIPTION
...pertyPath and valuePropertyPaths, if available

select.reel honors the valuePropertyPath and textPropertyPath when converting a passed in contentController to <option> tags, but does not honor the reverse. If an <option> tag is present, it doesn't convert value and text values into corresponding valuePropertyPath and textPropertyPath properties on the generated objects.

This fixes that by using the valuePropertyPath ad textPropertyPath values when present and defaulting to "value" and "text" when they're not present.

Signed-off-by: Tom Ortega tom.ortega@gmail.com
