### PR TITLE
Minimal test case for super() bug in MontageReviver 

### DIFF
--- a/test/core/super-spec.js
+++ b/test/core/super-spec.js
@@ -1906,4 +1906,34 @@ describe("test/core/super-spec", function () {
            });
         });
     });
+
+    describe("Parent method calls child method recursively", function () {
+        // can't use spies because they mess up super()
+        var vehicleCalls = 0;
+        var carCalls = 0;
+
+        var Vehicle = Montage.specialize({
+            speak: {
+                value: function(count) {
+                    vehicleCalls++;
+                    this.speak(count-1);
+                }
+            }
+        });
+        var Car = Vehicle.specialize({
+            speak: {
+                value: function(count) {
+                    carCalls++;
+                    if (count <= 0) return;
+                    this.super(count);
+                }
+            }
+        });
+
+        var car = new Car();
+        car.speak(2); // should call: Car 2, Vehicle 2, Car 1, Vehicle 1, Car 0
+
+        expect(vehicleCalls).toBe(2);
+        expect(carCalls).toBe(3);
+    });
 });


### PR DESCRIPTION
+100 points to @aadsm for this discovery: a bug caused by a strange loop!

![drawinghands](https://f.cloud.github.com/assets/8495/1603848/b77f4eea-53b1-11e3-9f15-a6c153230345.jpg)

_The problem_

`MontageReviver` is a subclass of `Reviver`. When you call `MontageReviver#reviveRootObject` it calls `super`, which resolves to `Reviver#reviveRootObject`. That method then calls other methods on the object, which eventually wind their way around to calling `MontageReviver#reviveRootObject` again. When we reach the `super` call the second time, which is still nested inside the call stack for the first time, the super context thinks we're trying to call the parent of `Reviver`, rather than of `MontageReviver`, and is thus a no-op.

_Possible fixes_
1. Laugh at this strange problem and content ourselves with manually calling `Reviver.prototype.reviveRootObject` instead of having the convenience of `super` in this specific case.
2. Fix `super` to work in cases like this. When we call super() from inside Class#method, we could wrap Class#method in a decorator. Then if it is called again within itself, the wrapper resets the super context just for the duration of the inner call.
