### PR TITLE
Make range controller selection clonable, but introduce a new bug in the bindings

### DIFF
--- a/core/range-controller.js
+++ b/core/range-controller.js
@@ -36,6 +36,12 @@ var RangeSelection = function(content, rangeController) {
     self.rangeController = rangeController;
     self.contentEquals = content && content.contentEquals || Object.is;
 
+    Object.defineProperty(self, "clone", {
+        value: function(){
+            return self.slice();
+        }
+    });
+
     /**
      * @method splice
      * @param {number} start


### PR DESCRIPTION
:warning: You probably don't want to merge this in Montage master.

However, if you have stuff that isn't working at all because of the clone problem, this is a good temporary workaround.
