### PR TITLE
Fixes for bootstrapping mopped with a <base> tag

### DIFF
--- a/montage.js
+++ b/montage.js
@@ -59,9 +59,12 @@ if (typeof window !== "undefined") {
         // Platform dependent
         platform.bootstrap(function (Require, Promise, URL) {
             var params = platform.getParams();
-            var config = platform.getConfig();
+            var config = {
+                // This takes <base> into account
+                location: Require.getLocation()
+            };
 
-            var montageLocation = URL.resolve(Require.getLocation(), params.montageLocation);
+            var montageLocation = URL.resolve(config.location, params.montageLocation);
 
             config.moduleTypes = ["html", "meta"];
 
@@ -466,12 +469,6 @@ if (typeof window !== "undefined") {
                 script.parentNode.removeChild(script);
             };
             document.getElementsByTagName("head")[0].appendChild(script);
-        },
-
-        getConfig: function() {
-            return {
-                location: "" + window.location
-            };
         },
 
         getParams: function() {


### PR DESCRIPTION
The Require.getLocation() needs to take the base tag into account. Depends upon
https://github.com/montagejs/mr/pull/70 landing in Mr, getting rolled into a release, and integrated here.
