### PR TITLE
Support component labels in defineBinding getPath

### DIFF
--- a/core/bindings.js
+++ b/core/bindings.js
@@ -6,6 +6,7 @@ var bindingPropertyDescriptors = {
 
     defineBinding: {
         value: function (targetPath, descriptor, commonDescriptor) {
+            descriptor.components = descriptor.components || this._ownerDocumentPart;
             return Bindings.defineBinding(this, targetPath, descriptor, commonDescriptor);
         }
     },

--- a/core/document-part.js
+++ b/core/document-part.js
@@ -92,7 +92,14 @@ var DocumentPart = Montage.specialize( {
 
             return deferred.promise;
         }
+    },
+
+    getObjectByLabel: {
+        value: function (label) {
+            return this.objects[label];
+        }
     }
+
 });
 
 exports.DocumentPart = DocumentPart;

--- a/core/paths.js
+++ b/core/paths.js
@@ -36,7 +36,7 @@ var pathPropertyDescriptors = { /** @lends Montage# */
                 this,
                 parameters || this,
                 document,
-                components
+                components || this._ownerDocumentPart
             );
         }
     },
@@ -57,7 +57,7 @@ var pathPropertyDescriptors = { /** @lends Montage# */
                 value,
                 parameters || this,
                 document,
-                components
+                components || this._ownerDocumentPart
             );
         }
     },
@@ -78,7 +78,9 @@ var pathPropertyDescriptors = { /** @lends Montage# */
         value: function (path, emit) {
             var syntax = parse(path);
             var observe = compileObserver(syntax);
-            return observe(autoCancelPrevious(emit), new Scope(this));
+            var scope = new Scope(this);
+            scope.components = this._ownerDocumentPart;
+            return observe(autoCancelPrevious(emit), scope);
         }
     },
 

--- a/test/ui/component-spec.js
+++ b/test/ui/component-spec.js
@@ -1360,5 +1360,22 @@ TestPageLoader.queueTest("draw/draw", function(testPage) {
                 expect(templatePropertyLabel).toBe("bar:i");
             });
         });
+
+        describe("getPath", function () {
+            it("acquires peer components by label", function () {
+                expect(testPage.test.owner.getPath("@repetition")).toBe(testPage.test.repetition);
+            });
+        });
+
+        describe("defineBinding", function () {
+            it("binds via peer components by label", function () {
+                testPage.test.owner.defineBinding("repetitionContent", {
+                    "<->": "@repetition.content"
+                });
+                testPage.test.owner.repetitionContent = [4, 5, 6];
+                expect(testPage.test.repetition.content).toEqual([4, 5, 6]);
+            });
+        });
+
     });
 });

--- a/ui/component.js
+++ b/ui/component.js
@@ -3286,6 +3286,7 @@ var RootComponent = Component.specialize( /** @lends RootComponent# */{
             this._documentResources = DocumentResources.getInstanceForDocument(value);
         }
     }
+
 });
 
 var rootComponent = new RootComponent().init();


### PR DESCRIPTION
Previously, defineBinding and getPath did not support FRB `@label`
notation because they had no way to access peer components of the
object. @aadsm reveals that components have an `_ownerDocumentPart` with
that knowledge. This change bridges that gap. The upshot should be that
`sortPath` and `filterPath`, among other such expressions, should have
access to peer components now.
