### PR TITLE
Fix an issue when a component without an element is the content of a Slot Component.

### DIFF
--- a/ui/slot.reel/slot.js
+++ b/ui/slot.reel/slot.js
@@ -81,6 +81,13 @@ exports.Slot = Component.specialize( /** @lends Slot# */ {
                     if (this.delegate && typeof this.delegate.slotElementForComponent === "function") {
                         element = this.delegate.slotElementForComponent(this, value, element);
                     }
+
+                    if (this.isDeserializing) {
+                        // Allows to a component without an initial element,
+                        // to be correctly attached to its parentComponent during the deserializing phase.
+                        this.element.appendChild(element);
+                    }
+
                     value.element = element;
                 } else {
                     element = value.element;


### PR DESCRIPTION
Allows to a component without an initial DOM element to be the content of a Slot Component and to be correctly attached to its parentComponent during the deserializing phase.
