### PR TITLE
Migrate from global require to mr

### DIFF
--- a/core/application.js
+++ b/core/application.js
@@ -319,7 +319,7 @@ var Application = exports.Application = Target.specialize( /** @lends Applicatio
                 }
             }
 
-            window.require.loadPackage({name: "montage"}).then(function(require) {
+            self.mr.loadPackage({name: "montage"}).then(function(require) {
                 var newWindow = window.open(require.location + "window-loader/index.html", "_blank", stringParamaters);
                 newWindow.loadInfo = loadInfo;
             }).done();

--- a/core/localizer.js
+++ b/core/localizer.js
@@ -177,7 +177,7 @@ var Localizer = exports.Localizer = Montage.specialize( /** @lends Localizer# */
     },
 
     _require: {
-        value: (typeof global !== "undefined") ? global.require : (typeof window !== "undefined") ? window.require : null
+        value: self.mr
     },
 
     /**

--- a/core/meta/binder-manager.js
+++ b/core/meta/binder-manager.js
@@ -153,7 +153,7 @@ var BinderManager = exports.BinderManager = Montage.specialize( /** @lends Binde
     defaultBinder: {
         get: function() {
             if (!this._defaultBinder) {
-                this._defaultBinder = new BinderModule.Binder().initWithNameAndRequire("default", global.require);
+                this._defaultBinder = new BinderModule.Binder().initWithNameAndRequire("default", self.mr);
                 this._defaultBinder.isDefault = true;
                 this.addBinder(this._defaultBinder);
             }

--- a/montage.js
+++ b/montage.js
@@ -282,8 +282,7 @@ if (typeof window !== "undefined") {
                         .done();
                     };
 
-                    global.require = applicationRequire;
-                    global.montageRequire = montageRequire;
+                    self.mr = applicationRequire;
                     platform.initMontage(montageRequire, applicationRequire, params);
                 });
             })

--- a/test/application-spec.js
+++ b/test/application-spec.js
@@ -68,7 +68,7 @@ TestPageLoader.queueTest("application-test", {src: "application-test/application
                 testWindow = testPage.iframe.contentWindow;
             });
             it("should be added to exports", function () {
-                return testWindow.montageRequire.async("core/application")
+                return testWindow.mr.async("montage/core/application")
                     .then(function (exports) {
                         expect(exports.application).toBeDefined();
                     })
@@ -76,7 +76,7 @@ TestPageLoader.queueTest("application-test", {src: "application-test/application
 
             describe("delegate", function() {
                 it("should have willFinishLoading method called", function() {
-                    return testWindow.montageRequire.async("core/application").get("application")
+                    return testWindow.mr.async("montage/core/application").get("application")
                         .then(function(testApplication) {
                             expect(testApplication.delegate.willFinishLoadingCalled).toBeTruthy();
                         })
@@ -100,7 +100,7 @@ TestPageLoader.queueTest("application-test-subtype", {src: "application-test/app
             describe("subtyping", function() {
                 it("should use defined subtype", function() {
                     var testWindow = testPage.iframe.contentWindow;
-                    var testApplication = testWindow.montageRequire("core/application").application;
+                    var testApplication = testWindow.mr("montage/core/application").application;
                     expect(testApplication.testProperty).toBeTruthy();
                 });
 

--- a/test/claimed-pointer-spec.js
+++ b/test/claimed-pointer-spec.js
@@ -45,7 +45,7 @@ TestPageLoader.queueTest("claimed-pointer-test/claimed-pointer-test", function(t
 
         beforeEach(function() {
             var testWindow = testPage.iframe.contentWindow;
-            eventManager = testWindow.montageRequire("core/application").application.eventManager;
+            eventManager = testWindow.mr("montage/core/application").application.eventManager;
             eventManager.reset();
 
             componentA = testPage.test.componentA;

--- a/test/composer/key-composer-spec.js
+++ b/test/composer/key-composer-spec.js
@@ -93,7 +93,7 @@ TestPageLoader.queueTest("key-composer-test/key-composer-test", function(testPag
                         listener2 = testPage.addListener(test.key_composer1, null, "longKeyPress"),
                         listener3 = testPage.addListener(test.key_composer1, null, "keyRelease");
 
-                    testPage.window.montageRequire("core/event/event-manager").defaultEventManager.activeTarget = test.example;
+                    testPage.window.mr("montage/core/event/event-manager").defaultEventManager.activeTarget = test.example;
 
                     testPage.keyEvent({target: testPage.window, modifiers: command, charCode: 0, keyCode: "J".charCodeAt(0)}, "keydown");
                     waits(1050);

--- a/test/core/localizer/serialization-spec.js
+++ b/test/core/localizer/serialization-spec.js
@@ -159,7 +159,7 @@ TestPageLoader.queueTest("fallback/fallback", {directory: module.directory}, fun
             });
 
             it("creates a binding from the localizer to the object", function() {
-                var iframeRequire = testPage.iframe.contentWindow.require;
+                var iframeRequire = testPage.iframe.contentWindow.mr;
 
                 return iframeRequire.async("montage/core/bindings")
                 .then(function(exports) {

--- a/test/events/active-target-spec.js
+++ b/test/events/active-target-spec.js
@@ -181,7 +181,7 @@ TestPageLoader.queueTest("active-target-test/active-target-test", function(testP
             var testTarget, proximalComponent, eventManager;
 
             beforeEach(function () {
-                testTarget = testDocument.defaultView.montageRequire("core/target").Target;
+                testTarget = testDocument.defaultView.mr("montage/core/target").Target;
                 var proximalElement = testDocument.querySelector("[data-montage-id=C0C0B0]");
                 proximalComponent = proximalElement.component;
 
@@ -201,7 +201,7 @@ TestPageLoader.queueTest("active-target-test/active-target-test", function(testP
                     spyOn(listener, "handleFoo").andCallThrough();
                     proximalComponent.addEventListener("foo", listener);
 
-                    var MutableEvent = testDocument.defaultView.montageRequire("core/event/mutable-event").MutableEvent;
+                    var MutableEvent = testDocument.defaultView.mr.getPackage({name: "montage"})("core/event/mutable-event").MutableEvent;
 
                     eventManager.activeTarget.dispatchEvent(MutableEvent.fromType("foo", true, true));
                     expect(listener.handleFoo).toHaveBeenCalled();

--- a/test/events/eventmanager-spec.js
+++ b/test/events/eventmanager-spec.js
@@ -52,7 +52,7 @@ TestPageLoader.queueTest("eventmanagertest/eventmanagertest", function(testPage)
 
         beforeEach(function() {
             var testWindow = testPage.iframe.contentWindow;
-            eventManager = testWindow.montageRequire("core/application").application.eventManager;
+            eventManager = testWindow.mr("montage/core/application").application.eventManager;
 
             testDocument = testPage.iframe.contentDocument;
 

--- a/test/events/object-hierarchy-spec.js
+++ b/test/events/object-hierarchy-spec.js
@@ -40,8 +40,8 @@ TestPageLoader.queueTest("object-hierarchy-test/object-hierarchy-test", function
         beforeEach(function() {
             var testWindow = testPage.iframe.contentWindow;
             var testDocument = testPage.iframe.contentDocument;
-            testTarget = testDocument.defaultView.montageRequire("core/target").Target;
-            testApplication = testWindow.montageRequire("core/application").application;
+            testTarget = testDocument.defaultView.mr.getPackage({name: "montage"})("core/target").Target;
+            testApplication = testWindow.mr.getPackage({name: "montage"})("core/application").application;
             eventManager = testApplication.eventManager;
             eventManager.reset();
         });

--- a/test/meta/blueprint-spec.js
+++ b/test/meta/blueprint-spec.js
@@ -25,7 +25,7 @@ describe("meta/blueprint-spec", function () {
         describe("Creation", function () {
         });
         describe("Adding blueprints", function () {
-            var binder = new Binder().initWithNameAndRequire("CompanyBinder", global.require);
+            var binder = new Binder().initWithNameAndRequire("CompanyBinder", self.mr);
 
             var personBlueprint = new Blueprint().initWithName("Person");
             binder.addBlueprint(personBlueprint);
@@ -90,7 +90,7 @@ describe("meta/blueprint-spec", function () {
         describe("blueprint to instance association", function () {
             var binder, personBlueprint, companyBlueprint;
             beforeEach(function () {
-                binder = new Binder().initWithNameAndRequire("Binder", global.require);
+                binder = new Binder().initWithNameAndRequire("Binder", self.mr);
                 personBlueprint = new Blueprint().initWithName("Person");
                 binder.addBlueprint(personBlueprint);
                 companyBlueprint = new Blueprint().initWithName("Company");
@@ -104,7 +104,7 @@ describe("meta/blueprint-spec", function () {
         describe("applying a basic blueprint to a prototype", function () {
             var louis, personBlueprint;
             beforeEach(function () {
-                var binder = new Binder().initWithNameAndRequire("Binder", global.require);
+                var binder = new Binder().initWithNameAndRequire("Binder", self.mr);
                 personBlueprint = new Blueprint().initWithName("Person");
                 personBlueprint.addPropertyBlueprint(personBlueprint.newPropertyBlueprint("name", 1));
                 personBlueprint.addPropertyBlueprint(personBlueprint.newPropertyBlueprint("keywords", Infinity));
@@ -127,7 +127,7 @@ describe("meta/blueprint-spec", function () {
         describe("adding a PropertyBlueprint", function () {
             var circle, shapeBlueprint;
             beforeEach(function () {
-                var binder = new Binder().initWithNameAndRequire("Binder", global.require);
+                var binder = new Binder().initWithNameAndRequire("Binder", self.mr);
                 shapeBlueprint = new Blueprint().initWithName("Shape");
                 binder.addBlueprint(shapeBlueprint);
                 var propertyBlueprint = shapeBlueprint.newPropertyBlueprint("size", 1);

--- a/test/meta/blueprint/binderhelper.js
+++ b/test/meta/blueprint/binderhelper.js
@@ -12,7 +12,7 @@ exports.BinderHelper = Montage.specialize( {
 }, {
     companyBinder: {
         value: function() {
-            var companyBinder = new Binder().initWithNameAndRequire("CompanyBinder", global.require);
+            var companyBinder = new Binder().initWithNameAndRequire("CompanyBinder", self.mr);
 
             var personBlueprint = companyBinder.addBlueprintNamed("Person", "meta/blueprint/person");
             personBlueprint.addToOnePropertyBlueprintNamed("name");

--- a/test/trigger/trigger-spec.js
+++ b/test/trigger/trigger-spec.js
@@ -92,7 +92,7 @@ describe("trigger-test", function() {
 
         it("should be able to inject a packaged description", function() {
             // the inject-description-location.json is supposed to define the main modules as inject.js
-            var injectModule = TestPageLoader.testPage.window.require.async("to-be-defined/inject");
+            var injectModule = TestPageLoader.testPage.window.mr.async("to-be-defined/inject");
 
             return injectModule.then(function(inject) {
                 expect(inject.injected).toBeTruthy();
@@ -101,7 +101,7 @@ describe("trigger-test", function() {
         });
         it("should be able to inject a packaged description location", function() {
             // the inject-description-location.json is supposed to define the main modules as inject.js
-            var injectModule = TestPageLoader.testPage.window.require.async("inject-description-location");
+            var injectModule = TestPageLoader.testPage.window.mr.async("inject-description-location");
 
             return injectModule.then(function(inject) {
                 expect(inject.injected).toBeTruthy();
@@ -110,7 +110,7 @@ describe("trigger-test", function() {
         });
         it("should be able to inject a mapping", function() {
 
-            var injectModule = TestPageLoader.testPage.window.require.async("__custom/inject");
+            var injectModule = TestPageLoader.testPage.window.mr.async("__custom/inject");
 
             return injectModule.then(function(inject) {
                 expect(inject.injected).toBeTruthy();
@@ -119,7 +119,7 @@ describe("trigger-test", function() {
         });
         it("should be able to inject a dependency", function() {
 
-            var injectModule = TestPageLoader.testPage.window.require.async("injected-dependency/inject");
+            var injectModule = TestPageLoader.testPage.window.mr.async("injected-dependency/inject");
 
             return injectModule.then(function(inject) {
                 expect(inject.injected).toBeTruthy();
@@ -128,7 +128,7 @@ describe("trigger-test", function() {
         });
         it("should be able to still use an existing dependency", function() {
 
-            var injectModule = TestPageLoader.testPage.window.require.async("existing/inject");
+            var injectModule = TestPageLoader.testPage.window.mr.async("existing/inject");
 
             return injectModule.then(function(inject) {
                 expect(inject.injected).toBeTruthy();

--- a/test/ui/component-spec.js
+++ b/test/ui/component-spec.js
@@ -555,7 +555,7 @@ TestPageLoader.queueTest("draw/draw", function(testPage) {
 
             describe("the component tree", function() {
                 it("should reorganize the component tree when a new component is added", function() {
-                    var Component = testPage.window.require("montage/ui/component").Component,
+                    var Component = testPage.window.mr("montage/ui/component").Component,
                         componentE1 = new Component(),
                         element = testPage.window.document.getElementById("componentE1");
 

--- a/test/ui/repetition-spec.js
+++ b/test/ui/repetition-spec.js
@@ -50,7 +50,7 @@ TestPageLoader.queueTest("repetition/repetition", function(testPage) {
         };
 
         beforeEach(function () {
-            application = testPage.window.montageRequire("core/application").application;
+            application = testPage.window.mr("montage/core/application").application;
             eventManager = application.eventManager;
             delegate = application.delegate;
         });
@@ -249,7 +249,7 @@ TestPageLoader.queueTest("repetition/repetition", function(testPage) {
             });
 
             xit("[TODO] should create a repetition programmatically", function() {
-                var Repetition = testPage.window.require("montage/ui/repetition.reel").Repetition,
+                var Repetition = testPage.window.mr("montage/ui/repetition.reel").Repetition,
                     repetition = new Repetition();
 
                 repetition.element = querySelector(".list12");

--- a/test/ui/repetition/repetition.html
+++ b/test/ui/repetition/repetition.html
@@ -643,7 +643,7 @@ POSSIBILITY OF SUCH DAMAGE.
                     "element": {"#": "objectAtCurrentIteration"}
                 },
                 "bindings": {
-                    "value": {"<-": "@repetitionWithObjectAtCurrentIteration.objectAtCurrentIteration"}
+                    "value": {"<-": "@repetitionWithObjectAtCurrentIteration:iteration.object"}
                 }
             },
 

--- a/ui/loader.reel/loader.js
+++ b/ui/loader.reel/loader.js
@@ -301,7 +301,7 @@ exports.Loader = Component.specialize( /** @lends Loader# */ {
             }
             this.isLoadingMainComponent = true;
             var self = this;
-            window.require.async(this.mainModule)
+            mr.async(this.mainModule)
             .then(function (exports) {
                 if (!(self.mainName in exports)) {
                     throw new Error(self.mainName + " was not found in " + self.mainModule);

--- a/window-loader/window-loader.js
+++ b/window-loader/window-loader.js
@@ -9,7 +9,7 @@ require.loadPackage(parentWindow.require.location)
         callback = loadInfo.callback;
 
     // Switching the package context back to the parent application
-    window.require = require;
+    window.mr = require;
 
     return require.async("montage/ui/component")
     .then(function(exports) {


### PR DESCRIPTION
:warning: Pending https://github.com/montagejs/montage-testing/pull/14

Fixes #1039

Many other names were considered including montageRequire (discarded
because it conflicts with a global variable used in Montage Testing),
applicationRequire (not specific enough to Montage), Montage.require
(because Montage is not a global and would be confused with and mask the
Montage constructor), and various others. `mr` balances specificity and
brevity.
