### PR TITLE
Add Succession, Transition & enable Component build-in / build-out CSS animation

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,9 +35,11 @@
     "q-io": "~1.11.0"
   },
   "devDependencies": {
+    "animate.css": "^3.1.1",
     "jshint": "~2.4.4",
     "montage-testing": "~0.4.1",
-    "native": "~0.2.0"
+    "native": "~0.2.0",
+    "normalize.css": "^3.x"
   },
   "scripts": {
     "test": "node test/node/node-spec.js",

--- a/ui/overview.reel/overview.html
+++ b/ui/overview.reel/overview.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <link rel="stylesheet" href="/node_modules/normalize.css/normalize.css"/>
     <script type="text/montage-serialization">
         {
             "owner": {
@@ -14,9 +15,7 @@
                     "element": {"#": "select"}
                 },
                 "bindings": {
-                    "content": {
-                        "<-": "@owner.componentList"
-                    }
+                    "content": {"<-": "@owner.componentList"}
                 }
             },
             "substitution": {
@@ -35,6 +34,12 @@
                 "properties": {
                     "element": {"#": "SegmentedBar"}
                 }
+            },
+            "Succession": {
+                "prototype": "ui/succession.info/sample/main.reel",
+                "properties": {
+                    "element": {"#": "Succession"}
+                }
             }
         }
     </script>
@@ -47,8 +52,12 @@
     <hr/>
 
     <div data-montage-id="substitution">
+        <!--blank placeholder-->
+        <div data-arg="Select a .info to render"></div>
+
         <!--add components below-->
         <div data-montage-id="SegmentedBar" data-arg="SegmentedBar"></div>
+        <div data-montage-id="Succession" data-arg="Succession"></div>
     </div>
 </div>
 

--- a/ui/overview.reel/overview.js
+++ b/ui/overview.reel/overview.js
@@ -8,6 +8,7 @@ exports.Main = Component.specialize({
         "--------------------",
         // add component class names below, UpperCamelCase
         // e.g.: "SegmentedBar"
-        "SegmentedBar"
+        "SegmentedBar",
+        "Succession"
     ]}
 });

--- a/ui/succession.info/sample/bar.reel/bar.css
+++ b/ui/succession.info/sample/bar.reel/bar.css
@@ -1,0 +1,9 @@
+.bar {
+    width: 100%;
+    height: 100%;
+    min-width: 100px;
+    min-height: 100px;
+    background: orange;
+    color: white;
+    overflow: auto;
+}

--- a/ui/succession.info/sample/bar.reel/bar.css
+++ b/ui/succession.info/sample/bar.reel/bar.css
@@ -5,5 +5,6 @@
     min-height: 100px;
     background: orange;
     color: white;
-    overflow: auto;
+    border: 5px orangered solid;
+    box-sizing: border-box;
 }

--- a/ui/succession.info/sample/bar.reel/bar.html
+++ b/ui/succession.info/sample/bar.reel/bar.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <title>Bar Component</title>
+
+    <link rel="stylesheet" href="bar.css">
+
+    <script type="text/montage-serialization">
+    {
+        "owner": {
+            "properties": {
+                "element": {"#": "Bar"}
+            }
+        }
+    }
+    </script>
+</head>
+<body>
+    <div data-montage-id="Bar" class="bar">
+        <h2>Static String.</h2>
+    </div>
+</body>
+</html>

--- a/ui/succession.info/sample/bar.reel/bar.js
+++ b/ui/succession.info/sample/bar.reel/bar.js
@@ -1,0 +1,7 @@
+"use strict";
+
+var Component = require("ui/component").Component;
+
+exports.Bar = Component.specialize({
+    displayTitle: {value: "Bar Component"}
+});

--- a/ui/succession.info/sample/foo.reel/foo.css
+++ b/ui/succession.info/sample/foo.reel/foo.css
@@ -1,0 +1,9 @@
+.foo {
+    width: 100%;
+    height: 100%;
+    min-width: 100px;
+    min-height: 100px;
+    color: white;
+    background: dodgerblue;
+    overflow: auto;
+}

