### PR TITLE
Fix flow selection management

### DIFF
--- a/ui/flow.reel/flow.html
+++ b/ui/flow.reel/flow.html
@@ -12,18 +12,17 @@
                         "#": "montage-flow-repetition"
                     },
                     "contentController": {
-                        "@": "frustrumController"
+                        "@": "frustumController"
                     }
                 },
                 "bindings": {
                     "isSelectionEnabled": {"<-": "@owner.isSelectionEnabled"}
                 }
             },
-            "frustrumController": {
+            "frustumController": {
                 "prototype": "core/range-controller",
                 "bindings": {
                     "content": {"<-": "@owner.contentController.organizedContent ?? @owner.content"},
-                    "selection": {"<-": "@owner.contentController.selection"},
                     "visibleIndexes": {"<-": "@owner._visibleIndexes"}
                 }
             },
@@ -68,12 +67,13 @@
                     "_cameraElement": {
                         "#": "montage-flow-camera"
                     },
-                    "_frustrumController": {
-                        "@": "frustrumController"
+                    "_frustumController": {
+                        "@": "frustumController"
                     }
                 },
                 "bindings": {
                     "scroll": {"<->": "@flowTranslateComposer.scroll"},
+                    "selection": {"<->": "@frustumController.selection"},
                     "selectedIndexes": {"<-": "@repetition.selectedIndexes"},
                     "activeIndexes": {"<-": "@repetition.activeIndexes"},
                     "draggedSlideIndex": {"<-": "@flowTranslateComposer._closerIndex"}

--- a/ui/flow.reel/flow.js
+++ b/ui/flow.reel/flow.js
@@ -16,7 +16,7 @@ var Flow = exports.Flow = Component.specialize( /** @lends Flow# */ {
         value: function Flow() {
             this.super();
             // The template has a binding from these visibleIndexes to
-            // the frustrum controller's visibleIndexes.  We manage the
+            // the frustum controller's visibleIndexes.  We manage the
             // array within the flow and use it also in the flow
             // translate composer.
             this._visibleIndexes = [];
@@ -25,7 +25,7 @@ var Flow = exports.Flow = Component.specialize( /** @lends Flow# */ {
             // FlowBezierSpline.
             this._slideOffsets = {};
             this.defineBinding("_numberOfIterations", {
-                "<-": "_frustrumController.content.length"
+                "<-": "_frustumController.content.length"
             });
             // dispatches handle_numberOfIterationsChange
             this.addOwnPropertyChangeListener("_numberOfIterations", this);
@@ -997,7 +997,7 @@ var Flow = exports.Flow = Component.specialize( /** @lends Flow# */ {
 
     /**
      * The content that governs the repetition is plucked from the original
-     * content using the frustrumController's visibleIndexes array, which we
+     * content using the frustumController's visibleIndexes array, which we
      * retain a copy of on Flow.
      *
      * In order to prevent jitter and minimize thrashing on the DOM, the Flow
@@ -1440,7 +1440,7 @@ var Flow = exports.Flow = Component.specialize( /** @lends Flow# */ {
     },
 
     /**
-     * The number of visible iterations after frustrum culling, which is
+     * The number of visible iterations after frustum culling, which is
      * subject to variation depending on the scroll offset.
      *
      * <pre>


### PR DESCRIPTION
By reversing the initial direction of a bidirectional binding between
the flow and the contained repetition's content controller.

Also, fix the spelling of frustum.
