### PR TITLE
Uprev Collections and FRB

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     }
   },
   "dependencies": {
-    "collections": "~0.2.0",
-    "frb": "~0.2.14",
+    "collections": "~0.2.1",
+    "frb": "~0.2.15",
     "mousse": "~0.1.2",
     "htmlparser2": "~3.0.5"
   },


### PR DESCRIPTION
This addresses a bug in Collections impacts FRB and all MontageJS
applications on Chrome 30.  Chrome 30 introduces ES6 Array methods,
`keys`, `values`, and `entries`, which breaks an invariant that map
collection constructors depended upon: that these methods would only
exist on map-alike collections excluding Array.  Collections now depends
on an `isMap` property on all map-alike collections except Array to
distinguish a map from an array of entries.
