### PR TITLE
Add support of a wheel button of a pointing device is rotated with the TranslateComposer under IE9-11.

### DIFF
--- a/composer/translate-composer.js
+++ b/composer/translate-composer.js
@@ -1079,7 +1079,7 @@ var TranslateComposer = exports.TranslateComposer = Composer.specialize(/** @len
                 this._element.addEventListener("mousedown", this, false);
 
                 var wheelEventName;
-                if (typeof window.onwheel !== "undefined"){
+                if (typeof window.onwheel !== "undefined" || typeof window.WheelEvent !== "undefined" ){
                     wheelEventName = "wheel";
                 } else {
                     wheelEventName = "mousewheel";

--- a/test/composer/translate-composer/translate-composer-spec.js
+++ b/test/composer/translate-composer/translate-composer-spec.js
@@ -284,7 +284,7 @@ TestPageLoader.queueTest("translate-composer-test", function(testPage) {
 
                     var eventName = "mousewheel";
                     var deltaPropertyName = "wheelDeltaY";
-                    if ("onwheel" in document.createElement("div")) {
+                    if (typeof window.onwheel !== "undefined" || typeof window.WheelEvent !== "undefined" ){
                         eventName = "wheel";
                         deltaPropertyName = "deltaY";
                     }


### PR DESCRIPTION
Internet Explorer exposes the wheel event only via addEventListener, there is no onwheel attribute on DOM objects. So, the TranslateComposer was listening to a MouseWheelEvent (even if it supports the WheelEvent) which has no wheelDeltaX or wheelDeltaY properties under IE, just a property named wheelDelta. That property just allow us to determine the distance and direction that the wheel button has rolled.

https://connect.microsoft.com/IE/feedback/details/782835/missing-onwheel-attribute-for-the-wheel-event-although-its-supported-via-addeventlistener
