### PR TITLE
Swap Montage and application requires around in bootstrap

### DIFF
--- a/test/trigger/trigger-spec.js
+++ b/test/trigger/trigger-spec.js
@@ -17,6 +17,9 @@ describe("trigger-test", function() {
                 var deferForMontageReady = Promise.defer();
                 testWindow = iWindow;
 
+                testWindow.postMessage({
+                    type: "isMontageReady",
+                }, "*");
                 testWindow.addEventListener("message", function(event) {
                     if(event.source === testWindow) {
                         deferForMontageReady.resolve(event);


### PR DESCRIPTION
So that Montage is loaded with the application require, instead of
vice versa.

This fixes the issue where if an application and Montage depend on
the same package, npm would (correctly) install it in the
application's node_modules but, because the montage package was loaded
first, Montage would try and use a version in its node_modules.

Fixes https://github.com/montagejs/montage-testing/issues/2
