### PR TITLE
Fix flow selection bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "collections": "~0.1.23",
-    "frb": "~0.2.10",
+    "frb": "~0.2.11",
     "mousse": "~0.1.2",
     "htmlparser2": "~3.0.5"
   },

--- a/ui/repetition.reel/repetition.js
+++ b/ui/repetition.reel/repetition.js
@@ -129,7 +129,7 @@ var Iteration = exports.Iteration = Montage.specialize({
             // is drawn, it enqueue's selection change draw operations and
             // notifies the repetition it needs to be redrawn.
             // Dispatches handlePropertyChange with the "selected" key:
-            this.defineBinding("selected", {
+            this.defineBinding("content.defined() ? selected : null", {
                 "<->": "repetition.contentController._selection.has(content)"
             });
             // An iteration can be "on" or "off" the document.  When the


### PR DESCRIPTION
Previously, when playing Hide and Seek with a selected iteration in a
Flow, the hidden iteration would automatically become deselected.  It is
now possible to play Hide and Seek with a Flow again.

Note that this fix requires an uprev of FRB to support the conditional null binding.
