### PR TITLE
Allow KeyComposer to fire events when there is no focus

### DIFF
--- a/core/event/key-manager.js
+++ b/core/event/key-manager.js
@@ -5,7 +5,8 @@
 
 var Montage = require("../core").Montage,
     defaultEventManager = require("./event-manager").defaultEventManager,
-    MutableEvent = require("./mutable-event").MutableEvent;
+    MutableEvent = require("./mutable-event").MutableEvent,
+    Application = require("../application").Application;
 
 var KEYNAMES_TO_KEYCODES = {
     // W3C Key Code
@@ -740,10 +741,14 @@ var KeyManager = exports.KeyManager = Montage.specialize(/** @lends KeyManager# 
                     }
                 }
 
-                // Most components can't receive key events directly: the events target the window,
-                // but we should also fire them on composers of the activeTarget component
-                if (!onTarget && defaultEventManager.activeTarget != keyComposer.component) {
-                    continue;
+                // If the event's target is body and the event manager's target is the application,
+                // we can simply fire an event to all listeners
+                if (event.target !== document.body || !(defaultEventManager.activeTarget instanceof Application)) {
+                    // Most components can't receive key events directly: the events target the window,
+                    // but we should also fire them on composers of the activeTarget component
+                    if (!onTarget && defaultEventManager.activeTarget != keyComposer.component) {
+                        continue;
+                    }
                 }
 
                 if (keyUp) {

--- a/test/composer/key-composer-spec.js
+++ b/test/composer/key-composer-spec.js
@@ -40,7 +40,7 @@ TestPageLoader.queueTest("key-composer-test/key-composer-test", function (testPa
             });
 
             it("should not fire keyComposer's event when pressing a composerKey which is not in the target path", function () {
-                var target = test.example.element.parentNode,
+                var target = test.example.element2.element,
                     keyPressCalled = false,
                     keyReleaseCalled = false;
 
@@ -56,8 +56,25 @@ TestPageLoader.queueTest("key-composer-test/key-composer-test", function (testPa
                 });
             });
 
+            it("should fire keyComposer's event when nothing is being focused", function() {
+                var target = test.example.element.parentNode,   // == <body>...</body>
+                    keyPressCalled = false;
+                    keyReleaseCalled = false;
+
+                test.key_composer1.addEventListener("keyPress", function (){keyPressCalled = true});
+                test.key_composer1.addEventListener("keyRelease", function (){keyReleaseCalled = true});
+
+                testPage.keyEvent({target: target, modifiers: command, charCode: 0, keyCode: "J".charCodeAt(0)}, "keydown");
+                waits(50);
+                runs(function (){
+                    testPage.keyEvent({target: target, modifiers: command, charCode: 0, keyCode:"J".charCodeAt(0)}, "keyup");
+                    expect(keyPressCalled).toBeTruthy();
+                    expect(keyPressCalled).toBeTruthy();
+                });
+            });
+
             it("should fire keyPress and KeyRelease on pressing a global key whatever of the target", function () {
-                var target = test.example.element.parentNode;
+                var target = test.example.element2.element;
 
                 test.keyPressCalled = false;
                 test.keyReleaseCalled = false;

--- a/test/composer/key-composer-test/key-composer-test.html
+++ b/test/composer/key-composer-test/key-composer-test.html
@@ -69,13 +69,21 @@ POSSIBILITY OF SUCH DAMAGE.
             "value": "hi"
         }
     },
+    "example2": {
+        "prototype": "montage/ui/text.reel",
+        "properties": {
+            "element": {"#": "example2"},
+            "value": "hi again"
+        }
+    },
 
     "test": {
         "prototype": "composer/key-composer-test/key-composer-test",
         "properties": {
             "key_composer1": {"@": "key_composer1"},
             "key_composer2": {"@": "key_composer2"},
-            "example": {"@": "example"}
+            "example": {"@": "example"},
+            "example2": {"@": "example2"}
         }
     },
     "application": {
@@ -101,5 +109,6 @@ POSSIBILITY OF SUCH DAMAGE.
     <h1>Key Composer test</h1>
 
     <div data-montage-id="example" class="example" tabIndex=-1></div>
+    <div data-montage-id="example2" class="example"></div>
 </body>
 </html>


### PR DESCRIPTION
i.e. the user is focused on the <body> and the eventManager is targeting the Application. Fixes #1571 