### PR TITLE
Steal children pointer in Flow

### DIFF
--- a/ui/flow.reel/flow-translate-composer.js
+++ b/ui/flow.reel/flow-translate-composer.js
@@ -16,6 +16,10 @@ var FlowTranslateComposer = exports.FlowTranslateComposer = TranslateComposer.sp
         }
     },
 
+    stealChildrenPointer: {
+        value: true
+    },
+
     _scrollingMode: {
         value: "linear"
     },


### PR DESCRIPTION
This allows to scroll if you are on top of a clickable element inside
a Flow
