### PR TITLE
Add spec for tables with repetitions

### DIFF
--- a/test/ui/repetition-spec.js
+++ b/test/ui/repetition-spec.js
@@ -1052,5 +1052,12 @@ TestPageLoader.queueTest("repetition/repetition", function (testPage) {
                 });
             });
         });
+
+        describe("repetitions on tables", function() {
+            it("should preserve the original structure of the table", function() {
+                var repetition = delegate.tableRepetition;
+                expect(repetition.element.querySelectorAll("tr").length).toBe(2);
+            });
+        });
     });
 });

--- a/test/ui/repetition/repetition.html
+++ b/test/ui/repetition/repetition.html
@@ -59,6 +59,7 @@ POSSIBILITY OF SUCH DAMAGE.
                     "repetition12": {"@": "repetition12"},
                     "repetition15": {"@": "repetition15"},
                     "domRepetition": {"@": "domRepetition"},
+                    "tableRepetition": {"@": "tableRepetition"},
                     "repetitionController": {"@": "repetitionController"},
                     "list1Objects": [
 
@@ -654,6 +655,36 @@ POSSIBILITY OF SUCH DAMAGE.
                     "content": [1, 2, 3],
                     "isSelectionEnabled": true
                 }
+            },
+
+            "tableElementA": {
+                "prototype": "montage/ui/text.reel",
+                "properties": {
+                    "element": {"#": "tableElementA"}
+                },
+                "bindings": {
+                    "value": {"<-": "@tableRepetition:iteration.object.a"}
+                }
+            },
+            "tableElementB": {
+                "prototype": "montage/ui/text.reel",
+                "properties": {
+                    "element": {"#": "tableElementB"}
+                },
+                "bindings": {
+                    "value": {"<-": "@tableRepetition:iteration.object.b"}
+                }
+            },
+
+            "tableRepetition": {
+                "prototype": "montage/ui/repetition.reel",
+                "properties": {
+                    "element": {"#": "tableRepetition"},
+                    "content": [
+                        {"a": "1-1", "b": "1-2"},
+                        {"a": "2-1", "b": "2-2"}
+                    ]
+                }
             }
 
     }</script>
@@ -865,5 +896,13 @@ POSSIBILITY OF SUCH DAMAGE.
             Item being repeated
         </li>
     </ul>
+
+    <h2>Table Repetition</h2>
+    <table data-montage-id="tableRepetition">
+        <tr>
+            <td><span data-montage-id="tableElementA"></span></td>
+            <td><span data-montage-id="tableElementB"></span></td>
+        </tr>
+    </table>
 </body>
 </html>


### PR DESCRIPTION
Catches a bug where repetitions would destroy the original structure of
tables (thereby not preserving nodes like tr, td, tbody). This bug was
addressed by 8b9735bb0b7ca8af65c2d0510ccf40b9c46d3dc9.