### PR TITLE
Range controller selection updates

### DIFF
--- a/core/range-controller.js
+++ b/core/range-controller.js
@@ -35,6 +35,7 @@ var RangeSelection = function(content, rangeController) {
     var self = content.clone();
     self.makeObservable();
     self.rangeController = rangeController;
+    self.contentEquals = content.contentEquals || Object.is;
 
     /**
      * @method splice
@@ -46,19 +47,39 @@ var RangeSelection = function(content, rangeController) {
      *  - if rC.multiSelect is false, only allow one item in set.
      *  - if rC.avoidsEmtySelection is true, require at least one item in set.
      *  - only add items that are present in rC.content
-     *  - enforce uniqueness of items
+     *  - enforce uniqueness of items according to the contentEquals of the content
      */
     var oldSplice = self.splice;
     Object.defineProperty(self, "splice", {
         configurable: false,
         value: function(start, howMany) {
+            this.contentEquals = this.rangeController.content.contentEquals || Object.is;
             start = start >= 0 ? start : this.length + start;
-            var plus = [].slice.call(arguments, 2).filter(function(item){
-                return this.has(item);
-            }, this.rangeController.content || []);
-            // TODO: enforce uniqueness, somehow?
             var oldLength = this.length;
             var minusLength = Math.min(howMany, oldLength - start);
+
+            var plusCandidates = [].slice.call(arguments, 2);
+            plusCandidates.contentEquals = this.contentEquals;
+
+            var plus = plusCandidates.filter(function(item, index){
+                // do not add items to the selection if they aren't in content
+                if (!this.rangeController.content.has(item)) {
+                    return false;
+                }
+
+                // if the same item appears twice in the add list, only add it once
+                if (plusCandidates.findLast(item) > index) {
+                    return false;
+                }
+
+                // if the item is already in the selection, don't add it
+                // unless it's in the part that we're about to delete.
+                var indexInSelection = this.find(item);
+                return indexInSelection < 0 ||
+                        (indexInSelection >= start && indexInSelection < start + minusLength);
+
+            }, this);
+
             var plusLength = Math.max(plus.length, 0);
             var diffLength = plusLength - minusLength;
             var newLength = Math.max(oldLength + diffLength, start + plusLength);
@@ -69,6 +90,7 @@ var RangeSelection = function(content, rangeController) {
                 var last = plusLength ? plus[plusLength-1] : this.one();
                 args = [0, oldLength, last];
             } else if (this.rangeController.avoidsEmptySelection && newLength === 0) {
+                // use the first item in the selection, unless it is no longer in the content
                 if (this.rangeController.content.has(this[0])) {
                     args = [1, this.length-1];
                 } else {

--- a/test/core/range-controller-spec.js
+++ b/test/core/range-controller-spec.js
@@ -294,4 +294,28 @@ describe("core/range-controller-spec", function() {
 
     });
 
+    describe("When content has a custom contentEquals", function () {
+        beforeEach(function () {
+            var content = [0, 1, 2];
+            content.contentEquals = function(){ return true; };
+            expect(content.find(42)).toBe(0);
+
+            rangeController = RangeController.create().initWithContent(content);
+            rangeController.multiSelect = true;
+            rangeController.selection = [0];
+
+            expect(rangeController.selection.toArray()).toEqual([0]);
+        });
+
+        it("should not allow duplicates according to the custom contentEquals", function () {
+            rangeController.selection.add(1);
+            expect(rangeController.selection.toArray()).toEqual([0]);
+        });
+
+        it("should check of selection is in content using the custom contentEquals", function () {
+            rangeController.selection.splice(0, 1, 42);
+            expect(rangeController.selection.toArray()).toEqual([42]);
+        });
+    });
+
 });


### PR DESCRIPTION
- Fixes a bug that allowed an item to be in the `selection` even if it wasn't in the `content`.
- Enforces uniqueness of items in the `selection`.
- Enforces all of the `selection`'s invariants relative to the `contentEquals` method of its `content`.
