### PR TITLE
Stop rebasing images with no src or empty src

### DIFF
--- a/core/template.js
+++ b/core/template.js
@@ -1191,9 +1191,11 @@ var Template = Montage.specialize( /** @lends Template# */ {
                         }
                     } else {
                         // DOM image
-                        url = node.getAttribute('src');
-                        if (!absoluteUrlRegExp.test(url)) {
-                            node.setAttribute('src', URL.resolve(baseUrl, url));
+                        if (node.hasAttribute("src")) {
+                            url = node.getAttribute('src');
+                            if (url !== "" && !absoluteUrlRegExp.test(url)) {
+                                node.setAttribute('src', URL.resolve(baseUrl, url));
+                            }
                         }
                     }
                 }

--- a/test/reel/template-spec.js
+++ b/test/reel/template-spec.js
@@ -496,6 +496,56 @@ describe("reel/template-spec", function() {
             });
         });
 
+        it("should replace a node into the template and not add a rebased src attribute to images that have a src attribute", function() {
+            var moduleId = "reel/template/modification.html",
+                htmlModification = require("reel/template/template-relative-image.html").content,
+                htmlDocument = document.implementation.createHTMLDocument("");
+
+            return template.initWithModuleId(moduleId, require)
+                .then(function() {
+                    var node, reference;
+
+                    htmlDocument.documentElement.innerHTML = htmlModification;
+
+                    node = htmlDocument.getElementById("content");
+                    reference = template.getElementById("title");
+
+                    template.replaceNode(node, reference);
+
+                    var domImage = template.document.getElementById("no_src");
+
+                    expect(domImage.hasAttribute("src")).toBeFalsy();
+                }).fail(function() {
+                    expect("test").toBe("executed");
+                });
+        });
+
+        it("should replace a node into the template and not modify a src attribute on images that have an empty src attribute", function() {
+            var moduleId = "reel/template/modification.html",
+                htmlModification = require("reel/template/template-relative-image.html").content,
+                htmlDocument = document.implementation.createHTMLDocument("");
+
+            return template.initWithModuleId(moduleId, require)
+                .then(function() {
+                    var node, reference;
+
+                    htmlDocument.documentElement.innerHTML = htmlModification;
+
+                    node = htmlDocument.getElementById("content");
+                    reference = template.getElementById("title");
+
+                    template.replaceNode(node, reference);
+
+                    var domImage = template.document.getElementById("empty_src"),
+                        domSrc = domImage ? domImage.src : "";
+
+                    expect(domSrc).toBe("");
+                }).fail(function() {
+                    expect("test").toBe("executed");
+                });
+        });
+
+
         it("should insert a node to the template and resolve any relative Urls", function() {
             var moduleId = "reel/template/modification.html",
                 htmlModification = require("reel/template/template-relative-image.html").content,

--- a/test/reel/template/template-relative-image.html
+++ b/test/reel/template/template-relative-image.html
@@ -9,6 +9,12 @@
         <!-- DOM image sample -->
         <img id="dom_image" src="./sample-image.jpeg">
 
+        <!-- nosrc sample -->
+        <img id="no_src">
+
+        <!-- empty_src sample -->
+        <img id="empty_src" src="">
+
         <!-- SVG image sample -->
         <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
             <image id="svg_image" width="128" height="128" xlink:href="./sample-image.jpeg"/>


### PR DESCRIPTION
This was triggering extra unnecessary requests that were often for
unexpected resources such a "foo.reel/null"
