### PR TITLE
visibility: collapse instead of display: none

### DIFF
--- a/ui/modal-overlay.reel/modal-overlay.css
+++ b/ui/modal-overlay.reel/modal-overlay.css
@@ -1,5 +1,6 @@
 .montage-ModalOverlay-modalMask {
-    display: none;
+    display: block;
+    visibility: collapse;
     position: absolute;
     z-index: 6999;
     top: 0;
@@ -10,5 +11,5 @@
 }
 
 .montage-ModalOverlay-modalMask--visible {
-    display: block;
+    visibility: visible;
 }


### PR DESCRIPTION
Using visibility: collapse instead of display: none allows for the modal mask properties to be transitioned/animated using just CSS on show()/hide(). This can be useful if the user wants the modal mask to be animated when it is shown/hidden. 

More info about this property: https://developer.mozilla.org/en-US/docs/Web/CSS/visibility
