### PR TITLE
The generated JSDoc should not have so many erroneous globals

### DIFF
--- a/core/core.js
+++ b/core/core.js
@@ -1098,11 +1098,11 @@ Montage.defineProperty(Montage, "equals", {
     value: Montage.prototype.equals
 });
 
-/*
+/**
     This method calls the method named with the identifier prefix if it exists.
     Example: If the name parameter is "shouldDoSomething" and the caller's identifier is "bob", then
     this method will try and call "bobShouldDoSomething"
-    @function callDelegateMethod
+    @function Montage.callDelegateMethod
     @param {string} name
 */
 Montage.defineProperty(Montage.prototype, "callDelegateMethod", {

--- a/core/meta/module-blueprint.js
+++ b/core/meta/module-blueprint.js
@@ -7,7 +7,11 @@ var ModuleReference = require("core/module-reference").ModuleReference;
 // Cache all loaded blueprints
 var BLUEPRINT_CACHE = Object.create(null);
 
-var ModuleBlueprint = exports.ModuleBlueprint = Blueprint.specialize({
+/**
+ * @class ModuleBlueprint
+ * @extends Blueprint
+ */
+var ModuleBlueprint = exports.ModuleBlueprint = Blueprint.specialize(/** @lends ModuleBlueprint# */ {
 
     /**
      @function
@@ -78,7 +82,7 @@ var ModuleBlueprint = exports.ModuleBlueprint = Blueprint.specialize({
         value: null
     }
 
-}, {
+}, /** @lends ModuleBlueprint. */ {
     /**
      Gets a blueprint from a serialized file at the given module id.
      @function

--- a/core/module-reference.js
+++ b/core/module-reference.js
@@ -1,6 +1,10 @@
 var Montage = require("montage").Montage;
 
-exports.ModuleReference = Montage.specialize({
+/**
+ * @class ModuleReference
+ * @extends Montage
+ */
+exports.ModuleReference = Montage.specialize( /** @lends ModuleReference */ {
     constructor: {
         value: function ModuleReference() {
             return this.super();

--- a/core/range-controller.js
+++ b/core/range-controller.js
@@ -24,6 +24,9 @@ var GenericCollection = require("collections/generic-collection");
 // the same position.
 
 /**
+ * @class RangeController
+ * @extends Montage
+ *
  * A <code>RangeController</code> receives a <code>content</code> collection,
  * manages what portition of that content is visible and the order of its
  * appearance (<code>organizedContent</code>), and projects changes to the the
@@ -43,7 +46,7 @@ var GenericCollection = require("collections/generic-collection");
  * The <code>RangeController</code> is also responsible for managing which
  * content is selected and provides a variety of knobs for that purpose.
  */
-var RangeController = exports.RangeController = Montage.specialize( {
+var RangeController = exports.RangeController = Montage.specialize( /** @lends RangeController# */ {
 
     /**
      * @private

--- a/core/serialization/deserializer/montage-reviver.js
+++ b/core/serialization/deserializer/montage-reviver.js
@@ -76,7 +76,10 @@ var ModuleLoader = Montage.specialize( {
     }
 });
 
-var MontageReviver = exports.MontageReviver = Montage.specialize.call(Reviver, {
+/**
+ * @class MontageReviver
+ */
+var MontageReviver = exports.MontageReviver = Montage.specialize.call(Reviver, /** @lends MontageReviver# */ {
     moduleLoader: {value: null},
 
     /**
@@ -368,7 +371,7 @@ var MontageReviver = exports.MontageReviver = Montage.specialize.call(Reviver, {
         }
     }
 
-}, {
+}, /** @lends MontageReviver. */ {
     _unitRevivers: {value: Object.create(null)},
     _unitNames: {value: []},
 

--- a/core/serialization/serialization.js
+++ b/core/serialization/serialization.js
@@ -4,7 +4,10 @@ var Montage = require("core/core").Montage,
     parse = require("frb/parse"),
     stringify = require("frb/stringify");
 
-var Serialization = Montage.specialize( {
+/**
+ * @class Serialization
+ */
+var Serialization = Montage.specialize( /** @lends Serialization# */ {
     _serializationString: {value: null},
     _serializationObject: {value: null},
 
@@ -159,7 +162,10 @@ var Serialization = Montage.specialize( {
     }
 });
 
-var SerializationMerger = Montage.specialize(null, {
+/**
+ * @class SerializationMerger
+ */
+var SerializationMerger = Montage.specialize(null, /** @lends SerializationMerger. */ {
     /**
      * Merges serialization2 into serialization1.
      *
@@ -235,7 +241,11 @@ var SerializationMerger = Montage.specialize(null, {
     }
 });
 
-var SerializationInspector = Montage.specialize( {
+
+/**
+ * @class SerializationInspector
+ */
+var SerializationInspector = Montage.specialize(/** @lends SerializationInspector# */ {
     initWithSerialization: {
         value: function(serialization) {
             this._serialization = serialization;
@@ -299,6 +309,7 @@ var SerializationInspector = Montage.specialize( {
     },
 
     /**
+     * @private
      * @param parentObject {Object} The parent object of the object to walk
      * @param key {String} The key of the object in the parent object
      * @param label {String} Optional label for when the object has no
@@ -534,6 +545,7 @@ var SerializationInspector = Montage.specialize( {
 
     /**
      * Visits all object references made in the binding parsing tree
+     * @private
      */
     _walksBindingReferences: {
         value: function(parseTree, visitor) {
@@ -552,7 +564,11 @@ var SerializationInspector = Montage.specialize( {
     }
 });
 
-var SerializationExtractor = Montage.specialize( {
+
+/**
+ * @class SerializationExtractor
+ */
+var SerializationExtractor = Montage.specialize( /** @lends SerializationExtractor# */ {
     _serialization: {value: null},
 
     initWithSerialization: {

--- a/core/serialization/serializer/montage-ast.js
+++ b/core/serialization/serializer/montage-ast.js
@@ -2,11 +2,10 @@ var Montage = require("montage").Montage;
 var Value = require("mousse/serialization/ast").Value;
 
 /**
- * ElementReference
- *
+ * @class ElementReference
  * @extends Value
  */
-var ElementReference = Montage.specialize.call(Value, {
+var ElementReference = Montage.specialize.call(Value, /** @lends ElementReference# */ {
 
     constructor: {
         value: function ElementReference() {}
@@ -27,11 +26,10 @@ var ElementReference = Montage.specialize.call(Value, {
 });
 
 /**
- * ModuleReference
- *
+ * @class ModuleReference
  * @extends Value
  */
-var ModuleReference = Montage.specialize.call(Value, {
+var ModuleReference = Montage.specialize.call(Value, /** @lends ModuleReference# */ {
 
     constructor: {
         value: function ModuleReference() {}

--- a/core/serialization/serializer/montage-builder.js
+++ b/core/serialization/serializer/montage-builder.js
@@ -4,10 +4,9 @@ var MontageAst = require("./montage-ast");
 
 /**
  * ElementReference
- *
- * @extends Value
+ * @class MontageBuilder
  */
-var MontageBuilder = Montage.specialize.call(Builder, {
+var MontageBuilder = Montage.specialize.call(Builder, /** @lends MontageBuilder# */ {
     constructor: {
         value: function MontageBuilder() {
             Builder.call(this);

--- a/core/target.js
+++ b/core/target.js
@@ -6,9 +6,9 @@ var Montage = require("montage").Montage,
  * A Target is any object that can be a candidate for dispatching and receiving events
  * throughout what is typically considered the "component tree" of a Montage application.
  *
- * @type {Target}
+ * @class Target
  */
-exports.Target = Montage.specialize( {
+exports.Target = Montage.specialize( /** @lends Target# */ {
 
     constructor: {
         value: function Target() {

--- a/core/template.js
+++ b/core/template.js
@@ -10,7 +10,11 @@ var Montage = require("montage").Montage,
     defaultEventManager = require("core/event/event-manager").defaultEventManager,
     defaultApplication;
 
-var Template = Montage.specialize( {
+/**
+ * @class Template
+ * @extends Montage
+ */
+var Template = Montage.specialize( /** @lends Template# */ {
     _SERIALIZATON_SCRIPT_TYPE: {value: "text/montage-serialization"},
     _ELEMENT_ID_ATTRIBUTE: {value: "data-montage-id"},
     PARAM_ATTRIBUTE: {value: "data-param"},
@@ -1212,7 +1216,11 @@ var Template = Montage.specialize( {
 
 });
 
-var TemplateResources = Montage.specialize( {
+/**
+ * @class TemplateResources
+ * @extends Montage
+ */
+var TemplateResources = Montage.specialize( /** @lends TemplateResources# */ {
     _resources: {value: null},
     _resourcesLoaded: {value: false},
     template: {value: null},

--- a/core/tree-controller.js
+++ b/core/tree-controller.js
@@ -3,16 +3,18 @@ var Montage = require("core/core").Montage;
 var Map = require("collections/map");
 var WeakMap = require("collections/weak-map");
 
-// A tree controller is a view-model that tracks whether each node in a
-// corresponding data-model is expanded or collapsed.  It also produces a
-// linearization of the visible iterations, transforming hierachical nesting
-// into a flat, incrementally-updated array of iterations with the
-// corresponding indentation depth.
-
-// Bind a root node from the data model to a tree controller and bind the tree
-// controller's iterations to a content controller for a repetition.
-
-var Node = exports.TreeControllerNode = Montage.specialize({
+/**
+ * @class TreeControllerNode
+ * @extends Montage
+ * @description A tree controller is a view-model that tracks whether each node in a
+ * corresponding data-model is expanded or collapsed.  It also produces a
+ * linearization of the visible iterations, transforming hierachical nesting
+ * into a flat, incrementally-updated array of iterations with the
+ * corresponding indentation depth.
+ * Bind a root node from the data model to a tree controller and bind the tree
+ * controller's iterations to a content controller for a repetition.
+ */
+var Node = exports.TreeControllerNode = Montage.specialize( /** @lends TreeControllerNode# */ {
 
     /**
      * The only meaningful user-defined state for this tree view, whether the
@@ -258,7 +260,11 @@ var Node = exports.TreeControllerNode = Montage.specialize({
 
 });
 
-exports.TreeController = Montage.specialize({
+
+/**
+ * @class TreeController
+ */
+exports.TreeController = Montage.specialize( /** @lends TreeController# */ {
 
     /**
      * The input of a tree controller, an object to serve at the root of the
@@ -394,7 +400,7 @@ exports.TreeController = Montage.specialize({
     },
 
     /**
-     * The type of the tree controller's nodes.
+     * @type TreeControllerNode
      */
     Node: {
         value: Node

--- a/ui/base/abstract-button.js
+++ b/ui/base/abstract-button.js
@@ -72,6 +72,7 @@ var AbstractButton = exports.AbstractButton = AbstractControl.specialize( /** @l
      * @type {boolean}
      * @default false
      * @event longpress
+     * @memberof AbstractButton
      */
     preventFocus: {
         get: function () {

--- a/ui/base/abstract-checkbox.js
+++ b/ui/base/abstract-checkbox.js
@@ -9,7 +9,7 @@ var CLASS_PREFIX = "montage-Checkbox";
  * @class AbstractCheckbox
  * @extends AbstractControl
  */
-var AbstractCheckbox = exports.AbstractCheckbox = AbstractControl.specialize( /* @lends AbstractCheckbox# */ {
+var AbstractCheckbox = exports.AbstractCheckbox = AbstractControl.specialize( /** @lends AbstractCheckbox# */ {
     /**
      * Dispatched when the checkbox is activated through a mouse click,
      * finger tap, or when focused and the spacebar is pressed.

--- a/ui/base/abstract-link.js
+++ b/ui/base/abstract-link.js
@@ -1,8 +1,5 @@
 /*global require, exports, document, Error*/
 
-/**
- * It's dangerous to go alone! Take this.
- */
 var Montage = require("montage").Montage,
     AbstractControl = require("ui/base/abstract-control").AbstractControl,
     PressComposer = require("composer/press-composer").PressComposer;
@@ -14,7 +11,7 @@ var CLASS_PREFIX = "montage-Link";
  * @extends AbstractControl
  */
 var AbstractLink = exports.AbstractLink = AbstractControl.specialize(
-/* @lends AbstractLink# */
+/** @lends AbstractLink# */
 {
     /**
      * Dispatched when the link is activated through a mouse click,

--- a/ui/base/abstract-number-field.js
+++ b/ui/base/abstract-number-field.js
@@ -11,7 +11,7 @@ var CLASS_PREFIX = "montage-NumberField";
  * @extends AbstractControl
  */
 var AbstractNumberField = exports.AbstractNumberField = AbstractControl.specialize(
-    /* @lends AbstractNumberField# */
+    /** @lends AbstractNumberField# */
 {
 
     // Lifecycle

--- a/ui/base/abstract-radio-button.js
+++ b/ui/base/abstract-radio-button.js
@@ -11,7 +11,7 @@ var CLASS_PREFIX = "montage-RadioButton";
  * @extends AbstractControl
  */
 var AbstractRadioButton = exports.AbstractRadioButton = AbstractControl.specialize(
-    /* @lends AbstractRadioButton# */
+    /** @lends AbstractRadioButton# */
 {
     /**
      * Dispatched when the radio button is activated through a mouse click,

--- a/ui/base/abstract-text-area.js
+++ b/ui/base/abstract-text-area.js
@@ -10,7 +10,7 @@ var CLASS_PREFIX = "montage-TextArea";
  * @extends Component
  */
 var AbstractTextArea = exports.AbstractTextArea = Component.specialize(
-    /* @lends AbstractTextArea# */
+    /** @lends AbstractTextArea# */
 {
     constructor: {
         value: function AbstractTextArea() {

--- a/ui/base/abstract-text-field.js
+++ b/ui/base/abstract-text-field.js
@@ -11,7 +11,7 @@ var CLASS_PREFIX = "montage-TextField";
  * @extends AbstractControl
  */
 var AbstractTextField = exports.AbstractTextField = AbstractControl.specialize(
-    /* @lends AbstractTextField# */
+    /** @lends AbstractTextField# */
 {
     /**
      * Dispatched when the textfield is activated through a enter.

--- a/ui/flow.reel/flow-translate-composer.js
+++ b/ui/flow.reel/flow-translate-composer.js
@@ -4,10 +4,11 @@ var Montage = require("montage").Montage,
     Point = require("core/geometry/point").Point,
     convertPointFromPageToNode = require("core/dom").convertPointFromPageToNode;
 
-// TODO doc
 /**
+ * @class FlowTranslateComposer
+ * @extends TranslateComposer
  */
-var FlowTranslateComposer = exports.FlowTranslateComposer = TranslateComposer.specialize( {
+var FlowTranslateComposer = exports.FlowTranslateComposer = TranslateComposer.specialize( /** @lends FlowTranslateComposer# */ {
 
     constructor: {
         value: function FlowTranslateComposer() {

--- a/ui/flow.reel/flow.js
+++ b/ui/flow.reel/flow.js
@@ -35,7 +35,12 @@ var Montage = require("montage").Montage,
     FlowBezierSpline = require("ui/flow.reel/flow-bezier-spline").FlowBezierSpline,
     RangeController = require("core/range-controller").RangeController;
 
-var Flow = exports.Flow = Component.specialize( {
+
+/**
+ * @class Flow
+ * @extends Component
+ */
+var Flow = exports.Flow = Component.specialize( /** @lends Flow# */ {
 
     /**
      * @private

--- a/ui/repetition.reel/repetition.js
+++ b/ui/repetition.reel/repetition.js
@@ -16,8 +16,10 @@ var observeKey = Observers.observeKey;
  * corresponds to a value from the contentController.  When an iteration is
  * drawn, it is tied to the corresponding controller-model that carries which
  * object the iteration is coupled to, and whether it is selected.
+ *
+ * @class Iteration
  */
-var Iteration = exports.Iteration = Montage.specialize({
+var Iteration = exports.Iteration = Montage.specialize( /** @lends Iteration# */ {
 
     /**
      * The parent repetition component.


### PR DESCRIPTION
[Before](montagejs.org/api/global.html).

After: 
![after](https://f.cloud.github.com/assets/55838/1338971/bfcdd854-35f3-11e3-8703-04a3cddcb923.png)

I don’t know where to put [exports.resolve](https://github.com/montagejs/montage/blob/master/core/url.js#L331) and exports.relative. They are not global yet they don’t belong to any class. I’m open to suggestions.
