### PR TITLE
Update values when new contentController is set

### DIFF
--- a/test/base/abstract-select-spec.js
+++ b/test/base/abstract-select-spec.js
@@ -123,6 +123,17 @@ describe("test/base/abstract-select-spec", function () {
                 expect(aSelect.value).toBe(content[1]);
             });
 
+            it("should change when content controller is modified", function() {
+                aSelect.contentController.selection = [content[0]];
+
+                var newContentController = new RangeController();
+                newContentController.content = content;
+                newContentController.selection = [content[1]];
+
+                aSelect.contentController = newContentController;
+                expect(aSelect.value).toBe(content[1]);
+            });
+
             it("should change to another value when content controller's selection is removed from the content", function() {
                 aSelect.contentController.selection = [content[0]];
                 aSelect.contentController.content.delete(content[0]);

--- a/ui/base/abstract-select.js
+++ b/ui/base/abstract-select.js
@@ -37,7 +37,8 @@ var AbstractSelect = exports.AbstractSelect = AbstractControl.specialize( /** @l
             this._pressComposer = new PressComposer();
             this.addComposer(this._pressComposer);
             this.contentController = new RangeController();
-            this._values = this.contentController.selection;
+
+            this.addPathChangeListener("contentController", this, "handleContentControllerChange");
 
             this.defineBindings({
                 "content": {
@@ -244,6 +245,15 @@ var AbstractSelect = exports.AbstractSelect = AbstractControl.specialize( /** @l
                 this.value = this.values.one();
             }
             this.needsDraw = true;
+        }
+    },
+
+    handleContentControllerChange: {
+        value: function(value) {
+            if (value) {
+                this._values = value.selection;
+                this.handleValuesRangeChange();
+            }
         }
     },
 


### PR DESCRIPTION
The AbstractSelect was ignoring the selection of a new contentController
and it was still tracking the selection of the previous one.
