### PR TITLE
Stop setting src to the rebased src in AbstractImage

### DIFF
--- a/test/base/abstract-image-spec.js
+++ b/test/base/abstract-image-spec.js
@@ -264,7 +264,22 @@ describe("test/base/abstract-image-spec", function () {
                 }
             };
 
-            expect(anImage.src).toBe("http://montagejs.org/images/logo-montage.png");
+            expect(anImage._image.src).toBe("http://montagejs.org/images/logo-montage.png");
+        });
+
+        it("should not change the src to the rebased src", function() {
+            var src = "logo-montage.png";
+
+            anImage.src = src;
+            anImage._ownerDocumentPart = {
+                template: {
+                    getBaseUrl: function() {
+                        return "http://montagejs.org/images/";
+                    }
+                }
+            };
+
+            expect(anImage.src).toBe(src);
         });
     });
 

--- a/ui/base/abstract-image.js
+++ b/ui/base/abstract-image.js
@@ -110,12 +110,15 @@ var AbstractImage = exports.AbstractImage = Component.specialize( /** @lends Abs
 
     _rebaseSrc: {
         value: function() {
-            var url;
+            var value;
 
-            url = this._getRebasedSrc();
+            value = this._getRebasedSrc();
 
-            if (url) {
-                this.src = url;
+            if (value) {
+                this._isLoadingImage = true;
+                this._isInvalidSrc = false;
+                this._image.src = value;
+                this.needsDraw = true;
             }
         }
     },


### PR DESCRIPTION
The src should always represent the value given by the user.
