### PR TITLE
Fix PressComposer hanging bug.

### DIFF
--- a/composer/press-composer.js
+++ b/composer/press-composer.js
@@ -269,7 +269,7 @@ var PressComposer = exports.PressComposer = Composer.specialize(/** @lends Press
                     this._dispatchPressCancel(event);
                     this._endInteraction(event);
                     return;
-                } else if (isSurrendered && !isTarget) {
+                } else {
                     this._endInteraction(event);
                 }
             }

--- a/test/composer/press-composer-spec.js
+++ b/test/composer/press-composer-spec.js
@@ -265,6 +265,27 @@ TestPageLoader.queueTest("press-composer-test/press-composer-test", function(tes
                 expect(outer_listener).toHaveBeenCalled();
                 expect(inner_listener).not.toHaveBeenCalled();
             });
+
+            // touchend's target is always the same as touch start, so this
+            // test doesn't apply
+            if (!window.Touch) {
+                describe("outer_listener", function () {
+                    var _endInteractionSpy;
+                    beforeEach(function () {
+                        _endInteractionSpy = spyOn(test.outer_press_composer, "_endInteraction")
+                    });
+                    it("should _endInteraction when the mouse is released elsewhere", function() {
+                        testPage.mouseEvent({target: test.innerComponent.element}, "mousedown");
+                        testPage.mouseEvent({target: testPage.document}, "mouseup");
+                        expect(_endInteractionSpy).toHaveBeenCalled();
+                     });
+                    it("should _endInteraction when the mouse is released within the element but unclaimed", function() {
+                        testPage.mouseEvent({target: test.innerComponent.element}, "mousedown");
+                        testPage.mouseEvent({target: test.inner2Component.element}, "mouseup");
+                        expect(_endInteractionSpy).toHaveBeenCalled();
+                     });
+                });
+            }
         });
     });
 });

--- a/test/composer/press-composer-test/press-composer-test.html
+++ b/test/composer/press-composer-test/press-composer-test.html
@@ -77,6 +77,19 @@ POSSIBILITY OF SUCH DAMAGE.
             "component": {"@": "innerComponent"}
         }
     },
+    "inner2Component": {
+        "prototype": "montage/ui/component",
+        "properties": {
+            "hasTemplate": false,
+            "element": {"#": "inner2Component"}
+        }
+    },
+    "inner2_press_composer": {
+        "prototype": "montage/composer/press-composer",
+        "properties": {
+            "component": {"@": "inner2Component"}
+        }
+    },
 
     "test": {
         "prototype": "composer/press-composer-test/press-composer-test",
@@ -85,7 +98,9 @@ POSSIBILITY OF SUCH DAMAGE.
             "example": {"@": "example"},
             "outerComponent": {"@": "outerComponent"},
             "innerComponent": {"@": "innerComponent"},
+            "inner2Component": {"@": "inner2Component"},
             "inner_press_composer": {"@": "inner_press_composer"},
+            "inner2_press_composer": {"@": "inner2_press_composer"},
             "outer_press_composer": {"@": "outer_press_composer"}
         }
     },
@@ -127,6 +142,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
     <div data-montage-id="outerComponent" class="outerComponent">
         <div data-montage-id="innerComponent" class="innerComponent"></div>
+        <div data-montage-id="inner2Component" class="inner2Component"></div>
     </div>
 </body>
 </html>


### PR DESCRIPTION
In some cases the press composer was not ending it's interaction if the
pointer was claimed then unclaimed but still released within.
