### PR TITLE
Allow a component to draw outside the document

### DIFF
--- a/ui/component.js
+++ b/ui/component.js
@@ -1671,7 +1671,7 @@ var Component = exports.Component = Target.specialize(/** @lends Component# */ {
 
             if (element.parentNode) {
                 element.parentNode.replaceChild(template, element);
-            } else {
+            } else if (!this._canDrawOutsideDocument) {
                 console.warn("Warning: Trying to replace element ", element," which has no parentNode");
             }
 

--- a/ui/loader.reel/loader.js
+++ b/ui/loader.reel/loader.js
@@ -325,6 +325,7 @@ exports.Loader = Component.specialize( /** @lends Loader# */ {
             this._mainComponent.enterDocument = this.mainComponentEnterDocument.bind(this);
             this._mainComponent.setElementWithParentComponent(document.createElement("div"), this);
             this._mainComponent.attachToParentComponent();
+            this._mainComponent._canDrawOutsideDocument = true;
             this._mainComponent.needsDraw = true;
         }
     },


### PR DESCRIPTION
This introduces the flag _canDrawOutsideDocument that can be set to
indicate the component that it's ok to draw in that state.
Avoid the warning message: "Trying to replace element <div>​</div>​ which
has no parentNode"
