### PR TITLE
Fork the active target specs mouse/touch.

### DIFF
--- a/test/events/active-target-spec.js
+++ b/test/events/active-target-spec.js
@@ -32,11 +32,20 @@ TestPageLoader.queueTest("active-target-test/active-target-test", function(testP
                     expect(proximalComponent.isActiveTarget).toBeTruthy();
                 });
 
-                it("should focus on a target when a target's own element receives mousedown", function () {
-                    testPage.mouseEvent({target: proximalElement}, "mousedown");
-                    expect(eventManager.activeTarget).toBe(proximalComponent);
-                    expect(proximalComponent.isActiveTarget).toBeTruthy();
-                });
+                if(window.Touch) {
+                    it("should focus on a target when a target's own element receives touchstart", function () {
+                        testPage.touchEvent({target: proximalElement}, "touchstart");
+                        expect(eventManager.activeTarget).toBe(proximalComponent);
+                        expect(proximalComponent.isActiveTarget).toBeTruthy();
+                    });
+                } else {
+                    it("should focus on a target when a target's own element receives mousedown", function () {
+                        testPage.mouseEvent({target: proximalElement}, "mousedown");
+                        expect(eventManager.activeTarget).toBe(proximalComponent);
+                        expect(proximalComponent.isActiveTarget).toBeTruthy();
+                    });
+                }
+
 
                 //TODO well this will work for now, but this whole forking strategy will need to be rethought (euphemism intended)
                 // The activation eventHandler still works in either/or mode for now
@@ -117,14 +126,14 @@ TestPageLoader.queueTest("active-target-test/active-target-test", function(testP
                     expect(proximalComponent.isActiveTarget).toBeFalsy();
                 });
 
-                it("should focus on some nextTarget that accepts focus when the proximal target receives mousedown", function () {
-                    testPage.mouseEvent({target: proximalElement}, "mousedown");
-                    expect(eventManager.activeTarget).toBe(activeComponent);
-                    expect(activeComponent.isActiveTarget).toBeTruthy();
-                });
-
-                if (window.Touch) {
-                    it("must not focus on the proximal target when the target receives touchstart", function () {
+                if (!window.Touch) {
+                    it("should focus on some nextTarget that accepts focus when the proximal target receives mousedown", function () {
+                        testPage.mouseEvent({target: proximalElement}, "mousedown");
+                        expect(eventManager.activeTarget).toBe(activeComponent);
+                        expect(activeComponent.isActiveTarget).toBeTruthy();
+                    });
+                } else {
+                   it("must not focus on the proximal target when the target receives touchstart", function () {
                         testPage.touchEvent({target: proximalElement}, "touchstart");
                         expect(proximalComponent.isActiveTarget).toBeFalsy();
                     });


### PR DESCRIPTION
In some cases mouse events won't work.
