### PR TITLE
Prevent text selection while dragging slider

### DIFF
--- a/ui/base/abstract-slider.js
+++ b/ui/base/abstract-slider.js
@@ -160,6 +160,7 @@ var AbstractSlider = exports.AbstractSlider = AbstractControl.specialize( /** @l
         value: function (e) {
             this.active = true;
             this.element.focus();
+            e.preventDefault();
         }
     },
 


### PR DESCRIPTION
Fixes montagejs/digit#37 "Slider: text gets selected while dragging the knob". The problem only persists in Safari. Chrome and Firefox are good.

http://screencast.com/t/mV5eytQyBJ

Is `e.preventDefault()` the Montage way of doing it?
