### PR TITLE
Quick fix when trying to require a JSON file within a mopped app.

### DIFF
--- a/packages/mr/require.js
+++ b/packages/mr/require.js
@@ -782,8 +782,7 @@
 
     Require.JsonCompiler = function (config, compile) {
         return function (module) {
-            var json = (module.location || "").match(/\.json$/);
-            if (json) {
+            if (!config.production && (module.location || "").match(/\.json$/)) {
                 module.exports = JSON.parse(module.text);
                 return module;
             } else {


### PR DESCRIPTION
:warning: do not merge. WIP

PR probably outdated, need to fix mr instead.

Within a mopped app the JSON content is already parsed and the property `text` is undefined.