### PR TITLE
Use latest API for enabling long stack traces in Q

### DIFF
--- a/montage.js
+++ b/montage.js
@@ -665,7 +665,7 @@ if (typeof window !== "undefined") {
 
                 // Setup Promise's longStackTrace support option
                 logger("Promise stacktrace support", function(state) {
-                    Promise.longStackJumpLimit = state ? 1 : 0;
+                    Promise.longStackSupport = !!state;
                 });
 
                 // Load the event-manager


### PR DESCRIPTION
API changed in Q 0.9.5
