### PR TITLE
Fix getInfoForObject to not change the Object prototype

### DIFF
--- a/core/core.js
+++ b/core/core.js
@@ -787,6 +787,14 @@ Montage.defineProperty(Montage, "getInfoForObject", {
             } else {
                 instanceMetadataDescriptor = _instanceMetadataDescriptor;
             }
+
+            // don't modify the Object prototype, because this will cause
+            // future calls to Montage.getInfoForObject on objects without
+            // their own _montage_metadata property to return this one
+            if (object === Object.prototype) {
+                return Object.create(metadata, instanceMetadataDescriptor);
+            }
+
             try {
                 return Object.defineProperty(object, "_montage_metadata", {
                     enumerable: false,

--- a/test/core/core-require-spec.js
+++ b/test/core/core-require-spec.js
@@ -79,5 +79,18 @@ function() {
             expect(info.isInstance).toBeFalsy();
             expect(info.moduleId).toBe("core/testobjects");
         });
+
+        it("should not be added to the Object constructor", function () {
+            Montage.getInfoForObject(Object.prototype);
+
+            var instance = new objects.Simple();
+            var info = Montage.getInfoForObject(instance);
+
+            expect(info.objectName).toBe("Simple");
+            expect(info.isInstance).toBeTruthy();
+            expect(info.moduleId).toBe("core/testobjects");
+
+            expect(Object.prototype.hasOwnProperty("_montage_metadata")).toBe(false);
+        });
     });
 });

--- a/test/core/testobjects.js
+++ b/test/core/testobjects.js
@@ -33,12 +33,12 @@ var Montage = require("montage").Montage;
 var Simple = exports.Simple = Montage.specialize( {
     simple: {value: null},
     prototypeUuid: {value: "a"}
-}, module);
+});
 
 var Proto = exports.Proto = Montage.specialize( {
     proto: {value: null},
     prototypeUuid: {value: "b"}
-}, module);
+});
 
 var FunkyProto = exports.FunkyProto = Montage.specialize( {
     firstUuid: {value: null},
@@ -48,7 +48,7 @@ Montage.getInfoForObject(FunkyProto);
 var SubProto = exports.SubProto = Proto.specialize( {
     subProto: {value: null},
     prototypeUuid: {value: "c"}
-}, module);
+});
 
 var Funktion = exports.Funktion = function() {
     this.foo = function() {

--- a/test/run.js
+++ b/test/run.js
@@ -33,6 +33,7 @@ require("montage-testing").run(require,[
         "composer/translate-composer/translate-composer-spec",
 
         "core/core-spec",
+        "core/core-require-spec",
         "core/dom-spec",
         "core/localizer-spec",
         "core/localizer/serialization-spec",


### PR DESCRIPTION
to prevent calling `getInfoForObject` on `Object.prototype` from creating
`_montage_metadata` and causing future calls on objects that don't
have _montage_metadata to return that empty object.
