### PR TITLE
Fix issue with capturing the pointer in touch

### DIFF
--- a/composer/press-composer.js
+++ b/composer/press-composer.js
@@ -190,18 +190,7 @@ var PressComposer = exports.PressComposer = Composer.specialize(/** @lends Press
             var i = 0, changedTouchCount;
 
             if (event.type === "touchstart") {
-                changedTouchCount = event.changedTouches.length;
-                for (; i < changedTouchCount; i++) {
-                    if (!this.component.eventManager.componentClaimingPointer(event.changedTouches[i].identifier)) {
-                        this._observedPointer = event.changedTouches[i].identifier;
-                        break;
-                    }
-                 }
-
-                if (this._observedPointer === null) {
-                    // All touches have been claimed
-                    return false;
-                }
+                this._observedPointer = event.changedTouches[0].identifier;
 
                 document.addEventListener("touchend", this, false);
                 document.addEventListener("touchcancel", this, false);

--- a/test/composer/press-composer-spec.js
+++ b/test/composer/press-composer-spec.js
@@ -211,5 +211,60 @@ TestPageLoader.queueTest("press-composer-test/press-composer-test", function(tes
                 });
             });
         });
+
+        describe("Nested PressComposers", function() {
+            beforeEach(function() {
+                test.outer_press_composer._endInteraction();
+                test.inner_press_composer._endInteraction();
+            });
+
+            it("should fire pressStart for both composers", function() {
+                var inner_listener = testPage.addListener(test.inner_press_composer, null, "pressStart"),
+                    outer_listener = testPage.addListener(test.outer_press_composer, null, "pressStart");
+
+                if (window.Touch) {
+                    testPage.touchEvent({target: test.innerComponent.element}, "touchstart");
+                    testPage.touchEvent({target: test.innerComponent.element}, "touchend");
+                } else {
+                    testPage.mouseEvent({target: test.innerComponent.element}, "mousedown");
+                    testPage.mouseEvent({target: test.innerComponent.element}, "mouseup");
+                }
+
+                expect(inner_listener).toHaveBeenCalled();
+                expect(outer_listener).toHaveBeenCalled();
+            });
+
+            it("should fire press for inner composer", function() {
+                var inner_listener = testPage.addListener(test.inner_press_composer, null, "press"),
+                    outer_listener = testPage.addListener(test.outer_press_composer, null, "press");
+
+                if (window.Touch) {
+                    testPage.touchEvent({target: test.innerComponent.element}, "touchstart");
+                    testPage.touchEvent({target: test.innerComponent.element}, "touchend");
+                } else {
+                    testPage.mouseEvent({target: test.innerComponent.element}, "mousedown");
+                    testPage.mouseEvent({target: test.innerComponent.element}, "mouseup");
+                }
+
+                expect(inner_listener).toHaveBeenCalled();
+                expect(outer_listener).not.toHaveBeenCalled();
+            });
+
+            it("should fire pressCancel for outer composer", function() {
+                var inner_listener = testPage.addListener(test.inner_press_composer, null, "pressCancel"),
+                    outer_listener = testPage.addListener(test.outer_press_composer, null, "pressCancel");
+
+                if (window.Touch) {
+                    testPage.touchEvent({target: test.innerComponent.element}, "touchstart");
+                    testPage.touchEvent({target: test.innerComponent.element}, "touchend");
+                } else {
+                    testPage.mouseEvent({target: test.innerComponent.element}, "mousedown");
+                    testPage.mouseEvent({target: test.innerComponent.element}, "mouseup");
+                }
+
+                expect(outer_listener).toHaveBeenCalled();
+                expect(inner_listener).not.toHaveBeenCalled();
+            });
+        });
     });
 });

--- a/test/composer/press-composer-test/press-composer-test.html
+++ b/test/composer/press-composer-test/press-composer-test.html
@@ -50,11 +50,43 @@ POSSIBILITY OF SUCH DAMAGE.
         }
     },
 
+    "outerComponent": {
+        "prototype": "montage/ui/component",
+        "properties": {
+            "hasTemplate": false,
+            "element": {"#": "outerComponent"}
+        }
+    },
+    "outer_press_composer": {
+        "prototype": "montage/composer/press-composer",
+        "properties": {
+            "component": {"@": "outerComponent"}
+        }
+    },
+
+    "innerComponent": {
+        "prototype": "montage/ui/component",
+        "properties": {
+            "hasTemplate": false,
+            "element": {"#": "innerComponent"}
+        }
+    },
+    "inner_press_composer": {
+        "prototype": "montage/composer/press-composer",
+        "properties": {
+            "component": {"@": "innerComponent"}
+        }
+    },
+
     "test": {
         "prototype": "composer/press-composer-test/press-composer-test",
         "properties": {
             "press_composer": {"@": "press_composer"},
-            "example": {"@": "example"}
+            "example": {"@": "example"},
+            "outerComponent": {"@": "outerComponent"},
+            "innerComponent": {"@": "innerComponent"},
+            "inner_press_composer": {"@": "inner_press_composer"},
+            "outer_press_composer": {"@": "outer_press_composer"}
         }
     },
     "application": {
@@ -73,6 +105,18 @@ POSSIBILITY OF SUCH DAMAGE.
         width: 50px;
         height: 50px;
     }
+
+    .outerComponent {
+        position: absolute;
+        width: 100px;
+        height: 100px;
+    }
+
+    .innerComponent {
+        position: absolute;
+        width: 50px;
+        height: 50px;
+    }
 </style>
 
 </head>
@@ -80,5 +124,9 @@ POSSIBILITY OF SUCH DAMAGE.
     <h1>Press Composer test</h1>
 
     <div data-montage-id="example" class="example"></div>
+
+    <div data-montage-id="outerComponent" class="outerComponent">
+        <div data-montage-id="innerComponent" class="innerComponent"></div>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
:warning: Do not merge yet!

When two or more PressComposers were in play during a touchstart only the first one (the outer one) would capture the pointer. The others would just ignore it because the pointer was already captured.
This was preventing the inner most PressComposer to capture the pointer and handle it, which is the desired behavior.

This doesn't happen on mouse interactions because all PressComposers capture the pointer even if someone has already captured it before.
