### PR TITLE
KeyComposer targeting fix

### DIFF
--- a/core/event/key-manager.js
+++ b/core/event/key-manager.js
@@ -760,7 +760,9 @@ var KeyManager = exports.KeyManager = Montage.specialize(/** @lends KeyManager# 
                     }
                 }
 
-                if (!onTarget) {
+                // Most components can't receive key events directly: the events target the window,
+                // but we should also fire them on composers of the activeTarget component
+                if (!onTarget && defaultEventManager.activeTarget != keyComposer.component) {
                     continue;
                 }
 

--- a/test/composer/key-composer-spec.js
+++ b/test/composer/key-composer-spec.js
@@ -85,6 +85,26 @@ TestPageLoader.queueTest("key-composer-test/key-composer-test", function(testPag
                     expect(test.keyReleaseCalled).toBeFalsy();
                 });
             });
+
+            describe("interacting with activeTarget", function() {
+                it("should fire window key events on composers of the activeTarget", function() {
+                    var target = test.example.element,
+                        listener1 = testPage.addListener(test.key_composer1, null, "keyPress"),
+                        listener2 = testPage.addListener(test.key_composer1, null, "longKeyPress"),
+                        listener3 = testPage.addListener(test.key_composer1, null, "keyRelease");
+
+                    testPage.window.montageRequire("core/event/event-manager").defaultEventManager.activeTarget = test.example;
+
+                    testPage.keyEvent({target: testPage.window, modifiers: command, charCode: 0, keyCode: "J".charCodeAt(0)}, "keydown");
+                    waits(1050);
+                    runs(function(){
+                        testPage.keyEvent({target: testPage.window, modifiers: command, charCode: 0, keyCode: "J".charCodeAt(0)}, "keyup");
+                        expect(listener1).toHaveBeenCalled();
+                        expect(listener2).toHaveBeenCalled();
+                        expect(listener3).toHaveBeenCalled();
+                    });
+                });
+            });
         });
     });
 });


### PR DESCRIPTION
KeyComposer now triggers events on itself. KeyManager is smart enough to also trigger events on KeyComposers of the activeTarget, even if they aren't in the dom hierarchy for the event.
