### PR TITLE
Optimize repetition iteration control for set

### DIFF
--- a/core/range-controller.js
+++ b/core/range-controller.js
@@ -78,6 +78,7 @@ var RangeController = exports.RangeController = Montage.specialize( {
             // The _orderedContent variable is a necessary intermediate stage
             // From which visibleIndexes plucks visible values.
             this.organizedContent = [];
+            // dispatches handleOrganizedContentRangeChange
             this.organizedContent.addRangeChangeListener(this, "organizedContent");
             this.defineBinding("_orderedContent", {
                 "<-": "content" +

--- a/ui/flow.reel/flow.js
+++ b/ui/flow.reel/flow.js
@@ -1053,7 +1053,7 @@ var Flow = exports.Flow = Component.specialize( {
             // Add new values to the end if the visible indexes have grown
             for (j = oldIndexesLength; i < newVisibleIndexes.length; i++) {
                 if (newVisibleIndexes[i] !== null) {
-                    oldVisibleIndexes.set(j,  newVisibleIndexes[i]);
+                    oldVisibleIndexes.set(j, newVisibleIndexes[i]);
                     j++;
                 }
             }


### PR DESCRIPTION
We encountered a performance problem in the interaction between Flow and
Repetition. The Flow updates the visible indexes of the repetition
during the draw cycle, and was found to be taking an exobitant amount of
time.  The visible indexes updates occur as a sequence of calls to `set`
on `visibleIndexes`, each of which propagates a call to
`handleOrganizedContentRangeChange` on the repetition, updating the
value at a single index.  As such, it is possible to bypass the check
for whether enough iterations have been created (none will be created or
destroyed), and possible to avoid splicing the iteration in and out.
This optimization just changes the bound content for the existing
iterations in place.

A previous revision of Repetition, before the integration of bindings,
certainly did contain this optimization.
