### PR TITLE
Fix _makeTemplateObjectGetter and add tests

### DIFF
--- a/test/ui/component-spec.js
+++ b/test/ui/component-spec.js
@@ -525,6 +525,40 @@ var testPage = TestPageLoader.queueTest("draw", function() {
            expect(element.getAttribute("id")).toBe("componentList");
         });
 
+        describe("_makeTemplateObjectGetter", function () {
+            it("returns a single component", function () {
+                var a = {};
+                var owner = {
+                    querySelectorAllComponent: function () {
+                        return [a];
+                    }
+                };
+                a.parentComponent = owner;
+
+                var getter = Component._makeTemplateObjectGetter(owner, "test");
+
+                expect(getter()).toEqual(a);
+                expect(getter()).toEqual(a);
+            });
+
+            it("returns all repeated components", function () {
+                var a = {};
+                var b = {};
+                var owner = {
+                    querySelectorAllComponent: function () {
+                        return [a, b];
+                    }
+                };
+                a.parentComponent = owner;
+                b.parentComponent = owner;
+
+                var getter = Component._makeTemplateObjectGetter(owner, "test");
+
+                expect(getter()).toEqual([a, b]);
+                expect(getter()).toEqual([a, b]);
+            });
+        });
+
         describe("dom arguments", function() {
             testPage.test.arguments._initDomArguments();
             testPage.test.noArguments._initDomArguments();

--- a/ui/component.js
+++ b/ui/component.js
@@ -1003,7 +1003,7 @@ var Component = exports.Component = Montage.create(Montage,/** @lends module:mon
                 templateObjects = Object.create(null);
 
             for (var label in objects) {
-                object = objects[label];
+                var object = objects[label];
 
                 if (typeof object === "object" && object != null) {
                     if (object.parentComponent === this) {
@@ -1020,9 +1020,8 @@ var Component = exports.Component = Montage.create(Montage,/** @lends module:mon
     },
 
     _makeTemplateObjectGetter: {
-        value: function(label) {
-            var owner = this,
-                querySelectorLabel = "@"+label,
+        value: function(owner, label) {
+            var querySelectorLabel = "@"+label,
                 isRepeated,
                 components,
                 component;


### PR DESCRIPTION
Mainly fixes the case of the repetition where the template objects
for a label was an empty array instead of an array of repeated
components.
