### PR TITLE
Fix errant code change in JSDoc normalization

### DIFF
--- a/core/object-controller.js
+++ b/core/object-controller.js
@@ -59,8 +59,6 @@ var ObjectController = exports.ObjectController = Montage.specialize( /** @lends
         value: null
     },
 
-}, {
-
     blueprintModuleId:require("montage")._blueprintModuleIdDescriptor,
 
     blueprint:require("montage")._blueprintDescriptor


### PR DESCRIPTION
But we will need to follow up to make blueprint properties fall
consistently either on the constuctor or the prototype. Presently, there
is no normal form.
