### PR TITLE
Fix translateComposer translateEnd on pointerStart

### DIFF
--- a/composer/translate-composer.js
+++ b/composer/translate-composer.js
@@ -449,7 +449,10 @@ var TranslateComposer = exports.TranslateComposer = Composer.specialize(/** @len
                 document.addEventListener("mouseup", this, true);
                 this._element.addEventListener("mousemove", this, false);
             }
-            this.isAnimating = false;
+            if (this.isAnimating) {
+                this.isAnimating = false;
+                this._dispatchTranslateEnd();
+            }
             this._isFirstMove = true;
         }
     },


### PR DESCRIPTION
This fix dispatches a translateEnd event when a pointer starts and a
previous momentum animation has not ended yet.

This was causing problems with components like Scroller, that hide
scrollbars based on translateStart and translateEnd events.
