### PR TITLE
Name constructors of most types

### DIFF
--- a/core/application.js
+++ b/core/application.js
@@ -419,7 +419,7 @@ var Application = exports.Application = Target.specialize( /** @lends Applicatio
      @private
      */
     constructor: {
-        value: function() {
+        value: function Application() {
             if (window.loadInfo && !this.parentApplication) {
                 this.parentApplication = window.loadInfo.parent.document.application;
             }

--- a/core/bitfield.js
+++ b/core/bitfield.js
@@ -46,6 +46,12 @@ var Montage = require("montage").Montage;
  */
 var BitField = exports.BitField = Montage.specialize( /** @lends BitField */ {
 
+    constructor: {
+        value: function BitField() {
+            this.super();
+        }
+    },
+
     /**
      Creates a new BitField object containing the fields provided in the propertyDescriptor parameter.
      @function

--- a/core/document-part.js
+++ b/core/document-part.js
@@ -10,6 +10,12 @@ var DocumentPart = Montage.specialize( {
     childComponents: {value: null},
     parameters: {value: null},
 
+    constructor: {
+        value: function DocumentPart() {
+            this.super();
+        }
+    },
+
     initWithTemplateAndFragment: {
         value: function(template, fragment) {
             this.template = template;

--- a/core/document-resources.js
+++ b/core/document-resources.js
@@ -7,6 +7,12 @@ var DocumentResources = Montage.specialize({
     _resources: {value: null},
     _preloaded: {value: null},
 
+    constructor: {
+        value: function DocumentResources() {
+            this.super();
+        }
+    },
+
     initWithDocument: {
         value: function(_document) {
             this.clear();

--- a/core/enum.js
+++ b/core/enum.js
@@ -46,6 +46,13 @@ exports.Enum = Montage.specialize( /** @lends Enum# */ {
     _value: {
         value: 0
     },
+
+    constructor: {
+        value: function Enum() {
+            this.super();
+        }
+    },
+
 /**
     @function
     @returns itself

--- a/core/exception.js
+++ b/core/exception.js
@@ -61,6 +61,13 @@ var Exception = exports.Exception = Montage.specialize(/** @lends Exception# */ 
     method: {
         value: null
     },
+
+    constructor: {
+        value: function Exception() {
+            this.super();
+        }
+    },
+
    /**
     @function
     @param {String} message The message to be initialized.

--- a/core/gate.js
+++ b/core/gate.js
@@ -40,6 +40,13 @@ var Montage = require("montage").Montage,
  @extends Montage
  */
 var Gate = exports.Gate = Montage.specialize(/** @lends Gate# */ {
+
+    constructor: {
+        value: function Gate() {
+            this.super();
+        }
+    },
+
 /**
     @function
     @returns {Gate} A new Gate instance.

--- a/core/localizer.js
+++ b/core/localizer.js
@@ -47,6 +47,12 @@ var reLanguageTagValidator = /^[a-zA-Z]+(?:-[a-zA-Z0-9]+)*$/;
 */
 var Localizer = exports.Localizer = Montage.specialize( /** @lends Localizer# */ {
 
+    constructor: {
+        value: function Localizer() {
+            this.super()
+        }
+    },
+
     /**
         Initialize the localizer.
         @function

--- a/core/logger.js
+++ b/core/logger.js
@@ -114,6 +114,13 @@ consoleLogMontage = function() {
  * @extends Montage
  */
 Logger = exports.Logger = Montage.specialize(/** @lends Logger# */ {
+
+    constructor: {
+        value: function Logger() {
+            this.super();
+        }
+    },
+
    /**
     @function
     @param {String} name The name of the logger.
@@ -266,6 +273,12 @@ exports.logger = function(loggerName, onStateChange, dontStoreState) {
 };
 
 LoggerUI = Montage.specialize( /** @lends LoggerUI# */{
+
+    constructor: {
+        value: function LoggerUI() {
+            this.super();
+        }
+    },
 
     init: {
         value: function() {

--- a/core/media-controller.js
+++ b/core/media-controller.js
@@ -712,10 +712,15 @@ var MediaController = exports.MediaController = Target.specialize( /** @lends Me
             this.mediaElement.addEventListener('emptied', this, false);
             this.mediaElement.addEventListener('ended', this, false);
         }
-    }
+    },
     /*-----------------------------------------------------------------------------
      MARK:   Configuration
      -----------------------------------------------------------------------------*/
 
+     constructor: {
+         value: function MediaController() {
+             this.super();
+         }
+     }
 
 });

--- a/core/object-controller.js
+++ b/core/object-controller.js
@@ -39,6 +39,13 @@ var Montage = require("montage").Montage;
  @extends Montage
  */
 var ObjectController = exports.ObjectController = Montage.specialize( /** @lends ObjectController# */ {
+
+    constructor: {
+        value: function ObjectController() {
+            this.super();
+        }
+    },
+
 /**
         @type {Property}
         @default null

--- a/core/promise-controller.js
+++ b/core/promise-controller.js
@@ -28,7 +28,7 @@ var Promise = require("core/promise").Promise;
 var PromiseController = exports.PromiseController = Montage.specialize( {
 
     constructor: {
-        value: function () {
+        value: function PromiseController() {
             this.reset = null;
             this.addOwnPropertyChangeListener("promise", this);
             this.promise = null;

--- a/core/radio-button-controller.js
+++ b/core/radio-button-controller.js
@@ -2,6 +2,7 @@ var Montage = require("montage").Montage,
     RangeController = require("core/range-controller").RangeController;
 
 exports.RadioButtonController = Montage.specialize( {
+
     _radioButtons: {
         value: null
     },
@@ -48,7 +49,7 @@ exports.RadioButtonController = Montage.specialize( {
      * @private
      */
     constructor: {
-        value: function () {
+        value: function RadioButtonController() {
             this._radioButtons = [];
 
             this.addRangeAtPathChangeListener("_radioButtons.map{checked}", this, "handleRadioButtonChange");

--- a/core/range-controller.js
+++ b/core/range-controller.js
@@ -49,7 +49,7 @@ var RangeController = exports.RangeController = Montage.specialize( {
      * @private
      */
     constructor: {
-        value: function () {
+        value: function RangeController() {
 
             this.content = null;
             this._selection = [];

--- a/core/selector.js
+++ b/core/selector.js
@@ -12,6 +12,12 @@ var Selector = exports.Selector = Montage.specialize( {
         value: null
     },
 
+    constructor: {
+        value: function Selector() {
+            this.super();
+        }
+    },
+
     initWithSyntax: {
         value: function (syntax) {
             this.syntax = syntax;

--- a/core/state-chart.js
+++ b/core/state-chart.js
@@ -44,6 +44,13 @@ var State = exports.State = Montage.specialize( /** @lends State# */{
         enumerable: false,
         value: null
     },
+
+    constructor: {
+        value: function State() {
+            this.super();
+        }
+    },
+
 /**
     Initializes a State object with a set of options.
     @function

--- a/core/target.js
+++ b/core/target.js
@@ -10,6 +10,12 @@ var Montage = require("montage").Montage,
  */
 exports.Target = Montage.specialize( {
 
+    constructor: {
+        value: function Target() {
+            this.super();
+        }
+    },
+
     /**
      * Whether or not this target can accept user focus and become the activeTarget
      * This matches up with the <code>document.activeElement</code> property purpose-wise;

--- a/core/template.js
+++ b/core/template.js
@@ -83,6 +83,12 @@ var Template = Montage.specialize( {
         }
     },
 
+    constructor: {
+        value: function Template() {
+            this.super();
+        }
+    },
+
     /**
      * Initializes the Template with an empty document.
      *
@@ -1165,7 +1171,7 @@ var TemplateResources = Montage.specialize( {
     rootUrl: {value: ""},
 
     constructor: {
-        value: function() {
+        value: function TemplateResources() {
             this._resources = Object.create(null);
         }
     },

--- a/core/undo-manager.js
+++ b/core/undo-manager.js
@@ -196,7 +196,7 @@ var UndoManager = exports.UndoManager = Target.specialize( /** @lends UndoManage
     },
 
     constructor: {
-        value: function () {
+        value: function UndoManager() {
             this._operationQueue = [];
             this._promiseOperationMap = new Map();
             this._undoStack = new List();

--- a/ui/condition.reel/condition.js
+++ b/ui/condition.reel/condition.js
@@ -63,6 +63,13 @@ exports.Condition = Component.specialize( /** @lends Condition# */ {
     _contents: {
         value: null
     },
+
+    constructor: {
+        value: function Condition() {
+            this.super();
+        }
+    },
+
 /**
         @type {Function}
         @default null

--- a/ui/flow.reel/flow-bezier-spline.js
+++ b/ui/flow.reel/flow-bezier-spline.js
@@ -4,7 +4,7 @@ var Montage = require("montage").Montage;
 var FlowBezierSpline = exports.FlowBezierSpline = Montage.specialize( {
 
     constructor: {
-        value: function () {
+        value: function FlowBezierSpline() {
             this._knots = [];
             this._densities = [];
         }

--- a/ui/flow.reel/flow-translate-composer.js
+++ b/ui/flow.reel/flow-translate-composer.js
@@ -9,6 +9,12 @@ var Montage = require("montage").Montage,
  */
 var FlowTranslateComposer = exports.FlowTranslateComposer = TranslateComposer.specialize( {
 
+    constructor: {
+        value: function FlowTranslateComposer() {
+            this.super();
+        }
+    },
+
     _scrollingMode: {
         value: "linear"
     },

--- a/ui/flow.reel/flow.js
+++ b/ui/flow.reel/flow.js
@@ -41,8 +41,8 @@ var Flow = exports.Flow = Component.specialize( {
      * @private
      */
     constructor: {
-        value: function () {
-            Component.constructor.call(this); // super
+        value: function Flow() {
+            this.super();
             // The template has a binding from these visibleIndexes to
             // the frustrum controller's visibleIndexes.  We manage the
             // array within the flow and use it also in the flow

--- a/ui/loader.reel/loader.js
+++ b/ui/loader.reel/loader.js
@@ -54,6 +54,12 @@ var Montage = require("core/core").Montage,
 
 exports.Loader = Component.specialize( /** @lends Loader# */ {
 
+    constructor: {
+        value: function Loader() {
+            this.super();
+        }
+    },
+
     // Configuration Properties
 
 /**

--- a/ui/overlay.reel/overlay.js
+++ b/ui/overlay.reel/overlay.js
@@ -123,7 +123,8 @@ exports.Overlay = Component.specialize( /** @lends module:Overlay# */ {
     },
 
     constructor: {
-        value: function() {
+        value: function Overlay() {
+            this.super();
             this._pressComposer = new PressComposer();
         }
     },

--- a/ui/repetition.reel/repetition.js
+++ b/ui/repetition.reel/repetition.js
@@ -118,7 +118,7 @@ var Iteration = exports.Iteration = Montage.specialize( {
      * @private
      */
     constructor: {
-        value: function () {
+        value: function Repetition() {
             this.super();
 
             this.repetition = null;

--- a/ui/slot.reel/slot.js
+++ b/ui/slot.reel/slot.js
@@ -47,8 +47,8 @@ exports.Slot = Component.specialize( /** @lends Slot# */ {
     },
 
     constructor: {
-        value: function() {
-            Component.constructor.call(this);
+        value: function Slot() {
+            this.super();
             this.content = null;
         }
     },

--- a/ui/text.reel/text.js
+++ b/ui/text.reel/text.js
@@ -12,6 +12,12 @@ var Montage = require("montage").Montage,
  */
 exports.Text = Component.specialize( /** @lends Text# */ {
 
+    constructor: {
+        value: function Text() {
+            this.super();
+        }
+    },
+
     hasTemplate: {
         value: false
     },


### PR DESCRIPTION
In a way, explicit constructors are bloat, but naming the constructors
gives the instances visible names in the debugger, which has been
invaluable.
