### PR TITLE
Better catch for checking if the feature WebKitPoint is supported.

### DIFF
--- a/core/dom.js
+++ b/core/dom.js
@@ -212,9 +212,6 @@ var _offsetForElement = function(element) {
 };
 
 var _webKitPoint = null;
-try {
-    _webKitPoint = new WebKitPoint(0,0);
-} catch (e) {}
 
 var webkitImplementation = function() {
     exports.convertPointFromNodeToPage = function(element, point) {
@@ -268,7 +265,8 @@ var shimImplementation = function() {
     };
 };
 
-if (_webKitPoint) {
+if (typeof WebKitPoint !== "undefined") {
+    _webKitPoint = new WebKitPoint(0,0);
     webkitImplementation();
 } else {
     shimImplementation();


### PR DESCRIPTION
Performance are not impacted on browsers that supports this feature, but they are really impacted on browsers that don’t. IE 11, Firefox 12 and Chrome 40.0.2202.3 canary.
