### PR TITLE
Remove use of Components.interfaces in FF.

### DIFF
--- a/core/event/event-manager.js
+++ b/core/event/event-manager.js
@@ -382,25 +382,22 @@ var EventManager = exports.EventManager = Montage.specialize(/** @lends EventMan
             }
 
             // In some browsers (Firefox) each element has their own addEventLister/removeEventListener
-            // Methodology to find all elements found in Chainvas
+            // Methodology to find all elements found in Chainvas (now mostly gone from this)
             if(aWindow.HTMLDivElement.prototype.addEventListener !== aWindow.Element.prototype.nativeAddEventListener) {
                 if (aWindow.HTMLElement &&
-                    'addEventListener' in aWindow.HTMLElement.prototype &&
-                    aWindow.Components &&
-                    aWindow.Components.interfaces
+                    'addEventListener' in aWindow.HTMLElement.prototype
                 ) {
-                    var candidate, candidatePrototype;
-
-                    for(candidate in Components.interfaces) {
-                        if(candidate.match(/^nsIDOMHTML\w*Element$/)) {
-                            candidate = candidate.replace(/^nsIDOM/, '');
-                            if(candidate = window[candidate]) {
-                                candidatePrototype = candidate.prototype;
-                                candidatePrototype.nativeAddEventListener = candidatePrototype.addEventListener;
-                                candidatePrototype.addEventListener = aWindow.Element.prototype.addEventListener;
-                                candidatePrototype.nativeRemoveEventListener = candidatePrototype.removeEventListener;
-                                candidatePrototype.removeEventListener = aWindow.Element.prototype.removeEventListener;
-                            }
+                    var candidates = Object.getOwnPropertyNames(aWindow),
+                        candidate, candidatePrototype,
+                        i = 0, candidatesLength = candidates.length;
+                    for (i; i < candidatesLength; i++) {
+                        candidate = candidates[i];
+                        if(candidate.match(/^HTML\w*Element$/) && typeof candidate === "function") {
+                            candidatePrototype = candidate.prototype;
+                            candidatePrototype.nativeAddEventListener = candidatePrototype.addEventListener;
+                            candidatePrototype.addEventListener = aWindow.Element.prototype.addEventListener;
+                            candidatePrototype.nativeRemoveEventListener = candidatePrototype.removeEventListener;
+                            candidatePrototype.removeEventListener = aWindow.Element.prototype.removeEventListener;
                         }
                     }
                 }


### PR DESCRIPTION
This was only used to provide a shim for Firefox. Components is
deprecated as described in:
https://developer.mozilla.org/en-US/docs/Components_object
Now we simply iterate over appropriate properties on the window.
