### PR TITLE
Workaround for IE 11, it doesn't set defaultPrevented for custom events when preventDefault is called.

### DIFF
--- a/core/event/key-manager.js
+++ b/core/event/key-manager.js
@@ -799,7 +799,7 @@ var KeyManager = exports.KeyManager = Montage.specialize(/** @lends KeyManager# 
                 keyComposer.dispatchEvent(keyComposerEvent);
 
                 // console.log("keyComposer Event DISPATCHED:", keyComposerEvent, event.target, keyComposer);
-                if (keyComposerEvent.defaultPrevented) {
+                if (keyComposerEvent._isDefaultPrevented) {
                     event.preventDefault();
                 }
                 if (keyComposerEvent.propagationStopped) {

--- a/core/target.js
+++ b/core/target.js
@@ -106,7 +106,7 @@ exports.Target = Montage.specialize( /** @lends Target# */ {
             targettedEvent.target = this;
             defaultEventManager.handleEvent(targettedEvent);
 
-            return !event.defaultPrevented;
+            return !targettedEvent.getPreventDefault();
         }
     },
 
@@ -125,7 +125,7 @@ exports.Target = Montage.specialize( /** @lends Target# */ {
             event.target = this;
             defaultEventManager.handleEvent(event);
 
-            return !event.defaultPrevented;
+            return !event.getPreventDefault();
         }
     },
 


### PR DESCRIPTION
https://code.google.com/p/dart/issues/detail?id=20350
:warning: do not merge yet
