### PR TITLE
Avoid waiting for inline styles to be loaded

### DIFF
--- a/core/document-resources.js
+++ b/core/document-resources.js
@@ -182,19 +182,17 @@ var DocumentResources = Montage.specialize({
             var url = element.getAttribute("href"),
                 documentHead;
 
-            url = this.normalizeUrl(url);
-
             if (url) {
+                url = this.normalizeUrl(url);
                 if (this.hasResource(url)) {
                     return;
                 } else {
                     this._addResource(url);
                 }
+                this._expectedStyles.push(url);
             }
 
             documentHead = this._document.head;
-
-            this._expectedStyles.push(url);
             documentHead.insertBefore(element, documentHead.firstChild);
         }
     },

--- a/test/document-resources-spec.js
+++ b/test/document-resources-spec.js
@@ -358,6 +358,28 @@ describe("document-resources-spec", function() {
         });
     });
 
+    it("should add an inline style but not wait for it to be loaded like a style file", function() {
+        var resources = new DocumentResources();
+
+        return createPage("reel/template/page.html")
+            .then(function(page) {
+                var style;
+
+                resources.initWithDocument(page.document);
+
+                style = page.document.createElement("style");
+                style.textContent = "body { padding-left: 42px; }";
+
+                resources.addStyle(style);
+
+                expect(resources.areStylesLoaded).toBe(true);
+                deletePage(page);
+            }).fail(function(reason) {
+                console.log(reason.stack);
+                expect("test").toBe("executed");
+            });
+    });
+
     it("should add a style file", function() {
         var resources = new DocumentResources(),
             url = "resource.css";


### PR DESCRIPTION
Not all styles have a file we need to wait to be loaded and doing so
will result in a dead lock in the draw cycle.
