### PR TITLE
Increase fault tolerance of range change listeners

### DIFF
--- a/core/paths.js
+++ b/core/paths.js
@@ -64,7 +64,9 @@ var pathPropertyDescriptors = {
             }
             var minus = [];
             return this.addPathChangeListener(path, function (plus) {
-                plus = plus || [];
+                if (!plus || !plus.addRangeChangeListener) {
+                    plus = [];
+                }
                 // Give copies to avoid modification by the listener.
                 dispatch(plus.slice(), minus.slice(), 0);
                 minus = plus;


### PR DESCRIPTION
This change allows a range change listener to tolerate invalid input,
which is a common occurrence as bindings become eventually consistent.
