### PR TITLE
Add setter for AbstractTextField.hasFocus

### DIFF
--- a/montage.js
+++ b/montage.js
@@ -767,6 +767,7 @@ if (!String.prototype.endsWith) {
 
                 window.nativePromise = window.Promise;
                 Object.defineProperty(window,"Promise", {
+                    configurable: true,
                     set: function(PromiseValue) {
                         Object.defineProperty(window,"Promise",{value:PromiseValue});
 


### PR DESCRIPTION
Allow bindings to the public hasFocus trigger on property change by using a setter rather than setting the private _hasFocus directly.
