### PR TITLE
Use more sensible text coercion operator in TextField

### DIFF
--- a/ui/base/abstract-text-field.js
+++ b/ui/base/abstract-text-field.js
@@ -2,7 +2,8 @@
 var Montage = require("montage").Montage,
     AbstractControl = require("ui/base/abstract-control").AbstractControl,
     KeyComposer = require("composer/key-composer").KeyComposer,
-    Dict = require("collections/dict");
+    Dict = require("collections/dict"),
+    Operators = require("frb/operators");
 
 var CLASS_PREFIX = "montage-TextField";
 
@@ -120,7 +121,7 @@ var AbstractTextField = exports.AbstractTextField = AbstractControl.specialize(
 
     draw: {
         value: function() {
-            this.element.value = this.value;
+            this.element.value = Operators.string(this.value);
             if (this.placeholderValue != null) {
                 this.element.setAttribute("placeholder", this.placeholderValue);
             }


### PR DESCRIPTION
The TextField would coerce objects, null, and undefined with the
JavaScript convention. This is not a good user experience in general, so
I've reused the string coercion operator from FRB, which translates
these all to an empty string.
