### PR TITLE
Fix accelerated scrolling within the repetition

### DIFF
--- a/ui/repetition.reel/repetition.js
+++ b/ui/repetition.reel/repetition.js
@@ -1917,8 +1917,6 @@ var Repetition = exports.Repetition = Component.specialize(/** @lends Repetition
             }
 
             if (touch) {
-                event.preventDefault();
-
                 this._move(touch.clientX, touch.clientY);
             }
         }


### PR DESCRIPTION
Don’t cancel the event touchmove in order to fix the bug with the webkit accelerated scrolling.
