### PR TITLE
Empty contents by removing them with DOM manipulation

### DIFF
--- a/ui/repetition.reel/repetition.js
+++ b/ui/repetition.reel/repetition.js
@@ -1612,7 +1612,10 @@ var Repetition = exports.Repetition = Component.specialize(/** @lends Repetition
     _drawInitialContent: {
         value: function () {
             var element = this.element;
-            element.innerHTML = "";
+            var childNodesCount = element.childNodes.length;
+            for (var i = 0; i < childNodesCount; i++) {
+                element.removeChild(element.firstChild);
+            }
             var bottomBoundary = element.ownerDocument.createTextNode("");
             element.appendChild(bottomBoundary);
             this._boundaries.push(bottomBoundary);


### PR DESCRIPTION
IE has a bug that corrupts the DOM tree of an element when its innerHTML
 is assigned.
