### PR TITLE
Moved the property definition out of superForImplementation to avoid doi...

### DIFF
--- a/core/core.js
+++ b/core/core.js
@@ -667,15 +667,17 @@ var superImplementation = function super_() {
     return typeof superFunction === "function" ? superFunction.bind(this) : Function.noop;
 };
 
+Montage.defineProperty(Montage, "_superContext", {
+    value: null
+});
+
 var superForImplementation = function (object, propertyType, propertyName) {
     var superFunction, superObject, property, cacheObject, boundSuper,
         context = object,
         cacheId = propertyName + "." + propertyType;
 
     if (!object._superContext) {
-        Montage.defineProperty(object, "_superContext", {
-            value: {}
-        });
+        object._superContext = {};
     }
     // is there a super context for this call? I.e. does the super() call originate in an ancestor of object?
     // If so, we use that object as the starting point (context) when looking for the super method.


### PR DESCRIPTION
...ng it per instance for all objects specialized off Montage. Objects not descending from Montage would still get an object assigned. No regression found through one app and Montage automated tests
