### PR TITLE
Forget bindings, just use the same damn array

### DIFF
--- a/test/base/abstract-select-spec.js
+++ b/test/base/abstract-select-spec.js
@@ -157,7 +157,7 @@ describe("test/base/abstract-select-spec", function () {
             it("should set first of the values", function() {
                 aSelect.values = [content[1], content[2]];
                 aSelect.value = content[2];
-                expect(aSelect.values).toEqual([content[2]]);
+                expect(aSelect.values.slice()).toEqual([content[2]]);
             });
         });
 
@@ -210,7 +210,7 @@ describe("test/base/abstract-select-spec", function () {
                 aSelect.values = [content[1]];
                 aSelect.contentController.selection.push(content[2]);
 
-                expect(aSelect.values).toEqual([content[1], content[2]]);
+                expect(aSelect.values.slice()).toEqual([content[1], content[2]]);
             });
         });
 
@@ -222,8 +222,9 @@ describe("test/base/abstract-select-spec", function () {
 
             it("should only have one item in the content controller's selection when multiSelect is off", function() {
                 aSelect.multiSelect = false;
-                aSelect.values = [content[1], content[2]];
+                expect(aSelect.contentController.selection.length).toBe(1);
 
+                aSelect.values = [content[1], content[2]];
                 expect(aSelect.contentController.selection.length).toBe(1);
             });
 

--- a/ui/base/abstract-select.js
+++ b/ui/base/abstract-select.js
@@ -37,13 +37,11 @@ var AbstractSelect = exports.AbstractSelect = AbstractControl.specialize( /** @l
             this._pressComposer = new PressComposer();
             this.addComposer(this._pressComposer);
             this.contentController = new RangeController();
+            this._values = this.contentController.selection;
 
             this.defineBindings({
                 "content": {
                     "<->": "contentController.content"
-                },
-                "values": {
-                    "<->": "contentController.selection.rangeContent()"
                 },
                 // FIXME: due to issues with 2 way bindings with rangeContent()
                 // we aren't currently able to have this "value" binding.
@@ -149,21 +147,8 @@ var AbstractSelect = exports.AbstractSelect = AbstractControl.specialize( /** @l
             return this._values;
         },
         set: function(value) {
-            // When a property is bound to a rangeContent() we can't change the
-            // reference of the property because the binding will not work
-            // anymore (MON-444).
-            if (this._values) {
-                // We can't change the value reference because it is bound to a
-                // rangeContent(), instead we just replace its entire contents
-                // with the contents of the value given.
-                var args = [0, this._values.length].concat(value);
-                this._values.splice.apply(this._values, args);
-            } else {
-                // This is the only time when we actually set the values
-                // property. It is the value given when establishing the binding
-                // to rangeContent() in the constructor.
-                this._values = value;
-            }
+            var args = [0, this._values.length].concat(value);
+            this._values.splice.apply(this._values, args);
 
             this.needsDraw = true;
         }


### PR DESCRIPTION
One solution to our problems with the two-way bindings between a RangeController's `values` and client code is to just directly reference the `values`. This is a net-negative on lines of code, makes all the invariants automatically pass, and feels pretty good.
