### PR TITLE
Use activeTarget to manage keyboard input.

### DIFF
--- a/test/base/abstract-text-field-spec.js
+++ b/test/base/abstract-text-field-spec.js
@@ -320,7 +320,7 @@ describe("test/base/abstract-text-field-spec", function () {
             });
 
             it("should be called when textfield is focused", function() {
-                aTextField.handleFocus();
+                aTextField.willBecomeActiveTarget();
                 expect(aTextFieldDelegate.didBeginEditing).toHaveBeenCalled();
             });
         });
@@ -328,29 +328,29 @@ describe("test/base/abstract-text-field-spec", function () {
         describe("shouldEndEditing", function () {
             beforeEach(function () {
                 aTextFieldDelegate.shouldEndEditing = jasmine.createSpy();
-                aTextField.handleFocus();
+                aTextField.willBecomeActiveTarget();
             });
 
             it("should be called when textfield receives blur", function() {
-                aTextField.handleBlur();
+                aTextField.surrendersActiveTarget();
                 expect(aTextFieldDelegate.shouldEndEditing).toHaveBeenCalled();
             });
 
             it("should be ignored if it returns undefined", function() {
                 aTextFieldDelegate.shouldEndEditing.andReturn(void 0);
-                aTextField.handleBlur();
+                aTextField.surrendersActiveTarget();
                 expect(aTextField.hasFocus).toBeFalsy();
             });
 
             it("should be prevent textfield being unfocused if it returns false", function() {
                 aTextFieldDelegate.shouldEndEditing.andReturn(false);
-                aTextField.handleBlur();
+                aTextField.surrendersActiveTarget();
                 expect(aTextField.hasFocus).toBeTruthy();
             });
 
             it("should not be prevent textfield being unfocused if it returns true", function() {
                 aTextFieldDelegate.shouldEndEditing.andReturn(true);
-                aTextField.handleBlur();
+                aTextField.surrendersActiveTarget();
                 expect(aTextField.hasFocus).toBeFalsy();
             });
 
@@ -362,7 +362,7 @@ describe("test/base/abstract-text-field-spec", function () {
             });
 
             it("should be called when textfield receives blur", function() {
-                aTextField.handleBlur();
+                aTextField.surrendersActiveTarget();
                 expect(aTextFieldDelegate.didEndEditing).toHaveBeenCalled();
             });
         });

--- a/ui/base/abstract-text-field.js
+++ b/ui/base/abstract-text-field.js
@@ -126,8 +126,6 @@ var AbstractTextField = exports.AbstractTextField = AbstractControl.specialize(
             if (firstTime) {
                 this.element.addEventListener("input", this, false);
                 this.element.addEventListener("change", this, false);
-                this.element.addEventListener("focus", this, false);
-                this.element.addEventListener("blur", this, false);
             }
         }
     },
@@ -160,26 +158,23 @@ var AbstractTextField = exports.AbstractTextField = AbstractControl.specialize(
         }
     },
 
-    handleFocus: {
+    willBecomeActiveTarget: {
         value: function(event) {
-            if (this.acceptsActiveTarget) {
-                this._hasFocus = true;
-                this.callDelegateMethod("didBeginEditing", this);
-            } else {
-                this.element.blur();
-            }
+            this._hasFocus = true;
+            this.callDelegateMethod("didBeginEditing", this);
         }
     },
 
-    handleBlur: {
+    surrendersActiveTarget: {
         value: function(event) {
             var shouldEnd = this.callDelegateMethod("shouldEndEditing", this);
             if (shouldEnd === false) {
-                this.element.focus();
+                return false;
             } else {
                 this._hasFocus = false;
                 this.callDelegateMethod("didEndEditing", this);
             }
+            return true;
         }
     },
 


### PR DESCRIPTION
Instead of manually managing focus and blur events we should use
Montage's active target.
