### PR TITLE
Fix addRangePathChangeListener listener's parameters

### DIFF
--- a/core/paths.js
+++ b/core/paths.js
@@ -53,7 +53,8 @@ Montage.defineProperties(Montage, {
             var minus = [];
             return this.addPathChangeListener(path, function (plus) {
                 plus = plus || [];
-                dispatch(plus, minus, 0);
+                // Give copies to avoid modification by the listener.
+                dispatch(plus.slice(), minus.slice(), 0);
                 minus = plus;
                 return plus.addRangeChangeListener(dispatch);
             });

--- a/test/paths-spec.js
+++ b/test/paths-spec.js
@@ -273,7 +273,25 @@ describe("paths-spec", function () {
 
         object.array = [];
         expect(spy).toHaveBeenCalledWith([], ['a', 'b'], 0);
+    });
 
+    describe("addRangeAtPathChangeListener II", function() {
+        it("should not pass a direct reference of the object at the path to the listener's plus/minus parameters", function() {
+            var object = Montage.create();
+            var spy = jasmine.createSpy();
+            var array1 = [1];
+            var array2 = [2];
+
+            object.array = array1;
+            object.addRangeAtPathChangeListener("array", function (plus, minus, index) {
+                spy(plus, minus, index);
+            });
+
+            object.array = array2;
+
+            expect(spy.mostRecentCall.args[0]).not.toBe(array2);
+            expect(spy.mostRecentCall.args[1]).not.toBe(array1);
+        })
     });
 
     describe("addRangeAtPathChangeListener with handler", function () {


### PR DESCRIPTION
addRangePathChangeListener doesn't give direct references to the objects at the path anymore.
