### PR TITLE
Add a way to block the owner component from drawing

### DIFF
--- a/test/ui/component-spec.js
+++ b/test/ui/component-spec.js
@@ -379,6 +379,61 @@ TestPageLoader.queueTest("draw/draw", function(testPage) {
 
                    expect(style).toBe("border: 1px solid black; margin: 2px");
                 });
+
+                describe("_blocksOwnerComponentDraw", function() {
+                    it("should stop the owner from drawing when the component can't", function() {
+                        // setup spies
+                        spyOn(testPage.test.componentH, 'draw').andCallThrough();
+                        // trigger test
+                        testPage.test.componentH.needsDraw = true;
+                        testPage.test.componentH1.canDrawGate.setField("field", false);
+                        /// wait for draw
+                        testPage.waitForDraw();
+                        // test results
+                        runs(function() {
+                            expect(testPage.test.componentH.draw).not.toHaveBeenCalled();
+                            testPage.test.componentH1.canDrawGate.setField("field", true);
+                        });
+                    });
+
+                    it("should continue drawing when the component can", function() {
+                        // setup spies
+                        spyOn(testPage.test.componentH, 'draw').andCallThrough();
+                        // trigger test
+                        testPage.test.componentH.needsDraw = true;
+                        testPage.test.componentH1.canDrawGate.setField("field", false);
+                        /// wait for draw
+                        testPage.waitForDraw();
+                        // test results
+                        runs(function() {
+                            testPage.test.componentH1.canDrawGate.setField("field", true);
+                            testPage.waitForDraw();
+                            runs(function() {
+                                expect(testPage.test.componentH.draw).toHaveBeenCalled();
+                            });
+                        });
+                    });
+
+                    it("should continue drawing even if the owner component doesn't need to draw", function() {
+                        // setup spies
+                        spyOn(testPage.test.componentH1, 'draw').andCallThrough();
+                        // trigger test
+                        testPage.test.componentH1.needsDraw = true;
+                        testPage.test.componentH1.canDrawGate.setField("field", false);
+
+                        /// wait for draw
+                        testPage.waitForDraw();
+                        // test results
+                        runs(function() {
+                            expect(testPage.test.componentH1.draw).not.toHaveBeenCalled();
+                            testPage.test.componentH1.canDrawGate.setField("field", true);
+                            testPage.waitForDraw();
+                            runs(function() {
+                                expect(testPage.test.componentH1.draw).toHaveBeenCalled();
+                            })
+                        });
+                    });
+                });
             });
 
             describe("didDraw calling after draw", function() {

--- a/test/ui/draw/draw.html
+++ b/test/ui/draw/draw.html
@@ -82,7 +82,9 @@ POSSIBILITY OF SUCH DAMAGE.
             "componentClassInTemplateAndBindings": {"@": "componentClassInTemplateAndBindings"},
             "componentF": {"@": "componentF"},
             "componentF1": {"@": "componentF1"},
-            "componentG": {"@": "componentG"}
+            "componentG": {"@": "componentG"},
+            "componentH": {"@": "componentH"},
+            "componentH1": {"@": "componentH1"}
         }
     },
     "owner": {
@@ -421,8 +423,25 @@ POSSIBILITY OF SUCH DAMAGE.
             "element": {"#": "componentG"},
             "hasTemplate": false
         }
-    }
+    },
 
+    "componentH": {
+        "prototype": "montage/ui/component",
+        "properties": {
+            "element": {"#": "componentH"},
+            "hasTemplate": false
+        }
+    },
+
+    "componentH1": {
+        "prototype": "montage/ui/component",
+        "properties": {
+            "element": {"#": "componentH1"},
+            "hasTemplate": false,
+            "ownerComponent": {"@": "componentH"},
+            "_blocksOwnerComponentDraw": true
+        }
+    }
 }
     </script>
 
@@ -551,6 +570,10 @@ POSSIBILITY OF SUCH DAMAGE.
     <div data-montage-id="componentF1">F1</div>
 </div>
 <div data-montage-id="componentG"></div>
+
+<div data-montage-id="componentH">
+    <div data-montage-id="componentH1">H1</div>
+</div>
 
 </body>
 </html>


### PR DESCRIPTION
"_blocksOwnerComponentDraw" property allows a component to block its
owner's draw.
This is done by tying the canDrawGate of the owner with the canDrawGate
of the component.
