### PR TITLE
Stop adding components to the draw list...

### DIFF
--- a/ui/component.js
+++ b/ui/component.js
@@ -676,7 +676,8 @@ var Component = exports.Component = Target.specialize(/** @lends module:montage/
                 childComponent._prepareForEnterDocument();
                 childComponent._parentComponent = this;
 
-                if (childComponent.needsDraw) {
+                if (childComponent.needsDraw &&
+                    !this.rootComponent.isComponentWaitingNeedsDraw(childComponent)) {
                     childComponent._addToParentsDrawList();
                 }
             }
@@ -2642,6 +2643,14 @@ var RootComponent = Component.specialize( /** @lends RootComponent# */{
                 window.clearTimeout(this._clearNeedsDrawTimeOut);
                 this._clearNeedsDrawTimeOut = null;
             }
+        }
+    },
+
+    // TODO: implement this with a flag on the component
+    isComponentWaitingNeedsDraw: {
+        value: function(component) {
+            return component.uuid in this._cannotDrawList ||
+                this._needsDrawList.indexOf(component) >= 0;
         }
     },
 


### PR DESCRIPTION
...when they shouldn't.
When adding component A as the child component of component B we always add component A to component B's draw list if component A needs to draw.
This was a mistake if component A blocked the draw and was waiting for the root component to add it to component B's draw list. This was making component A to draw when it shouldn't.

This fix is just temporary as it's more expensive than it should.
It also lacks tests.
