### PR TITLE
Suggested fix for overlay test failures.

### DIFF
--- a/test/mocks/component.js
+++ b/test/mocks/component.js
@@ -88,6 +88,8 @@ exports.rootComponent = function (_document) {
     defaultEventManager.registerEventHandlerForElement(component, _document);
     component.element = _document;
     component.drawTree = function() {};
+    component.rootComponent = component;
+    component.isComponentWaitingNeedsDraw = function() { return false; }
 
     return component;
 };


### PR DESCRIPTION
The combination of the [Overlay work](https://github.com/montagejs/montage/pull/1299) and @aadsm's [work on draw](https://github.com/montagejs/montage/commit/4af44d85fced9a0c54fab62e541a016b72d36a26) causes test failures:

```
TypeError: Cannot call method 'isComponentWaitingNeedsDraw' of undefined
at Object.exports.Component.Target.specialize.addChildComponent.value [as addChildComponent] (http://localhost/declarativ/declarativ/montage/ui/component.js:680:41)
at Overlay.exports.Component.Target.specialize.attachToParentComponent.value (http://localhost/declarativ/declarativ/montage/ui/component.js:713:33)
at Overlay.exports.Overlay.Component.specialize.enterDocument.value (http://localhost/declarativ/declarativ/montage/ui/overlay.reel/overlay.js:155:22)
at eval (http://localhost/declarativ/declarativ/montage/test/ui/overlay-spec.js:19:19)
```

The problem appears to be that the mocks for component and rootComponent do not have the rootComponent property or the new isComponentWaitingNeedsDraw method.

The PR contains one possible fix, but there are other options:
1. Implement isComponentWaitingNeedsDraw more realistically.
2. Make overlay specs into functional rather than unit tests, using montage-testing to get a real rootComponent
