### PR TITLE
Implement multiple attribute

### DIFF
--- a/ui/base/abstract-select.js
+++ b/ui/base/abstract-select.js
@@ -63,6 +63,9 @@ var AbstractSelect = exports.AbstractSelect = AbstractControl.specialize( /** @l
             // Need to draw when "content" or "values" change
             this.addRangeAtPathChangeListener("content", this, "handleContentRangeChange");
             this.addRangeAtPathChangeListener("values", this, "handleValuesRangeChange");
+
+            this.addOwnPropertyChangeListener("multiple", this);
+
             this.classList.add("matte-Select");
         }
     },
@@ -150,6 +153,10 @@ var AbstractSelect = exports.AbstractSelect = AbstractControl.specialize( /** @l
         value: false
     },
 
+    multiple: {
+        value: false
+    },
+
     _contentIsDirty: {
         value: true
     },
@@ -225,11 +232,23 @@ var AbstractSelect = exports.AbstractSelect = AbstractControl.specialize( /** @l
         }
     },
 
+    handleMultipleChange: {
+        value: function() {
+            this.needsDraw = true;
+        }
+    },
+
     enterDocument: {
         value: function(firstDraw) {
             if(firstDraw) {
                 this.element.setAttribute("role", "listbox");
             }
+        }
+    },
+
+    draw: {
+        value: function() {
+            this.element.multiple = this.multiple;
         }
     }
 });


### PR DESCRIPTION
Needed by montagejs/matte#27.

abstract-select.js currently doesn’t set element.multiple attribute.

I implemented 'multiple' that was used by montagejs/native. Later I realized that abstract-select already has 'multiSelect' property which however doesn’t change element.multiple.

Should I keep only multiSelect and make it change element.multiple?  
If so, should it change element.multiple in abstract-select.js or in Matte & Digit? I’m thinking the former to avoid code duplication.
