### PR TITLE
Allow activeTarget to refuse to surrender

### DIFF
--- a/core/event/event-manager.js
+++ b/core/event/event-manager.js
@@ -2195,6 +2195,12 @@ var EventManager = exports.EventManager = Montage.specialize(/** @lends EventMan
      *
      * This is particularly useful for things such as keyboard shortcuts or
      * menuAction events.
+     *
+     * Prior to setting the activeTarget manually the desired target should
+     * be checked to see if it `acceptsActiveTarget`. In the course of then
+     * setting that target as the activeTarget, the current activeTarget
+     * will be instructed to `surrendersActiveTarget`. If the activeTarget
+     * refuses to surrender, the change is rejected.
      */
     activeTarget: {
         get: function () {
@@ -2206,12 +2212,8 @@ var EventManager = exports.EventManager = Montage.specialize(/** @lends EventMan
                 value = this.application;
             }
 
-            if (value === this._activeTarget) {
+            if (value === this._activeTarget || (this.activeTarget && !this.activeTarget.surrendersActiveTarget(value))) {
                 return;
-            }
-
-            if (this.activeTarget) {
-                this.activeTarget.willSurrenderActiveTarget(value);
             }
 
             value.willBecomeActiveTarget(this.activeTarget);

--- a/core/target.js
+++ b/core/target.js
@@ -54,11 +54,15 @@ exports.Target = Montage.specialize( {
     },
 
     /**
-     * Called prior to this target surrendering the activeTarget
+     * Ask this target to surrender its activeTarget status
+     *
      * @param {Target} newTarget the Target that is about to become the activeTarget
+     * @return {Boolean} Whether or not to surrender activeTarget status
      */
-    willSurrenderActiveTarget: {
-        value: Function.noop
+    surrendersActiveTarget: {
+        value: function (newTarget) {
+            return true;
+        }
     },
 
     /**

--- a/test/events/active-target-spec.js
+++ b/test/events/active-target-spec.js
@@ -50,12 +50,22 @@ TestPageLoader.queueTest("active-target-test/active-target-test", function(testP
 
                 describe("activeTarget template methods", function () {
 
-                    it("should invoke willSurrenderActiveTarget before losing activeTarget status", function () {
+                    it("should invoke surrendersActiveTarget before losing activeTarget status", function () {
                         eventManager.activeTarget = proximalComponent;
-                        spyOn(proximalComponent, "willSurrenderActiveTarget");
+                        spyOn(proximalComponent, "surrendersActiveTarget");
 
                         eventManager.activeTarget = null;
-                        expect(proximalComponent.willSurrenderActiveTarget).toHaveBeenCalled();
+                        expect(proximalComponent.surrendersActiveTarget).toHaveBeenCalled();
+                    });
+
+                    it("must reject changing the activeTarget if the current activeTarget refuses to surrender", function () {
+                        eventManager.activeTarget = proximalComponent;
+                        spyOn(proximalComponent, "surrendersActiveTarget").andCallFake(function () {
+                            return false;
+                        });
+
+                        eventManager.activeTarget = null;
+                        expect(eventManager.activeTarget).toBe(proximalComponent);
                     });
 
                     it("should invoke willBecomeActiveTarget before gaining activeTarget status", function () {


### PR DESCRIPTION
This affords some more flexibility in manually setting the activeTarget
without worrying about disrupting the current activeTarget situation;
the activeTarget can refuse if it's undesirable.
