### PR TITLE
All translate* events should have the same shape.

### DIFF
--- a/composer/translate-composer.js
+++ b/composer/translate-composer.js
@@ -821,6 +821,8 @@ var TranslateComposer = exports.TranslateComposer = Composer.specialize(/** @len
             translateStartEvent.initCustomEvent("translateStart", true, true, null);
             translateStartEvent.translateX = x;
             translateStartEvent.translateY = y;
+            // Event needs to be the same shape as the one in flow-translate-composer
+            translateStartEvent.scroll = 0;
             this.dispatchEvent(translateStartEvent);
         }
     },
@@ -832,6 +834,8 @@ var TranslateComposer = exports.TranslateComposer = Composer.specialize(/** @len
             translateEndEvent.initCustomEvent("translateEnd", true, true, null);
             translateEndEvent.translateX = this._translateX;
             translateEndEvent.translateY = this._translateY;
+            // Event needs to be the same shape as the one in flow-translate-composer
+            translateEndEvent.scroll = 0;
             this.dispatchEvent(translateEndEvent);
         }
     },
@@ -842,6 +846,8 @@ var TranslateComposer = exports.TranslateComposer = Composer.specialize(/** @len
             translateEvent.initCustomEvent("translate", true, true, null);
             translateEvent.translateX = this._translateX;
             translateEvent.translateY = this._translateY;
+            // Event needs to be the same shape as the one in flow-translate-composer
+            translateEvent.scroll = 0;
             this.dispatchEvent(translateEvent);
         }
     },

--- a/ui/flow.reel/flow-translate-composer.js
+++ b/ui/flow.reel/flow-translate-composer.js
@@ -196,6 +196,8 @@ var FlowTranslateComposer = exports.FlowTranslateComposer = TranslateComposer.sp
 
             translateEndEvent.initCustomEvent("translateEnd", true, true, null);
             translateEndEvent.scroll = this._scroll;
+            translateEndEvent.translateX = 0;
+            translateEndEvent.translateY = 0;
             this.dispatchEvent(translateEndEvent);
         }
     },
@@ -208,6 +210,8 @@ var FlowTranslateComposer = exports.FlowTranslateComposer = TranslateComposer.sp
             var translateEvent = document.createEvent("CustomEvent");
             translateEvent.initCustomEvent("translate", true, true, null);
             translateEvent.scroll = this._scroll;
+            translateEvent.translateX = 0;
+            translateEvent.translateY = 0;
             this.dispatchEvent(translateEvent);
         }
     },


### PR DESCRIPTION
- Because we cache MutableEvent prototypes for each event type, any events of the same type must have the exact same properties.
- Long-term, we need to fix that FlowTranslateComposer should throw different events from FlowComposer.
- And maybe consider if there's a way to corect the cached prototype when the same event name includes different properties.
