### PR TITLE
Increase tolerance of addRangeAtPathChangeListener

### DIFF
--- a/core/paths.js
+++ b/core/paths.js
@@ -64,11 +64,16 @@ var pathPropertyDescriptors = {
             }
             var minus = [];
             return this.addPathChangeListener(path, function (plus) {
-                plus = plus || [];
-                // Give copies to avoid modification by the listener.
-                dispatch(plus.slice(), minus.slice(), 0);
-                minus = plus;
-                return plus.addRangeChangeListener(dispatch);
+                if (plus && plus.toArray && plus.addRangeChangeListener) {
+                    // Give copies to avoid modification by the listener.
+                    dispatch(plus.toArray(), minus.toArray(), 0);
+                    minus = plus;
+                    return plus.addRangeChangeListener(dispatch);
+                } else {
+                    plus = [];
+                    dispatch(plus, minus, 0);
+                    minus = plus;
+                }
             });
         }
     },

--- a/test/paths-spec.js
+++ b/test/paths-spec.js
@@ -1,5 +1,6 @@
 
 var Montage = require("montage").Montage;
+var Map = require("montage/collections/map");
 
 describe("paths-spec", function () {
 
@@ -238,41 +239,88 @@ describe("paths-spec", function () {
             object.array.clear();
             foos.clear();
             expect(spy).wasNotCalled();
-
         });
 
     });
 
     describe("addRangeAtPathChangeListener", function () {
+        it("should watch for changes to an array at a path", function () {
+            var object = new Montage();
 
-        var object = new Montage();
+            var spy = jasmine.createSpy();
+            object.addRangeAtPathChangeListener("array", function (plus, minus, index) {
+                // slice gets rid of the observability prototype
+                spy(plus.slice(), minus.slice(), index);
+            });
+            expect(spy).toHaveBeenCalledWith([], [], 0);
 
-        var spy = jasmine.createSpy();
-        object.addRangeAtPathChangeListener("array", function (plus, minus, index) {
-            // slice gets rid of the observability prototype
-            spy(plus.slice(), minus.slice(), index);
+            spy = jasmine.createSpy();
+            object.array = [1];
+            expect(spy).toHaveBeenCalledWith([1], [], 0);
+
+            spy = jasmine.createSpy();
+            object.array.push(2);
+            expect(spy).toHaveBeenCalledWith([2], [], 1);
+
+            spy = jasmine.createSpy();
+            object.array.shift();
+            expect(object.array.slice()).toEqual([2]);
+            expect(spy).toHaveBeenCalledWith([], [1], 0);
+
+            spy = jasmine.createSpy();
+            object.array = ['a', 'b'];
+            expect(spy).toHaveBeenCalledWith(['a', 'b'], [2], 0);
+
+            object.array = [];
+            expect(spy).toHaveBeenCalledWith([], ['a', 'b'], 0);
         });
-        expect(spy).toHaveBeenCalledWith([], [], 0);
 
-        spy = jasmine.createSpy();
-        object.array = [1];
-        expect(spy).toHaveBeenCalledWith([1], [], 0);
+        it("should handle transient nully input", function () {
+            var object = new Montage();
 
-        spy = jasmine.createSpy();
-        object.array.push(2);
-        expect(spy).toHaveBeenCalledWith([2], [], 1);
+            var spy = jasmine.createSpy();
+            object.addRangeAtPathChangeListener("array", function (plus, minus, index) {
+                // slice gets rid of the observability prototype
+                spy(plus.slice(), minus.slice(), index);
+            });
+            expect(spy).toHaveBeenCalledWith([], [], 0);
 
-        spy = jasmine.createSpy();
-        object.array.shift();
-        expect(object.array.slice()).toEqual([2]);
-        expect(spy).toHaveBeenCalledWith([], [1], 0);
+            spy = jasmine.createSpy();
+            object.array = [1];
+            expect(spy).toHaveBeenCalledWith([1], [], 0);
 
-        spy = jasmine.createSpy();
-        object.array = ['a', 'b'];
-        expect(spy).toHaveBeenCalledWith(['a', 'b'], [2], 0);
+            spy = jasmine.createSpy();
+            object.array = {0: 'a', 1: 'b', length: 2};
+            expect(spy).toHaveBeenCalledWith([], [1], 0);
 
-        object.array = [];
-        expect(spy).toHaveBeenCalledWith([], ['a', 'b'], 0);
+            spy = jasmine.createSpy();
+            object.array = ['a', 'b'];
+            expect(spy).toHaveBeenCalledWith(['a', 'b'], [], 0);
+        });
+
+        it("should handle transient map input", function () {
+            var object = new Montage();
+
+            var spy = jasmine.createSpy();
+            object.addRangeAtPathChangeListener("array", function (plus, minus, index) {
+                // slice gets rid of the observability prototype
+                spy(plus.slice(), minus.slice(), index);
+            });
+            expect(spy).toHaveBeenCalledWith([], [], 0);
+
+            spy = jasmine.createSpy();
+            object.array = [1];
+            expect(spy).toHaveBeenCalledWith([1], [], 0);
+
+            spy = jasmine.createSpy();
+            object.array = new Map({bogus: 'fogus'});
+            expect(spy).toHaveBeenCalledWith([], [1], 0);
+
+            spy = jasmine.createSpy();
+            object.array = ['a', 'b'];
+            expect(spy).toHaveBeenCalledWith(['a', 'b'], [], 0);
+        });
+
     });
 
     describe("addRangeAtPathChangeListener II", function() {
@@ -316,5 +364,4 @@ describe("paths-spec", function () {
     });
 
 });
-
 


### PR DESCRIPTION
This addresses a problem where the value at the end of a path passes
ephemerally through an invalid state for a range change listener, for
example listening for range changes on the "array" property, when the
property is temporarily a Map or null, until some other binding settles.
