### PR TITLE
optgroup nodes no longer ignored when reading in from markup

### DIFF
--- a/ui/native/select.reel/select.js
+++ b/ui/native/select.reel/select.js
@@ -352,7 +352,7 @@ var Select = exports.Select =  Montage.create(NativeControl, /** @lends module:"
                 if(String.isString(arr[i])) {
                     text = value = arr[i];
                 } else {
-                    if (arr[i].hasOwnProperty(this.groupPropertyPath || 'groupLabel'))
+                    if (arr[i].hasOwnProperty(this.groupPropertyPath || 'groupLabel') || lastGroupLabel)
                     {
                         currentGroupLabel = arr[i][this.groupPropertyPath || 'groupLabel'];
 
@@ -366,7 +366,7 @@ var Select = exports.Select =  Montage.create(NativeControl, /** @lends module:"
                             }
 
                             // create a new group base on groupLabel value
-                            if (currentGroupLabel != '') {
+                            if (currentGroupLabel) {
                                 optionGroup = document.createElement('optgroup');
                                 optionGroup.label = currentGroupLabel;
                                 lastGroupLabel = currentGroupLabel;


### PR DESCRIPTION
select.reel ignores optgroup when creating objects to stash in the contentController it creates to stash the values; This results in the groups disappearing in the drop down.

This fixes that by creating introducing a groupPropertyPath property and maintaining an offset value to use when calculating selected indexes of selected options.

Signed-off-by: Tom Ortega tom.ortega@gmail.com
