### PR TITLE
Surrounding access of window.localStorage with try catch

### DIFF
--- a/core/logger.js
+++ b/core/logger.js
@@ -442,11 +442,14 @@ var setupUI = function() {
     new LoggerUI().init();
 }
 if (typeof window !== "undefined") {
-    
-    window.loggers = loggers;
-    if (window.localStorage) {
-        // assigning to a local allows us to feature-test without typeof
+    // assigning to a local allows us to feature-test without typeof
+    try {
         localStorage = window.localStorage;
+    } catch (e) {
+        console.log("Error accessing localStorage", e);
+    }
+    window.loggers = loggers;
+    if (localStorage) {
         setupUI();
     }
 }


### PR DESCRIPTION
Sandboxed chrome apps cant even check for the existence of window.localStorage without throwing a security exception. Maybe there is a better way around this...

``` javascript
Error accessing localStorage 
DOMException {message: "Failed to read the 'localStorage' property from 'W…sandboxed and lacks the 'allow-same-origin' flag.", name: "SecurityError", code: 18, stack: "Error: Failed to read the 'localStorage' property …gifmckbli/node_modules/montage/montage.js:309:32)", INDEX_SIZE_ERR: 1…}
code: 18
message: "Failed to read the 'localStorage' property from 'Window': The document is sandboxed and lacks the 'allow-same-origin' flag."
name: "SecurityError"
stack: "Error: Failed to read the 'localStorage' property from 'Window': The document is sandboxed and lacks the 'allow-same-origin' flag.↵    at __FILE__chrome__extension______ahameiiiilhhnodikfleiidgifmckbli__node_modules__montage__core__logger__ (chrome-extension://ahameiiiilhhnodikfleiidgifmckbli/node_modules/montage/core/logger.js:447:30)↵    at module.factory (chrome-extension://ahameiiiilhhnodikfleiidgifmckbli/node_modules/montage/montage.js:309:32)↵    at getExports (chrome-extension://ahameiiiilhhnodikfleiidgifmckbli/node_modules/montage/packages/mr/require.js:215:46)↵    at require (chrome-extension://ahameiiiilhhnodikfleiidgifmckbli/node_modules/montage/packages/mr/require.js:283:24)↵    at __FILE__chrome__extension______ahameiiiilhhnodikfleiidgifmckbli__node_modules__montage__core__serialization__serializer__montage__serializer__ (chrome-extension://ahameiiiilhhnodikfleiidgifmckbli/node_modules/montage/core/serialization/serializer/montage-serializer.js:8:14)↵    at module.factory (chrome-extension://ahameiiiilhhnodikfleiidgifmckbli/node_modules/montage/montage.js:309:32)↵    at getExports (chrome-extension://ahameiiiilhhnodikfleiidgifmckbli/node_modules/montage/packages/mr/require.js:215:46)↵    at require (chrome-extension://ahameiiiilhhnodikfleiidgifmckbli/node_modules/montage/packages/mr/require.js:283:24)↵    at __FILE__chrome__extension______ahameiiiilhhnodikfleiidgifmckbli__node_modules__montage__core__serialization__ (chrome-extension://ahameiiiilhhnodikfleiidgifmckbli/node_modules/montage/core/serialization.js:1:165)↵    at module.factory (chrome-extension://ahameiiiilhhnodikfleiidgifmckbli/node_modules/montage/montage.js:309:32)"
uuid: (...)
```
