### PR TITLE
Fix nasty Safari bug with uuids

### DIFF
--- a/core/core.js
+++ b/core/core.js
@@ -1064,8 +1064,19 @@ var uuidGetGenerator = function() {
         // NOTE Safari (as of Version 5.0.2 (6533.18.5, r78685)
         // doesn't seem to allow redefining an existing property on a DOM Element
         // Still want to redefine the property where possible for speed
-        this._uuid = uuid;
     }
+
+    // NOTE Safari (as of Version 6.1 8537.71) has a bug related to ES5
+    // property values. In some situations, even when the uuid has already
+    // be defined as a property value, accessing the uuid of an object can
+    // make it go through the defaultUuidGet like if the property descriptor
+    // was still the original one. When that happens a new uuid is created
+    // for that object. To avoid that we always make sure that the object
+    // have a _uuid that will be looked up to at defaultUuidGet() before
+    // generating a new one. This mechanism was created to work around an
+    // issue with Safari that didn't allow redefining property descriptors
+    // in DOM elements.
+    this._uuid = uuid;
 
     return uuid;
 };


### PR DESCRIPTION
Safari (as of Version 6.1 8537.71) has a bug related to ES5
property values. In some situations, even when the uuid has already
be defined as a property value, accessing the uuid of an object can
make it go through the defaultUuidGet like if the property descriptor
was still the original one. When that happens a new uuid is created
for that object. To avoid that we always make sure that the object
have a _uuid that will be looked up to at defaultUuidGet() before
generating a new one. This mechanism was created to work around an
issue with Safari that didn't allow redefining property descriptors
in DOM elements.