--- a/ui/succession.info/sample/foo.reel/foo.html
+++ b/ui/succession.info/sample/foo.reel/foo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <title>Foo Component</title>
+
+    <link rel="stylesheet" href="foo.css">
+
+    <script type="text/montage-serialization">
+    {
+        "owner": {
+            "properties": {
+                "element": {"#": "Foo"}
+            }
+        },
+        "text": {
+            "prototype": "ui/text.reel",
+            "properties": {
+                "element": {"#": "text"}
+            },
+            "bindings": {
+                "value": {"<-": "@owner.displayTitle"}
+            }
+        },
+        "condition": {
+            "prototype": "ui/condition.reel",
+            "properties": {
+                "element": {"#": "condition"}
+            },
+            "bindings": {
+                "condition": {"<-": "@owner.destinationData"}
+            }
+        },
+        "data": {
+            "prototype": "ui/text.reel",
+            "properties": {
+                "element": {"#": "data"}
+            },
+            "bindings": {
+                "value": {"<-": "@owner.destinationData"}
+            }
+        }
+    }
+    </script>
+</head>
+<body>
+    <div data-montage-id="Foo" class="foo">
+        <h2 data-montage-id="text"></h2>
+        <div data-montage-id="condition">
+            Data from source of the transition that lead to this component:
+            <pre data-montage-id="data"></pre>
+        </div>
+    </div>
+</body>
+</html>

--- a/ui/succession.info/sample/foo.reel/foo.js
+++ b/ui/succession.info/sample/foo.reel/foo.js
@@ -1,0 +1,7 @@
+"use strict";
+
+var Component = require("ui/component").Component;
+
+exports.Foo = Component.specialize({
+    displayTitle: {value: "Foo Component"}
+});

--- a/ui/succession.info/sample/main.reel/main.css
+++ b/ui/succession.info/sample/main.reel/main.css
@@ -1,0 +1,95 @@
+.main {
+    text-align: center;
+}
+
+.wrapper {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-pack: center;
+    -webkit-justify-content: center;
+    -ms-flex-pack: center;
+    justify-content: center;
+    margin: 20px 0 20px 0;
+}
+
+.container,
+.stack {
+    width: 375px;
+    height: 667px;
+    margin: 0 20px 0 20px;
+}
+
+.container {
+    border: 1px lightgray solid;
+}
+
+.stack {
+    text-align: left;
+}
+
+.stack .top::after,
+.stack .previous::after,
+.stack .first::after {
+    font-size: 0.8em;
+    padding-left: 10px;
+}
+
+.stack li {
+    font-family: monospace;
+}
+
+.stack .top::after {
+    content: "top";
+    color: green;
+}
+
+.stack .previous::after {
+    content: "previous";
+    color: orange;
+}
+
+.stack .first::after {
+    content: "first";
+    color: gray;
+}
+
+.overflow-hidden {
+    overflow: hidden;
+}
+
+.transform-start {
+    -webkit-transition: all .75s cubic-bezier(0.165, 0.84, 0.44, 1);
+    transition: all .75s cubic-bezier(0.165, 0.84, 0.44, 1);
+    -webkit-transform: translateX(100%);
+    transform: translateX(100%);
+    opacity: .5;
+}
+
+.transform-end {
+    -webkit-transform: translateX(0);
+    transform: translateX(0);
+    opacity: 1;
+}
+
+.transform-build-out {
+    -webkit-transition: all .75s cubic-bezier(0.165, 0.84, 0.44, 1);
+    transition: all .75s cubic-bezier(0.165, 0.84, 0.44, 1);
+    -webkit-transform: translateX(-100%);
+    transform: translateX(100%);
+    opacity: .5;
+}
+
+.animated {
+    -webkit-animation-duration: 0.75s;
+    animation-duration: 0.75s;
+}
+
+.montage-transition-parent {
+    position: relative;
+}
+
+.montage-transition-child {
+    position: absolute;
+}

--- a/ui/succession.info/sample/main.reel/main.css
+++ b/ui/succession.info/sample/main.reel/main.css
@@ -27,6 +27,7 @@
 
 .stack {
     text-align: left;
+    overflow: scroll;
 }
 
 .stack .top::after,
