### PR TITLE
Allow repetition to be selected with no components

### DIFF
--- a/test/ui/repetition-spec.js
+++ b/test/ui/repetition-spec.js
@@ -1003,5 +1003,16 @@ TestPageLoader.queueTest("repetition/repetition", function(testPage) {
             });
         });
 
+        describe("iteration selection", function() {
+            it("should select an iteration that does not have components when clicked", function() {
+                var repetition = delegate.domRepetition;
+                var li = repetition.element.querySelectorAll("li")[1];
+                testPage.mouseEvent({target: li}, "mousedown", function () {
+                    testPage.mouseEvent({target: li}, "mouseup", function () {
+                        expect(repetition.iterations[1].selected).toBe(true);
+                    });
+                });
+            });
+        });
     });
 });

--- a/test/ui/repetition/repetition.html
+++ b/test/ui/repetition/repetition.html
@@ -58,6 +58,7 @@ POSSIBILITY OF SUCH DAMAGE.
                     "repetition9": {"@": "repetition9"},
                     "repetition12": {"@": "repetition12"},
                     "repetition15": {"@": "repetition15"},
+                    "domRepetition": {"@": "domRepetition"},
                     "repetitionController": {"@": "repetitionController"},
                     "list1Objects": [
 
@@ -644,6 +645,15 @@ POSSIBILITY OF SUCH DAMAGE.
                 "bindings": {
                     "value": {"<-": "@repetitionWithObjectAtCurrentIteration.objectAtCurrentIteration"}
                 }
+            },
+
+            "domRepetition": {
+                "prototype": "montage/ui/repetition.reel",
+                "properties": {
+                    "element": {"#": "domRepetition"},
+                    "content": [1, 2, 3],
+                    "isSelectionEnabled": true
+                }
             }
 
     }</script>
@@ -848,5 +858,12 @@ POSSIBILITY OF SUCH DAMAGE.
         <div data-montage-id="objectAtCurrentIteration" class="objectAtCurrentIteration"></div>
     </div>
 
+    <h2>DOM Repetition</h2>
+
+    <ul data-montage-id="domRepetition">
+        <li>
+            Item being repeated
+        </li>
+    </ul>
 </body>
 </html>

--- a/ui/repetition.reel/repetition.js
+++ b/ui/repetition.reel/repetition.js
@@ -231,6 +231,10 @@ var Iteration = exports.Iteration = Montage.specialize( /** @lends Iteration# */
             // Inject the elements into the document
             element.insertBefore(this._fragment, bottomBoundary);
 
+            repetition._drawnIterations.splice(index, 0, this);
+            repetition._updateDrawnIndexes(index);
+            repetition._addDirtyClassListIteration(this);
+
             // Once the child components have drawn once, and thus created all
             // their elements, we can add them to the _iterationForElement map
             var childComponentsLeftToDraw = this._childComponents.length;
@@ -246,15 +250,17 @@ var Iteration = exports.Iteration = Montage.specialize( /** @lends Iteration# */
             };
 
             // notify the components to wake up and smell the document
-            for (var i = 0; i < this._childComponents.length; i++) {
-                var childComponent = this._childComponents[i];
-                childComponent.addEventListener("firstDraw", firstDraw, false);
-                childComponent.needsDraw = true;
+            if (this._childComponents.length > 0) {
+                for (var i = 0; i < this._childComponents.length; i++) {
+                    var childComponent = this._childComponents[i];
+                    childComponent.addEventListener("firstDraw", firstDraw, false);
+                    childComponent.needsDraw = true;
+                }
+            } else {
+                this.forEachElement(function (element) {
+                    repetition._iterationForElement.set(element, self);
+                });
             }
-
-            repetition._drawnIterations.splice(index, 0, this);
-            repetition._updateDrawnIndexes(index);
-            repetition._addDirtyClassListIteration(this);
         }
     },
 


### PR DESCRIPTION
Selection was only working when components were part of the iteration.
This was happening because the data structure we use to know which iteration contains a specific node was only being populated when the child components of the iteration were drawn. Without child components nothing happened.
