### PR TITLE
Upgrade TreeController

### DIFF
--- a/core/tree-controller.js
+++ b/core/tree-controller.js
@@ -1,5 +1,7 @@
 
 var Montage = require("core/core").Montage;
+var Map = require("collections/map");
+var WeakMap = require("collections/weak-map");
 
 // A tree controller is a view-model that tracks whether each node in a
 // corresponding data-model is expanded or collapsed.  It also produces a
@@ -10,113 +12,392 @@ var Montage = require("core/core").Montage;
 // Bind a root node from the data model to a tree controller and bind the tree
 // controller's iterations to a content controller for a repetition.
 
-var Iteration = Montage.specialize( {
+var Node = exports.TreeControllerNode = Montage.specialize({
 
+    /**
+     * The only meaningful user-defined state for this tree view, whether the
+     * node is expanded (or collapsed).
+     */
+    expanded: {
+        value: true
+    },
+
+    /**
+     * The data model corresponding to this node.
+     */
+    content: {
+        value: null
+    },
+
+    /**
+     * The number of times this node should be indented to reach its visually
+     * representative depth.  This property or `junctions` are alternately
+     * useful for tree visualization strategies.
+     */
+    depth: {
+        value: null
+    },
+
+    /**
+     * The position of this node within the parent node, as maintained by
+     * bindings.
+     */
+    index: {
+        value: null
+    },
+
+    /**
+     * Whether this node appears in the last position of the parent node's
+     * children, as maintained by bindings.
+     */
+    isFinal: {
+        value: null
+    },
+
+    /**
+     * The node that is this node's parent, or null if this is the root node.
+     */
+    parent: {
+        value: null
+    },
+
+    /**
+     * The child nodes is an array of the corresponding tree controller
+     * view-model node for each of the children.  The child nodes array
+     * is maintained by `handleChildrenEntriesRangeChange`.
+     */
+    children: {
+        value: null
+    },
+
+    /**
+     * The governing content controller
+     */
+    controller: {
+        value: null
+    },
+
+    /**
+     * An array of the children of the content for this node.  The content
+     * itself may hang its children however it likes, but this will always be a
+     * simple array, observed using the `childrenPath` provided to the tree
+     * controller upon initialization.
+     * @private
+     */
+    _childrenContent: {
+        value: null
+    },
+
+    /**
+     * The child entries are an array bound to an enumeration of its children
+     * collection.  The enumeration produces entries objects (duples of [index,
+     * child]).  The node watches this array for changes and reacts by producing
+     * corresponding child nodes, passing the entry object to the node so that
+     * it can watch its own index within the parent node's children.  Watching
+     * the index is important for judging whether it is in final position,
+     * which is in turn useful for determining the junction type to associate
+     * with the node.
+     * @private
+     */
+    _childrenEntries: {
+        value: null
+    },
+
+    /**
+     * The iterations array contains this node and all of its children beneath
+     * expanded nodes.  It is maintained entirely by a binding that involves
+     * this node, its child nodes, the iterations of its child nodes, and
+     * whether this node is expanded.
+     */
+    iterations: {
+        value: null
+    },
+
+    /**
+     * An array of hints for what kind of line art needs to be employed
+     * for each level of indentation leading up to this node's content.  The
+     * hints include "final", "medial", "before", and "after".  The "final"
+     * hint implies a junction that leads from above to the content to the
+     * right.  The "medial" hint implies a junction that follows from above and
+     * continues down, with a line to content to the right.  The "before" hint
+     * implies a junction that passed from above to below.  The "after" hint
+     * implies a junction with no lines at all.  The junctions array reacts
+     * synchronous to content changes.
+     */
+    junctions: {
+        value: null
+    },
+
+    /**
+     * The last junction on this node's row, as determined solely by whether it
+     * is in final position by its immediate parent.
+     * @private
+     */
+    _junction: {
+        value: null,
+    },
+
+    /**
+     * The penultimate junction on each of this node's children, as determined
+     * solely by whether it is in final position of its parent.
+     * @private
+     */
+    _followingJunction: {
+        value: null
+    },
+
+    /**
+     * All of the junctions that prefix each of this node's children's
+     * junctions.
+     * @private
+     */
+    _followingJunctions: {
+        value: null
+    },
+
+    /**
+     * An [index, node] duple maintained by an enumeration binding on this
+     * node's parent's children.  The object exists to provide the `index` for
+     * this node, which in turn propagates out to the `initial` and `final`
+     * properties.
+     * @private
+     */
+    _entry: {
+        value: null
+    },
+
+    /**
+     * Creates a tree controller node.
+     * @param content
+     * @param {String} childenPath
+     * @param {Node} parent
+     * @param {Number} depth
+     * @param {[Number, Node]|null} entry
+     */
     constructor: {
-        value: function () {
-            this.depth = null;
-            this.node = null;
-            this.content = null;
-            this.defineBinding("content", {"<->": "node.content"});
-            this.defineBinding("expanded", {"<->": "node.expanded"});
-            this.defineBinding("parent", {"<-": "node.parent"});
-            this.defineBinding("children", {"<-": "node.children"});
+        value: function TreeControllerNode(controller, parent, content, depth, entry) {
+            this.super();
+
+            this.controller = controller;
+            this.parent = parent;
+            this.content = content;
+            this.depth = depth;
+            this._entry = entry || [0, this];
+            this.expanded = controller.initiallyExpanded || false;
+
+            this.children = [];
+
+            this.defineBinding("index", {"<-": "_entry.0"});
+            this.defineBinding("isFinal", {"<-": "index == parent.children.length - 1"});
+
+            // childrenPath -> _childrenContent
+            // waits for depth to be defined to ensure that child nodes know
+            // their depth when they are created by initialization of children
+            this.defineBinding("_childrenContent", {
+                "<-": "depth.defined() ? content.path(controller.childrenPath ?? 'children') : []"
+            });
+
+            // _childrenContent -> _childrenEntries
+            this.defineBinding("_childrenEntries", {
+                "<-": "_childrenContent.enumerate()"
+            });
+
+            // _childrenEntries -> children
+            this.handleChildrenEntriesRangeChange(this._childrenEntries, [], 0);
+            this._childrenEntries.addRangeChangeListener(this, "childrenEntries");
+
+            // this + children if expanded -> iterations
+            this.defineBinding("iterations", {
+                "<-": "[this].concat(expanded ? children.flatten{iterations} : [])"
+            });
+
+            // the all nodes binding facilitates the allExpanded binding
+            this.defineBinding("nodes", {
+                "<-": "[this].concat(children.flatten{nodes})"
+            });
+
+            // line art hints
+            this.defineBinding("_junction", {
+                "<-": "isFinal ? 'final' : 'medial'"
+            });
+            this.defineBinding("_followingJunction", {
+                "<-": "isFinal ? 'after' : 'before'"
+            });
+            this.defineBinding("_followingJunctions", {
+                "<-": "(parent._followingJunctions ?? []).concat([_followingJunction])"
+            });
+            this.defineBinding("junctions", {
+                "<-": "(parent._followingJunctions ?? []).concat([_junction])"
+            });
+
         }
     },
 
-    initWithNodeAndDepth: {
-        value: function (node, depth) {
-            this.depth = depth;
-            this.node = node;
-            return this;
+    /**
+     * Propagates changes to `_childrenEntries` (by way of `_childrenContent.enumerate()`)
+     * into `children`, by constructing the respective node for each child.
+     * @private
+     */
+    handleChildrenEntriesRangeChange: {
+        value: function (plus, minus, index) {
+            this.children.swap(
+                index,
+                minus.length,
+                plus.map(function (entry) {
+                    return new this.constructor(
+                        this.controller,
+                        this,
+                        entry[1], // content
+                        this.depth + 1,
+                        entry
+                    );
+                }, this)
+            );
         }
     }
 
 });
 
-var Node = exports.TreeController = Montage.specialize( {
+exports.TreeController = Montage.specialize({
 
+    /**
+     * The input of a tree controller, an object to serve at the root of the
+     * tree.
+     */
+    content: {
+        value: null
+    },
+
+    /**
+     * An FRB expression, that evaluated against content or any of its
+     * children, produces an array of that content's children.  By default,
+     * this is simply "children", but for an alternate example, a binary tree
+     * would have children `[left, right]`, except that said tree would need to
+     * have no children if left and right were both null, so `(left ??
+     * []).concat(right ?? [])`, to avoid infinite recursion.
+     *
+     * This property must be set before `content`.
+     */
+    childrenPath: {
+        value: null
+    },
+
+    /**
+     * Whether nodes of the tree are initially expanded.
+     *
+     * This property must be set before `content`.  If `content` has already
+     * set, use `allExpanded`.
+     */
+    initiallyExpanded: {
+        value: null
+    },
+
+    /**
+     * Whether every node eligible for expansion is expanded.
+     *
+     * This is a readable and writable property.  Setting to true causes all
+     * nodes to be expanded.
+     */
+    allExpanded: {
+        value: null
+    },
+
+    /**
+     * Whether any nodes are collapsed.
+     *
+     * This is a readable and writable property.  Setting to true causes all
+     * nodes to be collapsed.
+     */
+    noneExpanded: {
+        value: null
+    },
+
+    /**
+     * The product of a tree controller, an array of tree controller nodes
+     * corresponding to each branch of the content for which every parent node
+     * is `expanded`.
+     */
+    iterations: {
+        value: null
+    },
+
+    /**
+     * A by-product of the tree controller, the root node of the tree for the
+     * current content.
+     */
+    root: {
+        value: null
+    },
+
+    /**
+     * A WeakMap of alternate [content, root] pairs.  If the content is
+     * dropped, the view-model (tree controller nodes) may be collected.  If a
+     * content references is restored, the corresponding view model and all of
+     * its expanded/collapsed state, is restored.
+     * @private
+     */
+    _roots: {
+        value: null
+    },
+
+    /**
+     * Creates a tree controller.
+     */
     constructor: {
-        value: function () {
+        value: function TreeController(content, childrenPath, initiallyExpanded) {
+            this.super();
 
-            this.content = null;
-            this.parent = null;
-            this.expanded = false;
-            this.childrenPath = null;
-            this.children = [];
-            this.childNodes = [];
-            this.childIterations = [];
-            this.indentedChildIterations = [];
-            this.iterations = [];
+            this._roots = new WeakMap();
+            this.addOwnPropertyChangeListener("content", this);
+            this.defineBinding("iterations", {"<-": "root.iterations"});
+            this.defineBinding("nodes", {"<-": "root.nodes"});
+            this.defineBinding(
+                "allExpanded",
+                {"<->": "nodes.every{expanded || children.length == 0}"}
+            );
+            this.defineBinding(
+                "noneExpanded",
+                {"<->": "nodes.every{!expanded}"}
+            );
 
-            // childrenPath -> children
-            this.defineBinding("children.rangeContent()", {"<-": "content.path(childrenPath)"});
-
-            // children -> childNodes
-            this.children.addRangeChangeListener(this, "children");
-
-            // childNodes + expanded -> length
-            this.defineBinding("length", {"<-": "1 + (expanded ? childNodes.sum{length} : 0)"});
-
-            // childNodes -> childIterations
-            this.defineBinding("childIterations.rangeContent()", {
-                "<-": "expanded ? childNodes.flatten{iterations} : []"
-            });
-
-            // childIterations -> indentedChildIterations
-            this.childIterations.addRangeChangeListener(this, "childIterations");
-
-            // iteration + indentedChildIterations -> iterations
-            this.iteration = new Iteration().initWithNodeAndDepth(this, 0);
-            this.defineBinding("iterations.rangeContent()", {
-                "<-": "[[iteration], indentedChildIterations].flatten()"
-            });
-
-        }
-    },
-
-    init: {
-        value: function (content, childrenPath, parent) {
-            this.parent = parent || null;
-            this.content = content;
+            this.initiallyExpanded = initiallyExpanded;
             this.childrenPath = childrenPath;
-            return this;
+            this.content = content;
         }
     },
 
-    handleChildrenRangeChange: {
-        value: function (plus, minus, index) {
-            this.childNodes.swap(
-                index,
-                minus.length,
-                plus.map(function (child) {
-                    return new Node().init(
-                        child,
-                        this.childrenPath,
-                        this
-                    );
-                }, this)
-            );
+    /**
+     * Memoizes content to tree controller root nodes, using the `_roots`
+     * `WeakMap` to retain `expanded` / collapsed state.
+     * @private
+     */
+    handleContentChange: {
+        value: function (content) {
+            if (!content) {
+                this.root = null;
+                return;
+            }
+            if (!this._roots.has(content)) {
+                this._roots.set(
+                    content,
+                    new this.Node(
+                        this, // controller
+                        null, // parent
+                        content,
+                        0, // depth
+                        null // entry
+                    )
+                );
+            }
+            this.root = this._roots.get(content);
         }
     },
 
-    handleChildIterationsRangeChange: {
-        value: function (plus, minus, index) {
-            this.indentedChildIterations.swap(
-                index,
-                minus.length,
-                plus.map(function (iteration) {
-                    return new this.Iteration().initWithNodeAndDepth(
-                        iteration.node,
-                        iteration.depth + 1
-                    );
-                }, this)
-            );
-        }
-    },
-
-    Iteration: {
-        value: Iteration
+    /**
+     * The type of the tree controller's nodes.
+     */
+    Node: {
+        value: Node
     }
 
 });

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "collections": "~0.1.21",
-    "frb": "~0.2.5",
+    "frb": "~0.2.7",
     "mousse": "~0.1.2",
     "htmlparser2": "~3.0.5"
   },

--- a/test/core/tree-controller-spec.js
+++ b/test/core/tree-controller-spec.js
@@ -1,51 +1,303 @@
 
 var TreeController = require("montage/core/tree-controller").TreeController;
 
+Error.stackTraceLimit = Infinity;
+
 describe("core/tree-controller-spec", function () {
 
-    var tree = {
-        name: "X",
-        children: [
-            {
-                "name": "Y"
-            },
-            {
-                "name": "Z",
+    describe("default children structure", function () {
+        var tree;
+
+        beforeEach(function () {
+            tree = {
+                name: "I",
                 children: [
                     {
-                        name: "A"
+                        "name": "I/A",
+                        children: []
+                    },
+                    {
+                        "name": "I/B",
+                        children: [
+                            {
+                                name: "I/B/1"
+                            }
+                        ]
                     }
                 ]
-            }
-        ]
-    };
+            };
+        });
 
-    it("should vary visible iterations with expand and collapse", function () {
+        describe("expand and collapse", function () {
+            var treeController;
+            var root;
 
-        var node = new TreeController().init(tree, "children");
+            it("initialize", function () {
+                treeController = new TreeController();
+                treeController.content = tree;
+                root = treeController.root;
 
-        expect(node.length).toBe(1);
-        expect(node.iterations.map(function (iteration) {
-            return iteration.depth
-        })).toEqual([0]);
+                expect(treeController.iterations.map(function (iteration) {
+                    return iteration.content.name;
+                })).toEqual(['I']);
+            });
 
-        node.expanded = true;
-        expect(node.length).toBe(3); // + 2 unexpanded children
-        expect(node.iterations.map(function (iteration) {
-            return iteration.depth
-        })).toEqual([0, 1, 1]);
+            it("expand the root", function () {
+                root.expanded = true;
+                // + 2 unexpanded children
+                expect(treeController.iterations.map(function (iteration) {
+                    return iteration.content.name;
+                })).toEqual(['I', 'I/A', 'I/B']);
+            });
 
-        node.childNodes[1].expanded = true;
-        expect(node.length).toBe(4); // + 1 grandchild
-        expect(node.iterations.map(function (iteration) {
-            return iteration.depth
-        })).toEqual([0, 1, 1, 2]);
+            it("expand the left child", function () {
+                root.children[1].expanded = true;
+                // + 1 grandchild
+                expect(treeController.iterations.map(function (iteration) {
+                    return iteration.content.name;
+                })).toEqual(['I', 'I/A', 'I/B', 'I/B/1']);
+            });
 
-        node.expanded = false;
-        expect(node.length).toBe(1); // dispite children and grandchildren
-        expect(node.iterations.map(function (iteration) {
-            return iteration.depth
-        })).toEqual([0]);
+            it("collapse the root", function () {
+                root.expanded = false;
+                // dispite children and grandchildren
+                expect(treeController.iterations.map(function (iteration) {
+                    return iteration.content.name;
+                })).toEqual(['I']);
+            });
+
+        });
+
+        describe("iteration depths", function () {
+            it("initialize", function () {
+                treeController = new TreeController();
+                treeController.content = tree;
+                root = treeController.root;
+
+                expect(treeController.iterations.map(function (iteration) {
+                    return iteration.depth
+                })).toEqual([0]);
+            });
+
+            it("expand the root", function () {
+                root.expanded = true;
+                // + 2 unexpanded children
+                expect(treeController.iterations.map(function (iteration) {
+                    return iteration.depth
+                })).toEqual([0, 1, 1]);
+            });
+
+            it("expand the left child", function () {
+                root.children[1].expanded = true;
+                // + 1 grandchild
+                expect(treeController.iterations.map(function (iteration) {
+                    return iteration.depth
+                })).toEqual([0, 1, 1, 2]);
+            });
+
+            it("collapse the root", function () {
+                root.expanded = false;
+                // dispite children and grandchildren
+                expect(treeController.iterations.map(function (iteration) {
+                    return iteration.depth
+                })).toEqual([0]);
+            });
+
+        });
+
+        describe("model changes", function () {
+
+            it("initialize", function () {
+                treeController = new TreeController();
+                treeController.initiallyExpanded = true;
+                treeController.content = tree;
+                root = treeController.root;
+
+                expect(treeController.iterations.map(function (iteration) {
+                    return iteration.content.name;
+                })).toEqual([
+                    'I', 'I/A', 'I/B', 'I/B/1'
+                ]);
+            });
+
+            it("add child to model", function () {
+                root.children[0].content.children.push({
+                    name: 'I/A/1',
+                    children: []
+                });
+                expect(treeController.iterations.map(function (iteration) {
+                    return iteration.content.name;
+                })).toEqual([
+                    'I', 'I/A', 'I/A/1', 'I/B', 'I/B/1'
+                ]);
+            });
+
+            it("remove child from model", function () {
+                root.children[1].children = null;
+                expect(treeController.iterations.map(function (iteration) {
+                    return iteration.content.name;
+                })).toEqual([
+                    'I', 'I/A', 'I/A/1', 'I/B'
+                ]);
+            });
+
+            it("detach model", function () {
+                treeController.content = null;
+                expect(treeController.iterations).toBe(undefined);
+            });
+
+        });
+
+        describe("view model per content", function () {
+
+            var previous;
+            it("should have a fresh view model for a new root", function () {
+                treeController = new TreeController();
+                treeController.content = tree;
+                previous = tree;
+                treeController.root.expanded = true;
+                expect(treeController.nodes.map(function (iteration) {
+                    return iteration.expanded;
+                })).toEqual([true, false, false, false]);
+
+                treeController.content = {
+                    name: 'X',
+                    children: [
+                        {name: 'Y'}
+                    ]
+                };
+                expect(treeController.nodes.map(function (iteration) {
+                    return iteration.expanded;
+                })).toEqual([false, false]);
+            });
+
+            it("should restore previous view model", function () {
+                treeController.content = previous;
+                expect(treeController.nodes.map(function (iteration) {
+                    return iteration.expanded;
+                })).toEqual([true, false, false, false]);
+            });
+
+        });
+
+        describe("iteration junctions", function () {
+            it("initialize", function () {
+                treeController = new TreeController();
+                treeController.content = tree;
+                tree.children[0].children = [{
+                    name: "I/A/1"
+                }, {
+                    name: "I/A/2"
+                }, {
+                    name: "I/A/3"
+                }];
+                treeController.allExpanded = true;
+                var ascii = {
+                    "medial": " +-",
+                    "final": " ^-",
+                    "before": " | ",
+                    "after": "   "
+                };
+                expect(treeController.iterations.map(function (iteration) {
+                    return iteration.junctions.map(function (junction) {
+                        return ascii[junction];
+                    }).join("") + " " + iteration.content.name;
+                })).toEqual([
+                    " I",
+                    " +- I/A",
+                    " |  +- I/A/1",
+                    " |  +- I/A/2",
+                    " |  ^- I/A/3",
+                    " ^- I/B",
+                    "    ^- I/B/1"
+                ]);
+            });
+        });
+
+    });
+
+    describe("trees with alternate structures", function () {
+
+        var tree;
+
+        beforeEach(function () {
+            tree = {
+                value: 10,
+                left: {
+                    value: 20,
+                    left: {
+                        value: 30
+                    }
+                },
+                right: {
+                    value: 40,
+                    left: {
+                        value: 50
+                    }
+                }
+            };
+        });
+
+        var childrenPath =  "[left, right].filter{defined()}";
+
+        describe("handle an alternate childrenPath", function () {
+            var treeController;
+
+            it("initialize unexpanded per default", function () {
+                treeController = new TreeController();
+                treeController.childrenPath = childrenPath;
+                treeController.content = tree;
+                expect(treeController.iterations.map(function (iteration) {
+                    return iteration.getPath("content.value");
+                })).toEqual([10]);
+            });
+
+            it("show immediate children only on expanding the root", function () {
+                treeController.root.expanded = true;
+                expect(treeController.iterations.map(function (iteration) {
+                    return iteration.getPath("content.value");
+                })).toEqual([10, 20, 40]);
+            });
+
+            it("show the left node's children", function () {
+                treeController.root.children[0].expanded = true;
+                expect(treeController.iterations.map(function (iteration) {
+                    return iteration.getPath("content.value");
+                })).toEqual([10, 20, 30, 40]);
+            });
+
+            it("show the right node's children", function () {
+                treeController.root.children[1].expanded = true;
+                expect(treeController.iterations.map(function (iteration) {
+                    return iteration.getPath("content.value");
+                })).toEqual([10, 20, 30, 40, 50]);
+            });
+
+            it("show only the root if the root is collapsed", function () {
+                treeController.root.expanded = false;
+                expect(treeController.iterations.map(function (iteration) {
+                    return iteration.getPath("content.value");
+                })).toEqual([10]);
+            });
+
+            it("retain the inner expansion state when expanded again", function () {
+                treeController.root.expanded = true;
+                expect(treeController.iterations.map(function (iteration) {
+                    return iteration.getPath("content.value");
+                })).toEqual([10, 20, 30, 40, 50]);
+            });
+        });
+
+        it("be configurable as expanded", function () {
+            var treeController = new TreeController();
+            treeController.childrenPath = childrenPath;
+            treeController.content = tree;
+            treeController.allExpanded = true;
+
+            expect(treeController.iterations.map(function (iteration) {
+                return iteration.getPath("content.value");
+            })).toEqual([10, 20, 30, 40, 50]);
+        });
 
     });
 


### PR DESCRIPTION
-   Add `initiallyExpanded` configuration property.
-   As an alternative to simply rendering a tree with indentation depth,
  add support for drawing junctions at each indentation depth of each
  row of the tree.
-   Make the tree controller react properly to changes to the underlying
  content (tree model).  Produce a separate TreeControllerNode hierarchy
  (tree view-model) for each content root, so expanded/collapsed state is
  preserved independently for each content root.  Use a WeakMap so the
  TreeController only tracks the view-model for content that still exists.
  
  This is accomplished by making a thin TreeController wrapper class that
  tracks roots for each content and forwards its configuration properties
  (childrenPath, initiallyExpanded) to each root, and mirrors the current
  root's iterations array.
-   Make insensitive to the order in which configuration properties are set.
-   Remove distinction between a tree controller iteration and a tree
  controller node.  Tree controller nodes now serve as iterations.
-   JSDoc'd.
-   Judgement calls made on what is private and public.

Two poke-and-prod tests included:
-   ui/tree-test/tree-test.html Provides a tree editor and tree view (with ASCII
  junctions).  The viewer and editor share a single tree controller.
-   ui/tree-test/splay-test.html Provides a view of the internal state of a
  SortedSet, which is a splay tree.  This demo illustrates that it is
  possible to create a reactive view of arbitrary existing tree data
  structures with an appropriate `childrenPath` FRB expression.
  
  It also demonstrates a pretty huge memory leak, which I have yet to
  isolate.
