### PR TITLE
Fixes regression with the press composer related to d8b0231787c67f9204967ed02697cb973e00bae5

### DIFF
--- a/composer/press-composer.js
+++ b/composer/press-composer.js
@@ -341,14 +341,12 @@ var PressComposer = exports.PressComposer = Composer.specialize(/** @lends Press
                 if (target === this._element) {
                     this._dispatchPress(event);
                     this._endInteraction(event);
-
-                } else {
-                    this._endInteraction(event);
+                    return;
                 }
-            } else{
-                this._dispatchPressCancel(event);
-                this._endInteraction(event);
             }
+
+            this._dispatchPressCancel(event);
+            this._endInteraction(event);
         }
     },
 


### PR DESCRIPTION
Dispatch a PressCancel event when the mouse is released on another target that the one the press composer is supposed to listen to.