### PR TITLE
selectedIndexes of a repetition currently show all available indexes

### DIFF
--- a/ui/repetition.reel/repetition.js
+++ b/ui/repetition.reel/repetition.js
@@ -596,7 +596,7 @@ var Repetition = exports.Repetition = Component.specialize( /** @lends Repetitio
                 "<-": "iterations.filter{selected}"
             });
             this.defineBinding("selectedIndexes", {
-                "<-": "iterations.map{index}"
+                "<-": "selectedIterations.map{index}"
             });
 
 


### PR DESCRIPTION
In a repetition the selectedIndexes currently contain all available indexes, i believe this is not the intended behaviour. This patch makes it contain only the indexes of the selected iterations.
