### PR TITLE
Add .info loader

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,23 @@
+<!--.info loader-->
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+
+    <title>Montage Framework - Component Overview</title>
+
+    <script src="montage.js" async></script>
+    <script type="text/montage-serialization">
+    {
+        "owner": {
+            "prototype": "ui/loader.reel",
+            "properties": {
+                "mainModule": "ui/overview.reel"
+            }
+        }
+    }
+    </script>
+</head>
+<body>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -28,15 +28,16 @@
   "dependencies": {
     "collections": "~1.2.1",
     "frb": "~0.2.18",
-    "mr": "~0.15.3",
-    "mousse": "~0.3.0",
     "htmlparser2": "~3.0.5",
-    "q-io": "~1.11.0",
-    "q": "1.0.0"
+    "mousse": "~0.3.0",
+    "mr": "~0.15.3",
+    "q": "1.0.0",
+    "q-io": "~1.11.0"
   },
   "devDependencies": {
+    "jshint": "~2.4.4",
     "montage-testing": "~0.4.1",
-    "jshint": "~2.4.4"
+    "native": "~0.2.0"
   },
   "scripts": {
     "test": "node test/node/node-spec.js",

--- a/ui/overview.reel/overview.html
+++ b/ui/overview.reel/overview.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script type="text/montage-serialization">
+        {
+            "owner": {
+                "properties": {
+                    "element": {"#": "main"}
+                }
+            },
+            "select": {
+                "prototype": "native/ui/select.reel",
+                "properties": {
+                    "element": {"#": "select"}
+                },
+                "bindings": {
+                    "content": {
+                        "<-": "@owner.componentList"
+                    }
+                }
+            },
+            "substitution": {
+                "prototype": "ui/substitution.reel",
+                "properties": {
+                    "element": {"#": "substitution"}
+                },
+                "bindings": {
+                    "switchValue": {
+                        "<-": "@select.contentController.selection.0"
+                    }
+                }
+            }
+        }
+    </script>
+</head>
+
+<body>
+<div data-montage-id="main" data-montage-skin="light">
+    <select data-montage-id="select"></select>
+
+    <hr/>
+
+    <div data-montage-id="substitution">
+        <!--add components below-->
+    </div>
+</div>
+
+
+</body>
+</html>

--- a/ui/overview.reel/overview.js
+++ b/ui/overview.reel/overview.js
@@ -1,0 +1,10 @@
+var Component = require("ui/component").Component;
+
+exports.Main = Component.specialize({
+    componentList: {value: [
+        "Select a .info to render",
+        "--------------------"
+        // add component class names below, UpperCamelCase
+        // e.g.: "SegmentedBar"
+    ]}
+});


### PR DESCRIPTION
Reverted to using hard-coded `.info`s, select & substitution approach due to unable to bind to `mainModule` in `index.html`'s loader, reviewed by @thibaultzanini 

Adding `native` as npm dep due to https://github.com/montagejs/montage/issues/1530, can be removed once fixed

This PR doesn't render any `.info`s, just the skeleton. First working rendering will come with #1515

Blocking #1515 & #1522

Ready to be reviewed & merged