### PR TITLE
Make more use of `super` near property observers

### DIFF
--- a/core/bindings.js
+++ b/core/bindings.js
@@ -2,8 +2,9 @@
 var Montage = require("core/core").Montage;
 
 var Bindings = exports.Bindings = require("frb");
+var PropertyChanges = require("collections/listen/property-changes");
 
-var bindingPropertyDescriptors = {
+Montage.defineProperties(Montage.prototype, {
 
     defineBinding: {
         value: function (targetPath, descriptor, commonDescriptor) {
@@ -39,8 +40,11 @@ var bindingPropertyDescriptors = {
         value: function () {
             return Bindings.getBindings(this);
         }
+    },
+
+    makePropertyObservable: {
+        value: PropertyChanges.prototype.makePropertyObservable
     }
 
-};
-Montage.defineProperties(Montage, bindingPropertyDescriptors);
-Montage.defineProperties(Montage.prototype, bindingPropertyDescriptors);
+});
+

--- a/core/paths.js
+++ b/core/paths.js
@@ -11,6 +11,7 @@ var bind = require("frb/bind");
 var compileObserver = require("frb/compile-observer");
 var Scope = require("frb/scope");
 var Observers = require("frb/observers");
+var observeProperty = Observers.observeProperty;
 var autoCancelPrevious = Observers.autoCancelPrevious;
 
 var pathChangeDescriptors = new WeakMap();
@@ -47,6 +48,12 @@ var pathPropertyDescriptors = {
             var syntax = parse(path);
             var observe = compileObserver(syntax);
             return observe(autoCancelPrevious(emit), new Scope(this));
+        }
+    },
+
+    observeProperty: {
+        value: function (name, emit, scope) {
+            return observeProperty(this, name, emit, scope);
         }
     },
 

--- a/test/ui/draw/list.reel/list.js
+++ b/test/ui/draw/list.reel/list.js
@@ -4,8 +4,7 @@
     @requires montage/ui/component
 */
 var Montage = require("montage").Montage,
-    Component = require("montage/ui/component").Component,
-    observeProperty = require("montage/frb/observers").observeProperty;
+    Component = require("montage/ui/component").Component;
 
 /**
  @class module:"matte/ui/list.reel".List
@@ -74,13 +73,13 @@ var List = exports.List = Component.specialize(/** @lends module:"matte/ui/list.
     // into the repetition, not the list
 
     observeProperty: {
-        value: function (key, emit, scope) {
-            if (key === "objectAtCurrentIteration" || key === "currentIteration") {
+        value: function (name, emit, scope) {
+            if (name === "objectAtCurrentIteration" || name === "currentIteration") {
                 if (this._repetition) {
-                    return this._repetition.observeProperty(key, emit, scope);
+                    return this._repetition.observeProperty(name, emit, scope);
                 }
             } else {
-                return observeProperty(this, key, emit, scope);
+                return this.super(name, emit, scope);
             }
         }
     }

--- a/ui/flow.reel/flow.js
+++ b/ui/flow.reel/flow.js
@@ -31,7 +31,6 @@ POSSIBILITY OF SUCH DAMAGE.
 
 var Montage = require("montage").Montage,
     Component = require("ui/component").Component,
-    observeProperty = require("frb/observers").observeProperty,
     FlowBezierSpline = require("ui/flow.reel/flow-bezier-spline").FlowBezierSpline,
     RangeController = require("core/range-controller").RangeController;
 
@@ -1368,17 +1367,17 @@ var Flow = exports.Flow = Component.specialize( {
      * @private
      */
     observeProperty: {
-        value: function (key, emit, scope) {
+        value: function (name, emit, scope) {
             if (
-                key === "currentIteration" ||
-                key === "objectAtCurrentIteration" ||
-                key === "contentAtCurrentIteration"
+                name === "currentIteration" ||
+                name === "objectAtCurrentIteration" ||
+                name === "contentAtCurrentIteration"
             ) {
                 if (this._repetition) {
                     return this._repetition.observeProperty(key, emit, scope);
                 }
             } else {
-                return observeProperty(this, key, emit, scope);
+                return this.super(name, emit, scope);
             }
         }
     },

--- a/ui/repetition.reel/repetition.js
+++ b/ui/repetition.reel/repetition.js
@@ -8,7 +8,6 @@ var Map = require("collections/map");
 var Set = require("collections/set");
 
 var Observers = require("frb/observers");
-var observeProperty = Observers.observeProperty;
 var observeKey = Observers.observeKey;
 
 /**
@@ -1079,8 +1078,8 @@ var Repetition = exports.Repetition = Component.specialize(/** @lends Repetition
      * @private
      */
     observeProperty: {
-        value: function (key, emit, scope) {
-            if (key === "contentAtCurrentIteration" || key === "objectAtCurrentIteration") {
+        value: function (name, emit, scope) {
+            if (name === "contentAtCurrentIteration" || name === "objectAtCurrentIteration") {
                 // delegate to the mapping from iterations to content for the
                 // current iteration
                 return observeKey(
@@ -1089,14 +1088,14 @@ var Repetition = exports.Repetition = Component.specialize(/** @lends Repetition
                     emit,
                     scope
                 );
-            } else if (key === "currentIteration") {
+            } else if (name === "currentIteration") {
                 // Shortcut since this property is sticky -- won't change in
                 // the course of instantiating an iteration and should not
                 // dispatch a change notification when we instantiate the next.
                 return emit(this.currentIteration);
             } else {
                 // fall back to normal property observation
-                return observeProperty(this, key, emit, scope);
+                return this.super(name, emit, scope);
             }
         }
     },
@@ -1109,9 +1108,9 @@ var Repetition = exports.Repetition = Component.specialize(/** @lends Repetition
      * @private
      */
     makePropertyObservable: {
-        value: function (key) {
-            if (key !== "currentIteration") {
-                return Montage.makePropertyObservable.call(this, key);
+        value: function (name) {
+            if (name !== "currentIteration") {
+                return this.super(name);
             }
         }
     },


### PR DESCRIPTION
This change introduces `observeProperty` and `makePropertyObservable` to
the Montage prototype and makes use of them through `super` where
eligible.
