### PR TITLE
Event-Manager needs to listen on mouseDown or touchStart events for devices with multiple pointers.

### DIFF
--- a/core/event/event-manager.js
+++ b/core/event/event-manager.js
@@ -1349,13 +1349,12 @@ if (typeof window !== "undefined") { // client-side
                 // when the EM handles them eventually it will need to allow
                 // all components from the event target to the window to prepareForPointerEvents
                 // before finding event handlers that were registered for these events
-                if (aWindow.Touch) {
-                    aWindow.nativeAddEventListener("touchstart", this._activationHandler, true);
-                } else {
-                    aWindow.nativeAddEventListener("mousedown", this._activationHandler, true);
-                    //TODO also should accommodate mouseenter/mouseover possibly
-                }
+                aWindow.nativeAddEventListener("touchstart", this._activationHandler, true);
+                aWindow.nativeAddEventListener("mousedown", this._activationHandler, true);
                 aWindow.nativeAddEventListener("focus", this._activationHandler, true);
+
+                //TODO also should accommodate mouseenter/mouseover possibly
+                //TODO also need to support pointerEvents
 
                 if (this.application) {
 


### PR DESCRIPTION
Event-Manager needs to listen on both mouseDown or touchStart events for devices with multiple pointers in order to activate components. Plus, this commit fixes a issue for Firefox that implement by default the Touch constructor even if it’s not supported by the device.

[EDIT] Do not merge yet