### PR TITLE
Bunch of fixes for the Repetition Component

### DIFF
--- a/ui/repetition.reel/repetition.js
+++ b/ui/repetition.reel/repetition.js
@@ -18,7 +18,7 @@ var Observers = require("frb/observers");
 var observeProperty = Observers.observeProperty;
 var observeKey = Observers.observeKey;
 
-var TIMEOUT_BEFORE_ITERATION_BECOME_ACTIVE = 45;
+var TIMEOUT_BEFORE_ITERATION_BECOME_ACTIVE = 60;
 
 /**
  * A reusable view-model for each iteration of a repetition.  Each iteration


### PR DESCRIPTION
Bunch of fixes:
- Allows to disable a selection when a user move its pointer (finger, mouse…) after having begin to select an iteration.
- Allows an iteration to become active after a certain delay. Which allows us to scroll the repetition without making any iteration active.
- Make sure the future selected Iteration is also the current active Iteration.