@@ -34,6 +35,7 @@
 .stack .first::after {
     font-size: 0.8em;
     padding-left: 10px;
+    font-weight: bold;
 }
 
 .stack li {

--- a/ui/succession.info/sample/main.reel/main.html
+++ b/ui/succession.info/sample/main.reel/main.html
@@ -1,0 +1,218 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <title>succession.info</title>
+
+    <link rel="stylesheet" href="main.css">
+    <link rel="stylesheet" href="/node_modules/animate.css/animate.min.css"/>
+
+    <script type="text/montage-serialization">
+    {
+        "owner": {
+            "properties": {
+                "element": {"#": "Main"}
+            }
+        },
+        "Succession1": {
+            "prototype": "ui/succession.reel",
+            "properties": {
+                "element": {"#": "Succession1"}
+            },
+            "bindings": {
+                "top.destination.destinationData": {"<-": "this.top.destinationData"}
+            }
+        },
+        "push": {
+            "prototype": "native/ui/button.reel",
+            "properties": {
+                "element": {"#": "push"}
+            },
+            "listeners": [
+                {
+                    "type": "action",
+                    "listener": {"@": "owner"}
+                }
+            ]
+        },
+        "pop": {
+            "prototype": "native/ui/button.reel",
+            "properties": {
+                "element": {"#": "pop"}
+            },
+            "listeners": [
+                {
+                    "type": "action",
+                    "listener": {"@": "owner"}
+                }
+            ]
+        },
+        "clear": {
+            "prototype": "native/ui/button.reel",
+            "properties": {
+                "element": {"#": "clear"}
+            },
+            "listeners": [
+                {
+                    "type": "action",
+                    "listener": {"@": "owner"}
+                }
+            ]
+        },
+        "toggleOverflow": {
+            "prototype": "native/ui/button.reel",
+            "properties": {
+                "element": {"#": "toggleOverflow"}
+            },
+            "listeners": [
+                {
+                    "type": "action",
+                    "listener": {"@": "owner"}
+                }
+            ]
+        },
+        "stack": {
+            "prototype": "ui/repetition.reel",
+            "properties": {
+                "element": {"#": "stack"}
+            },
+            "bindings": {
+                "contentController": {"<-": "@Succession1.stack"},
+                "contentController.reversed": {"<-": "true"}
+            }
+        },
+        "destinationDisplayTitle": {
+            "prototype": "ui/text.reel",
+            "properties": {
+                "element": {"#": "destinationDisplayTitle"}
+            },
+            "bindings": {
+                "value": {"<-": "@stack:iteration.object.destination.displayTitle"},
+                "classList.has('top')": {"<-": "@stack:iteration.object.destination == @Succession1.top.destination"},
+                "classList.has('previous')": {"<-": "@stack:iteration.object.destination == @Succession1.previous.destination"},
+                "classList.has('first')": {"<-": "@stack:iteration.object.destination == @Succession1.first.destination"}
+            }
+        },
+        "sourceDisplayTitle": {
+            "prototype": "ui/text.reel",
+            "properties": {
+                "element": {"#": "sourceDisplayTitle"}
+            },
+            "bindings": {
+                "value": {"<-": "@stack:iteration.object.source.displayTitle ?? 'N/A'"}
+            }
+        },
+
+
+        "select": {
+            "prototype": "native/ui/select.reel",
+            "properties": {
+                "element": {"#": "select"},
+                "content": ["Foo", "Bar"],
+                "value": "Foo"
+            }
+        },
+        "substitution": {
+            "prototype": "ui/substitution.reel",
+            "properties": {
+                "element": {"#": "substitution"}
+            },
+            "bindings": {
+                "switchValue": {
+                    "<-": "@select.contentController.selection.0"
+                }
+            }
+        },
+        "Foo": {
+            "prototype": "ui/succession.info/sample/foo.reel",
+            "properties": {
+                "element": {"#": "Foo"},
+                "buildInCSSClassStart": "transform-start",
+                "buildInCSSClassEnd": "transform-end",
+                "buildOutCSSClass": "transform-build-out"
+            }
+        },
+        "Bar": {
+            "prototype": "ui/succession.info/sample/bar.reel",
+            "properties": {
+                "element": {"#": "Bar"},
+                "buildInCSSClassStart": "transform-start",
+                "buildInCSSClassEnd": "transform-end",
+                "buildOutCSSClass": "transform-build-out"
+            }
+        },
+
+
+        "detach": {
+            "prototype": "native/ui/button.reel",
+            "properties": {
+                "element": {"#": "detach"}
+            },
+            "listeners": [
+                {
+                    "type": "action",
+                    "listener": {"@": "owner"}
+                }
+            ]
+        },
+        "Bar2": {
+            "prototype": "ui/succession.info/sample/bar.reel",
+            "properties": {
+                "element": {"#": "Bar2"},
+                "buildInCSSClassStart": "transform-start",
+                "buildInCSSClassEnd": "transform-end",
+                "buildOutCSSClass": "transform-build-out"
+            }
+        },
+        "text": {
+            "prototype": "ui/text.reel",
+            "properties": {
+                "element": {"#": "text"},
+                "value": "Hello World.",
+                "buildInCSSClassStart": "transform-start",
+                "buildInCSSClassEnd": "transform-end",
+                "buildOutCSSClass": "transform-build-out"
+            }
+        }
+    }
+    </script>
+</head>
+<body>
+    <div data-montage-id="Main" class="main">
+        <h2>Inside Succession</h2>
+        <button data-montage-id="push">Push</button>
+        <button data-montage-id="pop">Pop</button>
+        <button data-montage-id="clear">Clear</button>
+        <button data-montage-id="toggleOverflow">Toggle Overflow</button>
+
+        <div class="wrapper">
+            <div data-montage-id="Succession1" class="container overflow-hidden"></div>
+            <div class="stack">
+                <h3>Succession Stack</h3>
+                <ul data-montage-id="stack">
+                    <li>
+                        <div>destination: <span data-montage-id="destinationDisplayTitle"></span></div>
+                        <div>source: <span data-montage-id="sourceDisplayTitle"></span></div>
+                    </li>
+                </ul>
+            </div>
+        </div>
+
+        <h2>Inside Subsititution</h2>
+        <select data-montage-id="select"></select>
+        <div class="wrapper">
+            <div data-montage-id="substitution" class="container overflow-hidden">
+                <div data-montage-id="Foo" data-arg="Foo"></div>
+                <div data-montage-id="Bar" data-arg="Bar"></div>
+            </div>
+        </div>
+
+        <h2>Stand-alone components declared in serialization</h2>
+        <button data-montage-id="detach">Detach From Component Tree</button>
+        <br/>
+        <br/>
+        <div data-montage-id="Bar2" data-arg="Bar2"></div>
+        <h3 data-montage-id="text"></h3>
+    </div>
+</body>
+</html>

--- a/ui/succession.info/sample/main.reel/main.js
+++ b/ui/succession.info/sample/main.reel/main.js
@@ -9,6 +9,9 @@ exports.Main = Component.specialize({
     foo: {
         get: function () {
             var component = new Foo();
+            //component.classList.add("animated");
+            //component.buildInCSSClassStart = "zoomInDown";
+            //component.buildOutCSSClass = "zoomOutDown";
             component.buildInCSSClassStart = "transform-start";
             component.buildInCSSClassEnd = "transform-end";
             component.buildOutCSSClass = "transform-build-out";
@@ -21,6 +24,9 @@ exports.Main = Component.specialize({
             component.classList.add("animated");
             component.buildInCSSClassStart = "zoomInDown";
             component.buildOutCSSClass = "zoomOutDown";
+            //component.buildInCSSClassStart = "transform-start";
+            //component.buildInCSSClassEnd = "transform-end";
+            //component.buildOutCSSClass = "transform-build-out";
             return component;
         }
     },

--- a/ui/succession.info/sample/main.reel/main.js
+++ b/ui/succession.info/sample/main.reel/main.js
@@ -1,0 +1,78 @@
+"use strict";
+
+var Component = require("ui/component").Component,
+    Foo = require("ui/succession.info/sample/foo.reel").Foo,
+    Bar = require("ui/succession.info/sample/bar.reel").Bar,
+    Transition = require("ui/transition.reel").Transition;
+
+exports.Main = Component.specialize({
+    foo: {
+        get: function () {
+            var component = new Foo();
+            component.buildInCSSClassStart = "transform-start";
+            component.buildInCSSClassEnd = "transform-end";
+            component.buildOutCSSClass = "transform-build-out";
+            return component;
+        }
+    },
+    bar: {
+        get: function () {
+            var component = new Bar();
+            component.classList.add("animated");
+            component.buildInCSSClassStart = "zoomInDown";
+            component.buildOutCSSClass = "zoomOutDown";
+            return component;
+        }
+    },
+
+    handlePushAction: {
+        value: function () {
+            var source, destination;
+
+            if (this.templateObjects.Succession1.top) {
+                source = this.templateObjects.Succession1.top.destination;
+                destination = this.templateObjects.Succession1.top.destination instanceof Foo ?
+                    this.bar : this.foo;
+            } else {
+                source = null;
+                destination = this.foo;
+            }
+
+            var transition = new Transition();
+            transition.identifier = Math.random() * 1000000 | 0;
+            transition.source = source;
+            transition.destination = destination;
+            transition.buildInCSSClassStart = "transform-start";
+            transition.buildInCSSClassEnd = "transform-end";
+            transition.buildOutCSSClass = "transform-build-out";
+            transition.sourceData = {};
+
+            this.templateObjects.Succession1.push(transition);
+        }
+    },
+
+    handlePopAction: {
+        value: function () {
+            this.templateObjects.Succession1.pop();
+        }
+    },
+
+    handleClearAction: {
+        value: function () {
+            this.templateObjects.Succession1.clear();
+        }
+    },
+
+    handleToggleOverflowAction: {
+        value: function () {
+            this.templateObjects.Succession1.classList.toggle("overflow-hidden");
+        }
+    },
+
+    handleDetachAction: {
+        value: function () {
+            this.templateObjects.Bar2.detachFromParentComponent();
+            this.templateObjects.text.detachFromParentComponent();
+        }
+    }
+});

--- a/ui/succession.reel/succession.js
+++ b/ui/succession.reel/succession.js
@@ -4,7 +4,6 @@
  * @module "montage/ui/succession.reel"
  */
 var Slot = require("ui/slot.reel").Slot,
-    Component = require("ui/component").Component,
     RangeController = require("core/range-controller").RangeController;
 
 /**
@@ -32,7 +31,7 @@ exports.Succession = Slot.specialize(/** @lends Succession.prototype */{
                 "top": {"<-": "this.stack.selection[0] ?? null"},
                 "content": {"<-": "this.top.destination"},
                 /**
-                 * The Transition immedately below the top of Succession stack.
+                 * The Transition immediately below the top of Succession stack.
                  *
                  * @property {Transition} previous
                  * @readonly
@@ -95,11 +94,11 @@ exports.Succession = Slot.specialize(/** @lends Succession.prototype */{
     performTransition: {
         value: function (transition) {
             // execute lifecycle hooks
-            if (transition.source && typeof transition.source.prepareForBuildOut == "function") {
-                transition.source.prepareForBuildOut(transition)
+            if (transition.source && typeof transition.source.prepareForBuildOut === "function") {
+                transition.source.prepareForBuildOut(transition);
             }
-            if (typeof transition.destination.prepareForBuildIn == "function") {
-                transition.destination.prepareForBuildIn(transition)
+            if (typeof transition.destination.prepareForBuildIn === "function") {
+                transition.destination.prepareForBuildIn(transition);
             }
 
             if (transition.sourceData) {

--- a/ui/succession.reel/succession.js
+++ b/ui/succession.reel/succession.js
@@ -1,0 +1,110 @@
+"use strict";
+
+/**
+ * @module "montage/ui/succession.reel"
+ */
+var Slot = require("ui/slot.reel").Slot,
+    Component = require("ui/component").Component,
+    RangeController = require("core/range-controller").RangeController;
+
+/**
+ * @class Succession
+ * @augments Slot
+ */
+exports.Succession = Slot.specialize(/** @lends Succession.prototype */{
+    constructor: {
+        value: function () {
+            /**
+             * @property {RangeController} stack
+             */
+            this.stack = new RangeController();
+            this.stack.selectAddedContent = true;
+
+            this.defineBindings({
+                /**
+                 * The top Transition of the Succession stack.
+                 * It is coerce to `null` as `undefined` causes issues with `Slot`.
+                 *
+                 * @property {Transition} top
+                 * @readonly
+                 * @namespace Succession
+                 */
+                "top": {"<-": "this.stack.selection[0] ?? null"},
+                "content": {"<-": "this.top.destination"},
+                /**
+                 * The Transition immedately below the top of Succession stack.
+                 *
+                 * @property {Transition} previous
+                 * @readonly
+                 * @namespace Succession
+                 */
+                "previous": {"<-": "this.stack.content[this.stack.content.length - 2]"},
+                /**
+                 * The beginning Transition of the Succession stack.
+                 *
+                 * @property {Transition} first
+                 * @readonly
+                 * @namespace Succession
+                 */
+                "first": {"<-": "this.stack.content[0]"}
+            });
+        }
+    },
+
+    /**
+     * @property {boolean}
+     * @default false
+     */
+    hasTemplate: {
+        enumerable: false,
+        value: false
+    },
+
+    push: {
+        value: function (transition) {
+            if (this.top && transition.source !== this.top.destination) {
+                console.error(
+                    new Error("Transition source isn't what's currently on the top of the " +
+                    "Succession stack. Abandoning transition.")
+                );
+
+            } else {
+                this.performTransition(transition);
+
+                // todo: push makes more sense,
+                // but RangeController.push doesn't work if RangeController.content is empty
+                this.stack.add(transition);
+            }
+        }
+    },
+
+    pop: {
+        value: function () {
+            this.stack.pop();
+            // todo: may be able to set RangeController.avoidsEmptySelection, but it seems broken
+            this.stack.selection = [this.stack.content[this.stack.content.length - 1]];
+        }
+    },
+
+    clear: {
+        value: function () {
+            this.stack.clear();
+        }
+    },
+
+    performTransition: {
+        value: function (transition) {
+            // execute lifecycle hooks
+            if (transition.source && typeof transition.source.prepareForBuildOut == "function") {
+                transition.source.prepareForBuildOut(transition)
+            }
+            if (typeof transition.destination.prepareForBuildIn == "function") {
+                transition.destination.prepareForBuildIn(transition)
+            }
+
+            if (transition.sourceData) {
+                transition.destinationData = transition.sourceData;
+            }
+        }
+    }
+});

--- a/ui/transition.reel/transition.js
+++ b/ui/transition.reel/transition.js
@@ -1,0 +1,77 @@
+"use strict";
+
+/**
+ * @module "montage/ui/transition.reel"
+ */
+var Montage = require("core/core").Montage;
+
+/**
+ * @class Transition
+ * @extends Montage
+ */
+exports.Transition = Montage.specialize(/** @lends Transition.prototype */{
+    /**
+     * Use this to diffirentiate one type of transition from another.
+     *
+     * @property {String}
+     */
+    identifier: {value: null},
+
+    /**
+     * The component visible before the transition.
+     *
+     * @property {Component}
+     */
+    source: {value: null},
+
+    /**
+     * The component visible after the transition.
+     *
+     * @property {Component}
+     */
+    destination: {value: null},
+
+    /**
+     * @todo
+     */
+    buildInAnimation: {value: null},
+
+    /**
+     * @todo
+     */
+    buildOutAnimation: {value: null},
+
+    /**
+     * A CSS class that enables build-in CSS transition & animation.
+     * This class is the starting point for CSS transition.
+     * For CSS animation, it should contain all the start / end implementation.
+     *
+     * @property {String}
+     */
+    buildInCSSClassStart: {value: null},
+
+    /**
+     * A CSS class that marks the end of build-in CSS transition.
+     * Use {@link Component.buildInCSSClassStart} for CSS animation.
+     *
+     * @property {String}
+     */
+    buildInCSSClassEnd: {value: null},
+
+    /**
+     * A CSS class that enables build-out CSS transition & animation.
+     *
+     * @property {String}
+     */
+    buildOutCSSClass: {value: null},
+
+    /**
+     * @property {*}
+     */
+    sourceData: {value: null},
+
+    /**
+     * @property {*}
+     */
+    destinationData: {value: null}
+});


### PR DESCRIPTION
WIP, API not final, do not merge
===

`Component` is enhanced to allow animation for both stand-alone components & components inside a placeholder like `Slot` or `Substitution`.

`Succession` implements a `stack` to keep track of navigation. You can `push` / `pop` / `clear` the stack. You can also bind to the `top` / `previous` / `first` components of the stack, e.g. to a Navigation Bar. The stack only tracks Components for now. Next step is to enable the use of a `Transition` object.

See `succession.info` for usage. For live demo, serve `/index.html` then select `Succession` from drop-down.

Video demo: https://www.youtube.com/watch?v=9F0SxMVXpgI

API & Usage Docs: https://gist.github.com/rayshan/fd5ef874a3c648b81138

**Known issues**

- When pushing onto then popping components off of the stack rapidly, sometimes components get stuck on the stack. It's likely the way `_performDomContentChanges` removes children elements need improvement.
- ~~Firefox isn't consistently hearing transition / animation end events~~