### PR TITLE
Fix when checking if browsers implement support for the HTML5 MediaController

### DIFF
--- a/test/events/eventmanager-spec.js
+++ b/test/events/eventmanager-spec.js
@@ -123,7 +123,7 @@ TestPageLoader.queueTest("eventmanagertest/eventmanagertest", function(testPage)
                 });
             }
 
-            if (MediaController) {
+            if (typeof MediaController !== "undefined") {
                 it("should have overridden the addEventListener for MediaController", function() {
                     var mediaController = testDocument.defaultView.MediaController.prototype;
                     expect(mediaController.nativeAddEventListener).toBeTruthy();
@@ -162,7 +162,7 @@ TestPageLoader.queueTest("eventmanagertest/eventmanagertest", function(testPage)
                 });
             }
 
-            if (MediaController) {
+            if (typeof MediaController !== "undefined") {
                 it("should have overridden the addEventListener for MediaController", function() {
                     var mediaController = testDocument.defaultView.MediaController.prototype;
                     expect(mediaController.nativeRemoveEventListener).toBeTruthy();


### PR DESCRIPTION
Avoid to raise a ReferenceError type Event when the HTML5 MediaController is not supported.
