### PR TITLE
requestAnimationFrame/cancelAnimationFrame to use unprefixed versions

### DIFF
--- a/ui/component.js
+++ b/ui/component.js
@@ -2774,7 +2774,8 @@ var RootComponent = Component.specialize( /** @lends RootComponent# */{
      * @function
      */
     requestAnimationFrame: {
-        value: (window.webkitRequestAnimationFrame ? window.webkitRequestAnimationFrame : window.mozRequestAnimationFrame),
+        value: (window.requestAnimationFrame || window.webkitRequestAnimationFrame 
+             || window.mozRequestAnimationFrame ||  window.msRequestAnimationFrame),
         enumerable: false
     },
 
@@ -2783,7 +2784,8 @@ var RootComponent = Component.specialize( /** @lends RootComponent# */{
      * @function
      */
     cancelAnimationFrame: {
-        value: (window.webkitCancelRequestAnimationFrame ? window.webkitCancelRequestAnimationFrame : window.mozCancelRequestAnimationFrame),
+        value: (window.cancelAnimationFrame ||  window.webkitCancelAnimationFrame 
+             || window.mozCancelAnimationFrame || window.msCancelAnimationFrame),
         enumerable: false
     },
 


### PR DESCRIPTION
The unprefixed window.requestAnimationFrame and window.cancelAnimationFrame methods has been added in Firefox 23.

This is a patch proposal to make component.js prefer the unprefixed versions of these methods in requestAnimationFrame and cancelAnimationFrame. This also removes the support for the old prefixed cancelRequestAnimationFrame in favor of cancelAnimationFrame.
