### PR TITLE
Fix an issue with the findNodeByContent function of the TreeController.

### DIFF
--- a/core/tree-controller.js
+++ b/core/tree-controller.js
@@ -250,7 +250,7 @@ var Node = exports.TreeControllerNode = Montage.specialize( /** @lends TreeContr
             }
             var node;
             for (var i = 0; i < this.children.length; i++) {
-                if (node = this.children[i].findNodeByContent(content)) {
+                if (node = this.children[i].findNodeByContent(content, equals)) {
                     break;
                 }
             }


### PR DESCRIPTION
The optional comparison function was called just once because it was
not passed during the iteration.
