### PR TITLE
Enhance Repetition performance and fix bug in selection

### DIFF
--- a/test/ui/repetition-selection-spec.js
+++ b/test/ui/repetition-selection-spec.js
@@ -151,10 +151,83 @@ TestPageLoader.queueTest("repetition/selection-test/selection-test", function (t
                 });
             });
 
+            describe("single selection", function () {
+                it("should properly update the iterations selected property", function () {
+                    var i;
+
+                    repetition.contentController.selection = [];
+                    for (i = 0; i < 6; i++) {
+                        expect(repetition.iterations[i].selected).toBeFalsy();
+                    }
+                    repetition.contentController.selection = [repetition.iterations[0].object];
+                    expect(repetition.iterations[0].selected).toBeTruthy();
+                    for (i = 1; i < 6; i++) {
+                        expect(repetition.iterations[i].selected).toBeFalsy();
+                    }
+                    repetition.contentController.selection = [repetition.iterations[1].object];
+                    expect(repetition.iterations[0].selected).toBeFalsy();
+                    expect(repetition.iterations[1].selected).toBeTruthy();
+                    for (i = 2; i < 6; i++) {
+                        expect(repetition.iterations[i].selected).toBeFalsy();
+                    }
+                });
+            });
+
+            describe("multiple selection", function () {
+                it("should properly update the iterations selected property", function () {
+                    var i;
+
+                    repetition.contentController.multiSelect = true;
+                    repetition.contentController.selection = [
+                        repetition.iterations[0].object,
+                        repetition.iterations[1].object
+                    ];
+                    expect(repetition.iterations[0].selected).toBeTruthy();
+                    expect(repetition.iterations[1].selected).toBeTruthy();
+                    for (i = 2; i < 6; i++) {
+                        expect(repetition.iterations[i].selected).toBeFalsy();
+                    }
+                    repetition.contentController.selection = [
+                        repetition.iterations[2].object,
+                        repetition.iterations[3].object
+                    ];
+                    expect(repetition.iterations[0].selected).toBeFalsy();
+                    expect(repetition.iterations[1].selected).toBeFalsy();
+                    expect(repetition.iterations[2].selected).toBeTruthy();
+                    expect(repetition.iterations[3].selected).toBeTruthy();
+                    expect(repetition.iterations[4].selected).toBeFalsy();
+                    expect(repetition.iterations[5].selected).toBeFalsy();
+                    repetition.contentController.multiSelect = false;
+                });
+            });
+
+        });
+
+        describe("reflecting the Repetition selection into the iterations", function () {
+            it("changes should properly update the iterations selected property", function () {
+                var i;
+
+                repetition.selection = [];
+                for (i = 0; i < 6; i++) {
+                    expect(repetition.iterations[i].selected).toBeFalsy();
+                }
+                repetition.selection = [repetition.iterations[0].object];
+                expect(repetition.iterations[0].selected).toBeTruthy();
+                for (i = 1; i < 6; i++) {
+                    expect(repetition.iterations[i].selected).toBeFalsy();
+                }
+                repetition.selection = [repetition.iterations[1].object];
+                expect(repetition.iterations[0].selected).toBeFalsy();
+                expect(repetition.iterations[1].selected).toBeTruthy();
+                for (i = 2; i < 6; i++) {
+                    expect(repetition.iterations[i].selected).toBeFalsy();
+                }
+            });
         });
 
         describe("changing visibleIndexes in repetition's controller", function () {
             it("should properly update the iteration's selected property", function () {
+                repetition.selection = [];
                 expect(repetition.iterations[0].object).toEqual("Alice");
                 expect(repetition.iterations[1].object).toEqual("Bob");
                 expect(repetition.iterations[0].selected).toBeFalsy();

--- a/test/ui/repetition-selection-spec.js
+++ b/test/ui/repetition-selection-spec.js
@@ -153,5 +153,22 @@ TestPageLoader.queueTest("repetition/selection-test/selection-test", function (t
 
         });
 
+        describe("changing visibleIndexes in repetition's controller", function () {
+            it("should properly update the iteration's selected property", function () {
+                expect(repetition.iterations[0].object).toEqual("Alice");
+                expect(repetition.iterations[1].object).toEqual("Bob");
+                expect(repetition.iterations[0].selected).toBeFalsy();
+                expect(repetition.iterations[1].selected).toBeFalsy();
+                repetition.iterations[0].selected = true;
+                expect(repetition.iterations[0].selected).toBeTruthy();
+                nameController.visibleIndexes = [1];
+                expect(repetition.iterations[0].object).toEqual("Bob");
+                expect(repetition.iterations[0].selected).toBeFalsy();
+                nameController.visibleIndexes = [0];
+                expect(repetition.iterations[0].object).toEqual("Alice");
+                expect(repetition.iterations[0].selected).toBeTruthy();
+            });
+        });
+
     });
 });

