### PR TITLE
Adds support for devices with multiple pointer types to the Translate Composer and improvements.

### DIFF
--- a/composer/composer.js
+++ b/composer/composer.js
@@ -189,4 +189,12 @@ exports.Composer = Target.specialize( /** @lends Composer# */ {
         }
     }
 
+}, {
+
+    isCoordinateOutsideRadius: {
+        value: function (x, y, radius) {
+            return x * x + y * y > radius * radius;
+        }
+    }
+
 });

--- a/test/composer/translate-composer/translate-composer-spec.js
+++ b/test/composer/translate-composer/translate-composer-spec.js
@@ -281,6 +281,7 @@ TestPageLoader.queueTest("translate-composer-test", function(testPage) {
                 it ("should translate on a the wheel event used by this browser", function() {
                     spyOn(test, 'handleTranslate').andCallThrough();
                     test.translateComposer.addEventListener("translate", test.handleTranslate, false);
+                    test.translateComposer.listenToWheelEvent = true;
 
                     var eventName = "mousewheel";
                     var deltaPropertyName = "wheelDeltaY";
@@ -294,6 +295,7 @@ TestPageLoader.queueTest("translate-composer-test", function(testPage) {
 
                     testPage.wheelEvent(eventInfo, eventName, function() {
                         expect(test.handleTranslate.callCount).toBe(1);
+                        test.translateComposer.listenToWheelEvent = false;
 
                         // test how much we scroll by, learn amounts
                     });

--- a/ui/flow.reel/flow-translate-composer.js
+++ b/ui/flow.reel/flow-translate-composer.js
@@ -37,6 +37,20 @@ var FlowTranslateComposer = exports.FlowTranslateComposer = TranslateComposer.sp
         }
     },
 
+    /**
+     *  How fast the cursor has to be moving before translating starts. Only
+     *  applied when another component has claimed the pointer.
+     *  @type {number}
+     *  @default 500
+     */
+    startTranslateSpeed: {
+        value: 500
+    },
+
+    startTranslateRadius: {
+        value: 8
+    },
+
     // TODO doc
     /**
      */
@@ -244,14 +258,16 @@ var FlowTranslateComposer = exports.FlowTranslateComposer = TranslateComposer.sp
                 this.endX = this.startX = this._pageX;
                 this.endY = this.startY = this._pageY;
 
-                if ((this._hasMomentum) && ((event.velocity.speed>40) || this.translateStrideX || this.translateStrideY)) {
+                var velocity = event.velocity;
+
+                if ((this._hasMomentum) && ((velocity.speed>40) || this.translateStrideX || this.translateStrideY)) {
                     if (this._axis != "vertical") {
-                        this.momentumX = event.velocity.x * this._pointerSpeedMultiplier * (this._invertXAxis ? 1 : -1);
+                        this.momentumX = velocity.x * this._pointerSpeedMultiplier * (this._invertXAxis ? 1 : -1);
                     } else {
                         this.momentumX = 0;
                     }
                     if (this._axis != "horizontal") {
-                        this.momentumY = event.velocity.y * this._pointerSpeedMultiplier * (this._invertYAxis ? 1 : -1);
+                        this.momentumY = velocity.y * this._pointerSpeedMultiplier * (this._invertYAxis ? 1 : -1);
                     } else {
                         this.momentumY=0;
                     }
@@ -285,6 +301,18 @@ var FlowTranslateComposer = exports.FlowTranslateComposer = TranslateComposer.sp
 
     _previousDeltaY: {
         value: 0
+    },
+
+    _listenToWheelEvent: {
+        value: true
+    },
+
+    captureWheel: {
+        value: function () {
+            if (!this.eventManager.componentClaimingPointer(this._WHEEL_POINTER)) {
+                this.eventManager.claimPointer(this._WHEEL_POINTER, this.component);
+            }
+        }
     },
 
     // TODO Add wheel event listener for Firefox


### PR DESCRIPTION
- Support Pointer Events
- Support devices with multiple pointer types.
- Performance improvements. (less translateStart raised when handling wheel event, less listeners and diverse improvements)
- Better stealing claimed pointers logic, wait for a reel move before stealing the pointer. The logic is based on different mouse and touch radius, except between Translate Composers the fact of stealing is immediate between these Composers.
- Fixes issues between composers that was claiming the same pointer. -> For example, using the translate composer on an element within a repetition. (repetition uses the PressComposer).
- Doesn’t listener on wheel events by default. (feature just used by the flow and scrollers)
- Fixes bug between inner scroller Components. (Was not able to work)
- Add unload function. (release listeners)
- Updates translate composer tests.
- Backwards compatibility for the Flow Translate Composer.
- Updates Event Manager in order to support storage of Pointer Events.
- Adds supports for horizontal “wheel” movement.
- Stops to raise translate events when a movement is beyond a extreme (max/min Translate X/Y).