### PR TITLE
Update overlay.js

### DIFF
--- a/ui/overlay.reel/overlay.js
+++ b/ui/overlay.reel/overlay.js
@@ -440,7 +440,7 @@ exports.Overlay = Component.specialize( /** @lends Overlay# */ {
         value: function() {
             var dismissEvent = document.createEvent("CustomEvent");
 
-            dismissEvent.initCustomEvent("dismiss", true, true);
+            dismissEvent.initCustomEvent("dismiss", true, true, null);
 
             this.dispatchEvent(dismissEvent);
         }


### PR DESCRIPTION
In Firefox prevents a:
"TypeError: Not enough arguments to CustomEvent.initCustomEvent."

This error doesn't allow the overlay to be shown again.
