### PR TITLE
Fixed RangeController issues

### DIFF
--- a/core/range-controller.js
+++ b/core/range-controller.js
@@ -46,7 +46,7 @@ var _RangeSelection = function(content, rangeController) {
     //Moved to RangeSelection.prototype for optimization
     //self.makeObservable();
     self.__proto__ = _RangeSelection.prototype;
-    
+
     self.rangeController = rangeController;
     self.contentEquals = content && content.contentEquals || Object.is;
 
@@ -94,11 +94,11 @@ Object.defineProperty(_RangeSelection.prototype, "push", {
           while (++i < l) {
             x[i] = arguments[i];
           }
-        
+
         this.swap_or_push(this.length, 0, x);
     }
 });
-    
+
 /**
  * A custom version of swap to ensure that changes obey the RangeController
  * invariants:
@@ -454,13 +454,12 @@ var RangeController = exports.RangeController = Montage.specialize( /** @lends R
      * The selection may be any collection that supports range change events
      * like `Array` or `SortedSet`.
      *
-     * @param {Collection} a collection of values to be set as the selection.
-     * @returns {?Array|Set|SortedSet}
-     *
-     * @deprecated: setting the `selection` will not replace it with the provided.
+     * Deprecation warning: setting the `selection` will not replace it with the provided.
      * collection. Instead, it will empty the selection and then shallow-copy the
      * contents of the argument into the existing selection array. This is done to
      * maintain the complicated invariants about what the selection can be.
+     *
+     * @property {?Array|Set|SortedSet}
      */
     selection: {
         get: function () {
@@ -735,7 +734,7 @@ var RangeController = exports.RangeController = Montage.specialize( /** @lends R
     /**
      * Creates a content value for this range controller.
      * If the backing
-     * collection has an intrinsict type, uses its `contentConstructor`.
+     * collection has an intrinsic type, uses its `contentConstructor`.
      * Otherwise, creates and returns simple, empty objects.
      *
      * This property can be set to an alternate content constructor, which will
@@ -761,6 +760,7 @@ var RangeController = exports.RangeController = Montage.specialize( /** @lends R
     /**
      * Dispatched by range changes to the controller's content, arranged in
      * constructor.
+     *
      * Reacts to content changes to ensure that content that no
      * longer exists is removed from the selection, regardless of whether it is
      * from the user or any other entity modifying the backing collection.
@@ -773,7 +773,13 @@ var RangeController = exports.RangeController = Montage.specialize( /** @lends R
                 // remove all values from the selection that were removed (but
                 // not added back)
                 minus.deleteEach(plus, equals);
-                if (this.selection) {
+
+                if (this.selection.length) {
+                    // ensure selection always has content
+                    if (this.content.length && this.avoidsEmptySelection && !this.multiSelect) {
+                        // selection can't contain previous content value as content already changed
+                        this.selection.add(this.content[this.content.length - 1]);
+                    }
                     this.selection.deleteEach(minus);
                 }
             }
@@ -783,7 +789,9 @@ var RangeController = exports.RangeController = Montage.specialize( /** @lends R
     /**
      * Watches changes to the private reflection of the public selection,
      * enforcing the `multiSelect` and `avoidsEmptySelection` invariants.
+     *
      * @private
+     * @todo this doesn't seem to be used anywhere
      */
     handleSelectionRangeChange : {
         value: function (plus, minus, index) {
@@ -848,13 +856,11 @@ var RangeController = exports.RangeController = Montage.specialize( /** @lends R
     handleAdd: {
         value: function (value) {
             if (this.selectAddedContent && this.selection) {
-                if (
-                    !this.multiSelect &&
-                    this.selection.length >= 1
-                ) {
-                    this.selection.clear();
+                if (!this.multiSelect && this.selection.length) {
+                    this.selection.swap(0, this.selection.length, [value]);
+                } else {
+                    this.selection.add(value);
                 }
-                this.selection.add(value);
             }
         }
     },

--- a/test/core/range-controller-spec.js
+++ b/test/core/range-controller-spec.js
@@ -190,6 +190,15 @@ describe("core/range-controller-spec", function () {
                     expect(rangeController.selection.length).toBe(1);
                     expect(rangeController.selection.toArray()).not.toEqual([0]);
                 });
+
+                it("should contain last element of content, if it would be empty after content change", function () {
+                    rangeController.multiSelect = false;
+                    rangeController.selection = [2];
+
+                    rangeController.content.delete(2);
+                    expect(rangeController.selection.length).toBe(1);
+                    expect(rangeController.selection.toArray()).toEqual([1]);
+                });
             });
 
             describe("when false", function () {
@@ -205,6 +214,30 @@ describe("core/range-controller-spec", function () {
                 it("allows splice to clear selection", function () {
                     rangeController.selection.splice(0, 100);
                     expect(rangeController.selection.toArray()).toEqual([]);
+                });
+            });
+        });
+
+        describe("constrained by selectAddedContent", function () {
+            beforeEach(function () {
+                rangeController.selectAddedContent = true;
+            });
+
+            describe("when true", function () {
+                it("should select added content", function () {
+                    rangeController.selection.length = 0;
+                    rangeController.add(3);
+                    expect(rangeController.selection.toArray()).toEqual([3]);
+                });
+
+                it("should use swap to ensure selection isn't cleared then content added", function () {
+                    rangeController.selection = [2];
+
+                    rangeController.selection.addRangeChangeListener(function (plus, minus, i) {
+                        expect(plus.length).not.toBe(0);
+                    });
+
+                    rangeController.add(3); // observed change of plus should be [3], not [] then [3]
                 });
             });
         });


### PR DESCRIPTION
Discovered during work on Succession
- Ensure selection always has content
- Use swap instead of clear / add to prevent setting selection
  multiple times
