### PR TITLE
Guard against exploring nonexistent serialization

### DIFF
--- a/core/serialization/serialization.js
+++ b/core/serialization/serialization.js
@@ -64,10 +64,12 @@ var Serialization = Montage.specialize( /** @lends Serialization# */ {
 
     getSerializationLabels: {
         value: function() {
+            var serializationObject;
+
             if (!this._serializationLabels) {
-                this._serializationLabels = Object.keys(
-                    this.getSerializationObject()
-                );
+                if (serializationObject = this.getSerializationObject()) {
+                    this._serializationLabels = Object.keys(serializationObject);
+                }
             }
 
             return this._serializationLabels;


### PR DESCRIPTION
If the serialization being parsed for labels has no serializationObject,
don't bother trying to read the keys. `Object.keys` doesn't react well
to a null argument.