--- a/ui/repetition.reel/repetition.js
+++ b/ui/repetition.reel/repetition.js
@@ -755,21 +755,33 @@ var Repetition = exports.Repetition = Component.specialize(/** @lends Repetition
     handleSelectionRangeChange: {
         value: function (add, remove) {
             var iterationsMap = new Map(),
-                iteration,
                 length = this.iterations.length,
-                i;
+                objectIterations,
+                object,
+                iteration,
+                i, j;
 
             for (i = 0; i < length; i++) {
-                iterationsMap.set(this.iterations[i].object, this.iterations[i]);
+                iteration = this.iterations[i];
+                object = iteration.object;
+                if (!(objectIterations = iterationsMap.get(object))) {
+                    objectIterations = [];
+                    iterationsMap.set(object, objectIterations);
+                }
+                objectIterations.push(iteration);
             }
             for (i = 0; i < remove.length; i++) {
-                if (iteration = iterationsMap.get(remove[i])) {
-                    iteration.selected = false;
+                if (objectIterations = iterationsMap.get(remove[i])) {
+                    for (j = 0; j < objectIterations.length; j++) {
+                        objectIterations[j].selected = false;
+                    }
                 }
             }
             for (i = 0; i < add.length; i++) {
-                if (iteration = iterationsMap.get(add[i])) {
-                    iteration.selected = true;
+                if (objectIterations = iterationsMap.get(add[i])) {
+                    for (j = 0; j < objectIterations.length; j++) {
+                        objectIterations[j].selected = true;
+                    }
                 }
             }
         }

--- a/ui/repetition.reel/repetition.js
+++ b/ui/repetition.reel/repetition.js
@@ -1486,13 +1486,9 @@ var Repetition = exports.Repetition = Component.specialize(/** @lends Repetition
                 logger.debug("Repetition:%s +%s -%s iterations", Object.hash(this), addIterationsCount, removeIterationsCount);
             }
 
-            if (reusableIterationsCount > 0) {
-
-                for (var i = 0; i < reusableIterationsCount; i++, index++) {
-                    iterations[index].object = plus[i];
-                    contentForIteration.set(iterations[index], plus[i]);
-                }
-
+            for (var i = 0; i < reusableIterationsCount; i++, index++) {
+                iterations[index].object = plus[i];
+                contentForIteration.set(iterations[index], plus[i]);
             }
 
             if (removeIterationsCount > 0) {

--- a/ui/repetition.reel/repetition.js
+++ b/ui/repetition.reel/repetition.js
@@ -754,33 +754,53 @@ var Repetition = exports.Repetition = Component.specialize(/** @lends Repetition
 
     handleSelectionRangeChange: {
         value: function (add, remove) {
-            var iterationsMap = new Map(),
+            var iterationsMap,
                 length = this.iterations.length,
                 objectIterations,
                 object,
                 iteration,
                 i, j;
 
-            for (i = 0; i < length; i++) {
-                iteration = this.iterations[i];
-                object = iteration.object;
-                if (!(objectIterations = iterationsMap.get(object))) {
-                    objectIterations = [];
-                    iterationsMap.set(object, objectIterations);
-                }
-                objectIterations.push(iteration);
-            }
-            for (i = 0; i < remove.length; i++) {
-                if (objectIterations = iterationsMap.get(remove[i])) {
-                    for (j = 0; j < objectIterations.length; j++) {
-                        objectIterations[j].selected = false;
+            if ((add.length <= 1) && (remove.length <= 1)) {
+                if (remove.length) {
+                    object = remove[0];
+                    for (i = 0; i < length; i++) {
+                        if (this.iterations[i].object === object) {
+                            this.iterations[i].selected = false;
+                        }
                     }
                 }
-            }
-            for (i = 0; i < add.length; i++) {
-                if (objectIterations = iterationsMap.get(add[i])) {
-                    for (j = 0; j < objectIterations.length; j++) {
-                        objectIterations[j].selected = true;
+                if (add.length) {
+                    object = add[0];
+                    for (i = 0; i < length; i++) {
+                        if (this.iterations[i].object === object) {
+                            this.iterations[i].selected = true;
+                        }
+                    }
+                }
+            } else {
+                iterationsMap = new Map();
+                for (i = 0; i < length; i++) {
+                    iteration = this.iterations[i];
+                    object = iteration.object;
+                    if (!(objectIterations = iterationsMap.get(object))) {
+                        objectIterations = [];
+                        iterationsMap.set(object, objectIterations);
+                    }
+                    objectIterations.push(iteration);
+                }
+                for (i = 0; i < remove.length; i++) {
+                    if (objectIterations = iterationsMap.get(remove[i])) {
+                        for (j = 0; j < objectIterations.length; j++) {
+                            objectIterations[j].selected = false;
+                        }
+                    }
+                }
+                for (i = 0; i < add.length; i++) {
+                    if (objectIterations = iterationsMap.get(add[i])) {
+                        for (j = 0; j < objectIterations.length; j++) {
+                            objectIterations[j].selected = true;
+                        }
                     }
                 }
             }

--- a/ui/repetition.reel/repetition.js
+++ b/ui/repetition.reel/repetition.js
@@ -719,32 +719,32 @@ var Repetition = exports.Repetition = Component.specialize(/** @lends Repetition
     // Implementation:
     // ----
 
-    _selection: {
-        value: null
-    },
-
     _cancelSelectionRangeChangeListener: {
         value: null
     },
 
     selection: {
         get: function () {
-            return this._selection;
+            if (this.contentController) {
+                return this.contentController.selection;
+            }
+            return null;
         },
         set: function (value) {
-            if (this._selection !== value) {
-                this._selection = value;
-                if (this.contentController && this.contentController.selection !== value) {
-                    this.contentController.selection = value;
+            var controller;
+
+            if (controller = this.contentController) {
+                if (controller.selection !== value) {
+                    controller.selection = value;
                 }
                 if (this._cancelSelectionRangeChangeListener) {
                     this._cancelSelectionRangeChangeListener();
                 }
                 if (value) {
                     this._cancelSelectionRangeChangeListener = (
-                        value.addRangeChangeListener(this, "selection")
+                        controller.selection.addRangeChangeListener(this, "selection")
                     );
-                    this.handleSelectionRangeChange(value, []);
+                    this.handleSelectionRangeChange(controller.selection, []);
                 } else {
                     this._cancelSelectionRangeChangeListener = null;
                 }

--- a/ui/repetition.reel/repetition.js
+++ b/ui/repetition.reel/repetition.js
@@ -1494,14 +1494,14 @@ var Repetition = exports.Repetition = Component.specialize(/** @lends Repetition
             if (removeIterationsCount > 0) {
                 // Subtract iterations
                 var freedIterations = iterations.splice(index, removeIterationsCount);
-                freedIterations.forEach(function (iteration) {
-                    // Notify these iterations that they have been recycled,
-                    // particularly so they know to disable animations with the
-                    // "no-transition" CSS class.
-                    iteration.recycle();
-                });
+
+                // Notify these iterations that they have been recycled,
+                // particularly so they know to disable animations with the
+                // "no-transition" CSS class.
                 // Add them back to the free list so they can be reused
-                for (var i = 0, freedIteration; freedIteration = freedIterations[i]; i++) {
+                for (var i = 0, freedIteration; i < removeIterationsCount; i++) {
+                    freedIteration = freedIterations[i];
+                    freedIteration.recycle();
                     if (!freedIteration.isDirty) {
                         this._freeIterations.push(freedIteration);
                     }


### PR DESCRIPTION
Enhances Repetition performance by replacing an expensive binding for the selected property in the repetition's iterations by a getter/setter and the additional logic to maintain it up to date.

Refractors a couple of pieces of code by removing an unnecessary loop and merging 2 loops into one.

Fixes a bug in selection when used in conjunction with visibleIndexes from the repetition's controller and adds a test for this bug.