### PR TITLE
TranslateComposer can be disabled

### DIFF
--- a/composer/translate-composer.js
+++ b/composer/translate-composer.js
@@ -37,8 +37,8 @@ var TranslateComposer = exports.TranslateComposer = Composer.specialize(/** @len
     },
 
     // When set to true, do not respond to events, claim pointers, or prevent default
-    disabled: {
-        value: false
+    enabled: {
+        value: true
     },
 
     _externalUpdate: {
@@ -480,7 +480,7 @@ var TranslateComposer = exports.TranslateComposer = Composer.specialize(/** @len
 
     captureMousedown: {
         value: function(event) {
-            if (this.disabled) return;
+            if (!this.enabled) return;
 
             if (event.button !== 0) {
                 return;
@@ -502,7 +502,7 @@ var TranslateComposer = exports.TranslateComposer = Composer.specialize(/** @len
     */
     handleMousedown: {
         value: function(event) {
-            if (this.disabled) return;
+            if (!this.enabled) return;
 
             if (event.button === 0 && !this.eventManager.componentClaimingPointer(this._observedPointer)) {
                 this.eventManager.claimPointer(this._observedPointer, this);
@@ -515,7 +515,7 @@ var TranslateComposer = exports.TranslateComposer = Composer.specialize(/** @len
     // initially
     handleMousemove: {
         value: function(event) {
-            if (this.disabled) return;
+            if (!this.enabled) return;
 
             if (this.eventManager.isPointerClaimedByComponent(this._observedPointer, this)) {
                 event.preventDefault();
@@ -533,7 +533,7 @@ var TranslateComposer = exports.TranslateComposer = Composer.specialize(/** @len
 
     captureMousemove: {
         value: function(event) {
-            if (this.disabled) return;
+            if (!this.enabled) return;
 
             if (this.eventManager.isPointerClaimedByComponent(this._observedPointer, this)) {
                 event.preventDefault();
@@ -551,7 +551,7 @@ var TranslateComposer = exports.TranslateComposer = Composer.specialize(/** @len
 
     captureMouseup: {
         value: function(event) {
-            if (this.disabled) return;
+            if (!this.enabled) return;
 
             this._end(event);
         }
@@ -587,7 +587,7 @@ var TranslateComposer = exports.TranslateComposer = Composer.specialize(/** @len
 
     captureTouchstart: {
         value: function(event) {
-            if (this.disabled) return;
+            if (!this.enabled) return;
             
             // If already scrolling, ignore any new touchstarts
             if (this._observedPointer !== null && this.eventManager.isPointerClaimedByComponent(this._observedPointer, this)) {
@@ -603,7 +603,7 @@ var TranslateComposer = exports.TranslateComposer = Composer.specialize(/** @len
 
     handleTouchstart: {
         value: function(event) {
-            if (this.disabled) return;
+            if (!this.enabled) return;
             
             if (!this.eventManager.componentClaimingPointer(this._observedPointer)) {
                 if (event.targetTouches && event.targetTouches.length === 1) {
@@ -621,7 +621,7 @@ var TranslateComposer = exports.TranslateComposer = Composer.specialize(/** @len
     // initially
     handleTouchmove: {
         value: function(event) {
-            if (this.disabled) return;
+            if (!this.enabled) return;
             
             if (this.eventManager.isPointerClaimedByComponent(this._observedPointer, this)) {
                 event.preventDefault();
@@ -640,7 +640,7 @@ var TranslateComposer = exports.TranslateComposer = Composer.specialize(/** @len
 
     captureTouchmove: {
         value: function(event) {
-            if (this.disabled) return;
+            if (!this.enabled) return;
 
             var i = 0, len = event.changedTouches.length;
             while (i < len && event.changedTouches[i].identifier !== this._observedPointer) {
@@ -661,7 +661,7 @@ var TranslateComposer = exports.TranslateComposer = Composer.specialize(/** @len
 
     captureTouchend: {
         value: function(event) {
-            if (this.disabled) return;
+            if (!this.enabled) return;
             
             var i = 0, len = event.changedTouches.length;
             while (i < len && event.changedTouches[i].identifier !== this._observedPointer) {
@@ -751,7 +751,7 @@ var TranslateComposer = exports.TranslateComposer = Composer.specialize(/** @len
 
     handleWheel: {
         value: function(event) {
-            if (this.disabled) return;
+            if (!this.enabled) return;
             
             var self = this;
 


### PR DESCRIPTION
When the TranslateComposer is disabled, it no longer claims pointers, prevents default, etc. This is useful if it is attached to a Scroller component which may, dynamically, not need to scroll. Disabling the TranslateComposer enables touches, mousewheels, etc. to bubble up and be handled on a parent component or the default browser behavior. 

This is used in the matte pull request to disable TranslateComposer when the scroller doesn't need to scroll: https://github.com/montagejs/matte/pull/23
