### PR TITLE
Stop stifling the error we've encountered

### DIFF
--- a/ui/component.js
+++ b/ui/component.js
@@ -1025,6 +1025,7 @@ var Component = exports.Component = Montage.create(Montage,/** @lends module:mon
                 }).fail(function(reason) {
                     var message = reason.stack || reason;
                     console.error("Error in", template.getBaseUrl() + ":", message);
+                    throw reason;
                 });
             });
         }


### PR DESCRIPTION
While it's nice to report the error message, we weren't passing it along
so we never had a chance to handle it downstream.

I'm not sure if you want to continue logging the message, it's an easy enough fix without my patch, so however it get resolved is fine by me so long as I know it failed.
