### PR TITLE
Makes Montage works with PointerEvents

### DIFF
--- a/montage.js
+++ b/montage.js
@@ -1,11 +1,5 @@
 /*global BUNDLE, module: false */
 if (typeof window !== "undefined") {
-
-    // Workaround for window.Touch on desktop browsers
-    if (!("ontouchstart" in window)) {
-        window.Touch = null;
-    }
-
     document._montageTiming = {};
     document._montageTiming.loadStartTime = Date.now();
 

--- a/test/composer/press-composer-spec.js
+++ b/test/composer/press-composer-spec.js
@@ -4,287 +4,412 @@ var Montage = require("montage").Montage,
 
 TestPageLoader.queueTest("press-composer-test/press-composer-test", function (testPage) {
     var test;
+
     beforeEach(function () {
         test = testPage.test;
+
+        if (test && test.example) {
+            test.example.eventManager.blocksEmulatedEvents = false;
+        }
     });
 
     describe("composer/press-composer-spec", function () {
-        describe("PressComposer", function (){
-            it("should fire pressStart on mousedown/touchstart", function () {
-                var listener = testPage.addListener(test.press_composer, null, "pressStart");
+        if (!window.PointerEvent && !window.navigator.msPointerEnabled) {
 
-                if (window.Touch) {
-                    testPage.touchEvent({target: test.example.element}, "touchstart");
-                } else {
+            describe("PressComposer", function () {
+
+                it("should fire pressStart on mousedown", function () {
+                    var listener = testPage.addListener(test.press_composer, null, "pressStart");
+
                     testPage.mouseEvent({target: test.example.element}, "mousedown");
-                }
 
-                expect(listener).toHaveBeenCalled();
-                expect(test.press_composer.state).toBe(PressComposer.PRESSED);
-            });
+                    expect(listener).toHaveBeenCalled();
+                    expect(test.press_composer.state).toBe(PressComposer.PRESSED);
+                });
 
-            it("should fire press on mouseup/touchend", function () {
-                var pressListener = testPage.addListener(test.press_composer, null, "press");
-                var cancelListener = testPage.addListener(test.press_composer, null, "pressCancel");
+                it("should fire press on mouseup", function () {
+                    var pressListener = testPage.addListener(test.press_composer, null, "press");
+                    var cancelListener = testPage.addListener(test.press_composer, null, "pressCancel");
+
+                    testPage.mouseEvent({target: test.example.element}, "mouseup");
+
+                    expect(pressListener).toHaveBeenCalled();
+                    expect(cancelListener).not.toHaveBeenCalled();
+                    expect(test.press_composer.state).toBe(PressComposer.UNPRESSED);
+                });
 
                 if (window.Touch) {
-                    testPage.touchEvent({target: test.example.element}, "touchend");
-                } else {
-                    testPage.mouseEvent({target: test.example.element}, "mouseup");
+                    it("should fire pressStart on touchstart", function () {
+                        var listener = testPage.addListener(test.press_composer, null, "pressStart");
+
+                        testPage.touchEvent({target: test.example.element}, "touchstart");
+
+                        expect(listener).toHaveBeenCalled();
+                        expect(test.press_composer.state).toBe(PressComposer.PRESSED);
+                    });
+
+                    it("should fire press on touchend", function () {
+                        var pressListener = testPage.addListener(test.press_composer, null, "press");
+                        var cancelListener = testPage.addListener(test.press_composer, null, "pressCancel");
+
+                        testPage.touchEvent({target: test.example.element}, "touchend");
+
+                        expect(pressListener).toHaveBeenCalled();
+                        expect(cancelListener).not.toHaveBeenCalled();
+                        expect(test.press_composer.state).toBe(PressComposer.UNPRESSED);
+                    });
                 }
 
-                expect(pressListener).toHaveBeenCalled();
-                expect(cancelListener).not.toHaveBeenCalled();
-                expect(test.press_composer.state).toBe(PressComposer.UNPRESSED);
-            });
-
-            // touchend's target is always the same as touch start, so this
-            // test doesn't apply
-            if (!window.Touch) {
-                it("should fire pressCancel when the mouse is released elsewhere", function () {
+                // touchend's target is always the same as touch start, so this
+                // test doesn't apply
+                it("should fire pressCancel when the mouse/touch is released elsewhere", function () {
                     var pressListener = testPage.addListener(test.press_composer, null, "press");
                     var cancelListener = testPage.addListener(test.press_composer, null, "pressCancel");
 
                     testPage.mouseEvent({target: test.example.element}, "mousedown");
-                    testPage.mouseEvent({target: testPage.document}, "mouseup");
+                    testPage.mouseEvent({target: test.innerComponent.element}, "mouseup");
 
                     expect(pressListener).not.toHaveBeenCalled();
                     expect(cancelListener).toHaveBeenCalled();
                     expect(test.press_composer.state).toBe(PressComposer.UNPRESSED);
+
+                    if (window.Touch) {
+                        pressListener = testPage.addListener(test.press_composer, null, "press");
+                        cancelListener = testPage.addListener(test.press_composer, null, "pressCancel");
+
+                        testPage.touchEvent({target: test.example.element}, "touchstart");
+                        testPage.touchEvent({target: test.innerComponent.element}, "touchend");
+
+                        expect(pressListener).not.toHaveBeenCalled();
+                        expect(cancelListener).toHaveBeenCalled();
+                        expect(test.press_composer.state).toBe(PressComposer.UNPRESSED);
+                    }
                 });
-            }
 
-            it("should fire pressCancel when surrenderPointer is called", function () {
-                var pressListener = testPage.addListener(test.press_composer, null, "press");
-                var cancelListener = testPage.addListener(test.press_composer, null, "pressCancel");
-
-                if (window.Touch) {
-                    testPage.touchEvent({target: test.example.element}, "touchstart");
-                } else {
-                    testPage.mouseEvent({target: test.example.element}, "mousedown");
-                }
-
-                test.press_composer.surrenderPointer(-1, test.example);
-
-                expect(pressListener).not.toHaveBeenCalled();
-                expect(cancelListener).toHaveBeenCalled();
-
-                if (window.Touch) {
-                    testPage.touchEvent({target: test.example.element}, "touchend");
-                } else {
-                    testPage.mouseEvent({target: test.example.element}, "mouseup");
-                }
-
-                expect(test.press_composer.state).toBe(PressComposer.UNPRESSED);
-
-            });
-
-            describe("delegate", function () {
-                it("surrenderPointer should be called", function () {
+                it("should fire pressCancel when surrenderPointer is called", function () {
                     var pressListener = testPage.addListener(test.press_composer, null, "press");
                     var cancelListener = testPage.addListener(test.press_composer, null, "pressCancel");
 
-                    test.press_composer.delegate = {
-                        surrenderPointer: function (pointer, component) {
-                            return false;
-                        }
-                    };
-                    spyOn(test.press_composer.delegate, 'surrenderPointer').andCallThrough();
-
-
-                    if (window.Touch) {
-                        testPage.touchEvent({target: test.example.element}, "touchstart");
-                    } else {
-                        testPage.mouseEvent({target: test.example.element}, "mousedown");
-                    }
+                    testPage.mouseEvent({target: test.example.element}, "mousedown");
 
                     test.press_composer.surrenderPointer(-1, test.example);
 
-                    expect(cancelListener).not.toHaveBeenCalled();
-                    expect(test.press_composer.state).toBe(PressComposer.PRESSED);
-
-                    if (window.Touch) {
-                        testPage.touchEvent({target: test.example.element}, "touchend");
-                    } else {
-                        testPage.mouseEvent({target: test.example.element}, "mouseup");
-                    }
-
-                    expect(pressListener).toHaveBeenCalled();
-                    expect(test.press_composer.state).toBe(PressComposer.UNPRESSED);
-                });
-            });
-
-            describe("cancelPress", function () {
-                it("cancels the active press and returns true", function () {
-                    var pressListener = testPage.addListener(test.press_composer, null, "press");
-                    var cancelListener = testPage.addListener(test.press_composer, null, "pressCancel");
-
-                    if (window.Touch) {
-                        testPage.touchEvent({target: test.example.element}, "touchstart");
-                    } else {
-                        testPage.mouseEvent({target: test.example.element}, "mousedown");
-                    }
-
-                    expect(test.press_composer.cancelPress()).toBe(true);
-
                     expect(pressListener).not.toHaveBeenCalled();
                     expect(cancelListener).toHaveBeenCalled();
+
+                    testPage.mouseEvent({target: test.example.element}, "mouseup");
+
                     expect(test.press_composer.state).toBe(PressComposer.UNPRESSED);
-                });
-
-                it("returns false if there is no active press", function () {
-                    var cancelListener = testPage.addListener(test.press_composer, null, "pressCancel");
-
-                    expect(test.press_composer.cancelPress()).toBe(false);
-
-                    expect(cancelListener).not.toHaveBeenCalled();
-                    expect(test.press_composer.state).toBe(PressComposer.UNPRESSED);
-                });
-            });
-
-            describe("longPress", function () {
-                it("is fired after longPressThreshold", function () {
-                    var listener = testPage.addListener(test.press_composer, null, "longPress");
 
                     if (window.Touch) {
+                        pressListener = testPage.addListener(test.press_composer, null, "press");
+                        cancelListener = testPage.addListener(test.press_composer, null, "pressCancel");
+
                         testPage.touchEvent({target: test.example.element}, "touchstart");
-                    } else {
-                        testPage.mouseEvent({target: test.example.element}, "mousedown");
+
+                        test.press_composer.surrenderPointer(-1, test.example);
+
+                        expect(pressListener).not.toHaveBeenCalled();
+                        expect(cancelListener).toHaveBeenCalled();
+
+                        testPage.touchEvent({target: test.innerComponent.element}, "touchend");
+
+                        expect(test.press_composer.state).toBe(PressComposer.UNPRESSED);
                     }
-
-                    waits(test.press_composer.longPressThreshold);
-                    runs(function () {
-                        expect(listener).toHaveBeenCalled();
-
-                        if (window.Touch) {
-                            testPage.touchEvent({target: test.example.element}, "touchend");
-                        } else {
-                            testPage.mouseEvent({target: test.example.element}, "mouseup");
-                        }
-                    });
                 });
 
-                it("isn't fired if the press is released before the timeout", function () {
-                    var longListener = testPage.addListener(test.press_composer, null, "longPress");
+                describe("delegate", function () {
+                    it("surrenderPointer should be called", function () {
+                        var pressListener = testPage.addListener(test.press_composer, null, "press");
+                        var cancelListener = testPage.addListener(test.press_composer, null, "pressCancel");
 
-                    if (window.Touch) {
-                        testPage.touchEvent({target: test.example.element}, "touchstart");
-                    } else {
+                        test.press_composer.delegate = {
+                            surrenderPointer: function (pointer, component) {
+                                return false;
+                            }
+                        };
+                        spyOn(test.press_composer.delegate, 'surrenderPointer').andCallThrough();
+
                         testPage.mouseEvent({target: test.example.element}, "mousedown");
-                    }
 
-                    waits(test.press_composer.longPressThreshold - 100);
-                    runs(function () {
-                        expect(longListener).not.toHaveBeenCalled();
+                        test.press_composer.surrenderPointer(-1, test.example);
 
-                        if (window.Touch) {
-                            testPage.touchEvent({target: test.example.element}, "touchend");
-                        } else {
-                            testPage.mouseEvent({target: test.example.element}, "mouseup");
-                        }
-                    });
-                });
+                        expect(cancelListener).not.toHaveBeenCalled();
+                        expect(test.press_composer.state).toBe(PressComposer.PRESSED);
 
-                describe("longPressThreshold", function () {
-                    it("can be changed", function () {
-                        var listener = testPage.addListener(test.press_composer, null, "longPress");
-                        var timeout = test.press_composer.longPressThreshold - 500;
-                        test.press_composer.longPressThreshold = timeout;
+                        testPage.mouseEvent({target: test.example.element}, "mouseup");
+
+                        expect(pressListener).toHaveBeenCalled();
+                        expect(test.press_composer.state).toBe(PressComposer.UNPRESSED);
 
                         if (window.Touch) {
+                            pressListener = testPage.addListener(test.press_composer, null, "press");
+                            cancelListener = testPage.addListener(test.press_composer, null, "pressCancel");
+
+                            test.press_composer.delegate = {
+                                surrenderPointer: function (pointer, component) {
+                                    return false;
+                                }
+                            };
+                            spyOn(test.press_composer.delegate, 'surrenderPointer').andCallThrough();
+
                             testPage.touchEvent({target: test.example.element}, "touchstart");
-                        } else {
-                            testPage.mouseEvent({target: test.example.element}, "mousedown");
-                        }
 
-                        waits(timeout);
+                            test.press_composer.surrenderPointer(-1, test.example);
+
+                            expect(cancelListener).not.toHaveBeenCalled();
+                            expect(test.press_composer.state).toBe(PressComposer.PRESSED);
+
+                            testPage.touchEvent({target: test.example.element}, "touchend");
+
+                            expect(pressListener).toHaveBeenCalled();
+                            expect(test.press_composer.state).toBe(PressComposer.UNPRESSED);
+                        }
+                    });
+                });
+
+                describe("cancelPress", function () {
+                    it("cancels the active press and returns true", function () {
+                        var pressListener = testPage.addListener(test.press_composer, null, "press");
+                        var cancelListener = testPage.addListener(test.press_composer, null, "pressCancel");
+
+                        testPage.mouseEvent({target: test.example.element}, "mousedown");
+
+                        expect(test.press_composer.cancelPress()).toBe(true);
+
+                        expect(pressListener).not.toHaveBeenCalled();
+                        expect(cancelListener).toHaveBeenCalled();
+                        expect(test.press_composer.state).toBe(PressComposer.UNPRESSED);
+
+                        if (window.Touch) {
+                            pressListener = testPage.addListener(test.press_composer, null, "press");
+                            cancelListener = testPage.addListener(test.press_composer, null, "pressCancel");
+
+                            testPage.touchEvent({target: test.example.element}, "touchstart");
+
+                            expect(test.press_composer.cancelPress()).toBe(true);
+
+                            expect(pressListener).not.toHaveBeenCalled();
+                            expect(cancelListener).toHaveBeenCalled();
+                            expect(test.press_composer.state).toBe(PressComposer.UNPRESSED);
+                        }
+                    });
+
+                    it("returns false if there is no active press", function () {
+                        var cancelListener = testPage.addListener(test.press_composer, null, "pressCancel");
+
+                        expect(test.press_composer.cancelPress()).toBe(false);
+
+                        expect(cancelListener).not.toHaveBeenCalled();
+                        expect(test.press_composer.state).toBe(PressComposer.UNPRESSED);
+                    });
+                });
+
+                describe("longPress", function () {
+                    it("is fired after longPressThreshold", function () {
+                        var listener = testPage.addListener(test.press_composer, null, "longPress");
+
+                        testPage.mouseEvent({target: test.example.element}, "mousedown");
+
+                        waits(test.press_composer.longPressThreshold);
                         runs(function () {
                             expect(listener).toHaveBeenCalled();
-                            if (window.Touch) {
+
+                            testPage.mouseEvent({target: test.example.element}, "mouseup");
+                        });
+
+                        if (window.Touch) {
+                            listener = testPage.addListener(test.press_composer, null, "longPress");
+
+                            testPage.touchEvent({target: test.example.element}, "touchstart");
+
+                            waits(test.press_composer.longPressThreshold);
+                            runs(function () {
+                                expect(listener).toHaveBeenCalled();
+
                                 testPage.touchEvent({target: test.example.element}, "touchend");
-                            } else {
+                            });
+                        }
+                    });
+
+                    it("isn't fired if the press is released before the timeout", function () {
+                        var longListener = testPage.addListener(test.press_composer, null, "longPress");
+
+                        testPage.mouseEvent({target: test.example.element}, "mousedown");
+
+                        waits(test.press_composer.longPressThreshold - 100);
+                        runs(function () {
+                            expect(longListener).not.toHaveBeenCalled();
+
+                            testPage.mouseEvent({target: test.example.element}, "mouseup");
+                        });
+
+                        if (window.Touch) {
+                            longListener = testPage.addListener(test.press_composer, null, "longPress");
+
+                            testPage.touchEvent({target: test.example.element}, "touchstart");
+
+                            waits(test.press_composer.longPressThreshold - 100);
+                            runs(function () {
+                                expect(longListener).not.toHaveBeenCalled();
+
+                                testPage.touchEvent({target: test.example.element}, "touchend");
+                            });
+                        }
+                    });
+
+                    describe("longPressThreshold", function () {
+                        it("can be changed", function () {
+                            var listener = testPage.addListener(test.press_composer, null, "longPress");
+                            var timeout = test.press_composer.longPressThreshold - 500;
+                            test.press_composer.longPressThreshold = timeout;
+
+                            testPage.mouseEvent({target: test.example.element}, "mousedown");
+
+                            waits(timeout);
+                            runs(function () {
+                                expect(listener).toHaveBeenCalled();
                                 testPage.mouseEvent({target: test.example.element}, "mouseup");
+                            });
+
+                            if (window.Touch) {
+                                listener = testPage.addListener(test.press_composer, null, "longPress");
+                                timeout = test.press_composer.longPressThreshold - 500;
+                                test.press_composer.longPressThreshold = timeout;
+
+                                testPage.touchEvent({target: test.example.element}, "touchstart");
+
+                                waits(timeout);
+                                runs(function () {
+                                    expect(listener).toHaveBeenCalled();
+                                    testPage.touchEvent({target: test.example.element}, "touchend");
+                                });
                             }
                         });
                     });
                 });
             });
-        });
 
-        describe("Nested PressComposers", function () {
-            beforeEach(function () {
-                test.outer_press_composer._endInteraction();
-                test.inner_press_composer._endInteraction();
-            });
+            describe("Nested PressComposers", function () {
+                beforeEach(function () {
+                    test.outer_press_composer._endInteraction();
+                    test.inner_press_composer._endInteraction();
+                });
 
-            it("should fire pressStart for both composers", function () {
-                var inner_listener = testPage.addListener(test.inner_press_composer, null, "pressStart"),
-                    outer_listener = testPage.addListener(test.outer_press_composer, null, "pressStart");
+                it("should fire pressStart for both composers", function () {
+                    var inner_listener = testPage.addListener(test.inner_press_composer, null, "pressStart"),
+                        outer_listener = testPage.addListener(test.outer_press_composer, null, "pressStart");
 
-                if (window.Touch) {
-                    testPage.touchEvent({target: test.innerComponent.element}, "touchstart");
-                    testPage.touchEvent({target: test.innerComponent.element}, "touchend");
-                } else {
                     testPage.mouseEvent({target: test.innerComponent.element}, "mousedown");
                     testPage.mouseEvent({target: test.innerComponent.element}, "mouseup");
-                }
 
-                expect(inner_listener).toHaveBeenCalled();
-                expect(outer_listener).toHaveBeenCalled();
-            });
+                    expect(inner_listener).toHaveBeenCalled();
+                    expect(outer_listener).toHaveBeenCalled();
 
-            it("should fire press for inner composer", function () {
-                var inner_listener = testPage.addListener(test.inner_press_composer, null, "press"),
-                    outer_listener = testPage.addListener(test.outer_press_composer, null, "press");
+                    if (window.Touch) {
+                        /* Touch */
+                        inner_listener = testPage.addListener(test.inner_press_composer, null, "pressStart");
+                        outer_listener = testPage.addListener(test.outer_press_composer, null, "pressStart");
 
-                if (window.Touch) {
-                    testPage.touchEvent({target: test.innerComponent.element}, "touchstart");
-                    testPage.touchEvent({target: test.innerComponent.element}, "touchend");
-                } else {
+                        testPage.touchEvent({target: test.innerComponent.element}, "touchstart");
+                        testPage.touchEvent({target: test.innerComponent.element}, "touchend");
+
+                        expect(inner_listener).toHaveBeenCalled();
+                        expect(outer_listener).toHaveBeenCalled();
+                    }
+                });
+
+
+                it("should fire press for inner composer", function () {
+                    var inner_listener = testPage.addListener(test.inner_press_composer, null, "press"),
+                        outer_listener = testPage.addListener(test.outer_press_composer, null, "press");
+
                     testPage.mouseEvent({target: test.innerComponent.element}, "mousedown");
                     testPage.mouseEvent({target: test.innerComponent.element}, "mouseup");
-                }
 
-                expect(inner_listener).toHaveBeenCalled();
-                expect(outer_listener).not.toHaveBeenCalled();
-            });
+                    expect(inner_listener).toHaveBeenCalled();
+                    expect(outer_listener).not.toHaveBeenCalled();
 
-            it("should fire pressCancel for outer composer", function () {
-                var inner_listener = testPage.addListener(test.inner_press_composer, null, "pressCancel"),
-                    outer_listener = testPage.addListener(test.outer_press_composer, null, "pressCancel");
+                    if (window.Touch) {
+                        /* Touch */
+                        inner_listener = testPage.addListener(test.inner_press_composer, null, "press");
+                        outer_listener = testPage.addListener(test.outer_press_composer, null, "press");
 
-                if (window.Touch) {
-                    testPage.touchEvent({target: test.innerComponent.element}, "touchstart");
-                    testPage.touchEvent({target: test.innerComponent.element}, "touchend");
-                } else {
+                        var boundingRect = test.innerComponent.element.getBoundingClientRect(),
+                            clientX = boundingRect.left,
+                            clientY = boundingRect.top;
+
+                        testPage.touchEvent({clientX:clientX, clientY: clientY, target: test.innerComponent.element}, "touchstart");
+                        testPage.touchEvent({clientX:clientX, clientY: clientY, target: test.innerComponent.element}, "touchend");
+
+                        expect(inner_listener).toHaveBeenCalled();
+                        expect(outer_listener).not.toHaveBeenCalled();
+                    }
+
+                });
+
+                it("should fire pressCancel for outer composer", function () {
+                    var inner_listener = testPage.addListener(test.inner_press_composer, null, "pressCancel"),
+                        outer_listener = testPage.addListener(test.outer_press_composer, null, "pressCancel");
+
                     testPage.mouseEvent({target: test.innerComponent.element}, "mousedown");
                     testPage.mouseEvent({target: test.innerComponent.element}, "mouseup");
-                }
 
-                expect(outer_listener).toHaveBeenCalled();
-                expect(inner_listener).not.toHaveBeenCalled();
-            });
+                    expect(outer_listener).toHaveBeenCalled();
+                    expect(inner_listener).not.toHaveBeenCalled();
 
-            // touchend's target is always the same as touch start, so this
-            // test doesn't apply
-            if (!window.Touch) {
+                    if (window.Touch) {
+                        /* Touch */
+                        inner_listener = testPage.addListener(test.inner_press_composer, null, "pressCancel");
+                        outer_listener = testPage.addListener(test.outer_press_composer, null, "pressCancel");
+
+                        var boundingRect = test.innerComponent.element.getBoundingClientRect(),
+                            clientX = boundingRect.left,
+                            clientY = boundingRect.top;
+
+                        testPage.touchEvent({clientX:clientX, clientY: clientY, target: test.innerComponent.element}, "touchstart");
+                        testPage.touchEvent({clientX:clientX, clientY: clientY, target: test.innerComponent.element}, "touchend");
+
+                        expect(outer_listener).toHaveBeenCalled();
+                        expect(inner_listener).not.toHaveBeenCalled();
+                    }
+                });
+
+                // touchend's target is always the same as touch start, so this
+                // test doesn't apply
                 describe("outer_listener", function () {
                     var _endInteractionSpy;
                     beforeEach(function () {
                         _endInteractionSpy = spyOn(test.outer_press_composer, "_endInteraction")
                     });
-                    it("should _endInteraction when the mouse is released elsewhere", function () {
+
+                    it("should _endInteraction when the touch is released elsewhere", function () {
                         testPage.mouseEvent({target: test.innerComponent.element}, "mousedown");
                         testPage.mouseEvent({target: testPage.document}, "mouseup");
                         expect(_endInteractionSpy).toHaveBeenCalled();
-                     });
-                    it("should _endInteraction when the mouse is released within the element but unclaimed", function () {
+                    });
+
+                    it("should _endInteraction when the mouse/touch is released within the element but unclaimed", function () {
                         testPage.mouseEvent({target: test.innerComponent.element}, "mousedown");
                         testPage.mouseEvent({target: test.inner2Component.element}, "mouseup");
                         expect(_endInteractionSpy).toHaveBeenCalled();
-                     });
+                    });
+
+                    if (window.Touch) {
+                        it("should _endInteraction when the touch is released elsewhere", function () {
+                            testPage.touchEvent({target: test.innerComponent.element}, "touchstart");
+                            testPage.touchEvent({target: testPage.document}, "touchend");
+                            expect(_endInteractionSpy).toHaveBeenCalled();
+                        });
+
+                        it("should _endInteraction when the touch is released within the element but unclaimed", function () {
+                            testPage.touchEvent({target: test.innerComponent.element}, "touchstart");
+                            testPage.touchEvent({target: test.inner2Component.element}, "touchend");
+                            expect(_endInteractionSpy).toHaveBeenCalled();
+                        });
+                    }
                 });
-            }
-        });
+            });
+        }
     });
 });

--- a/test/composer/press-composer-test/press-composer-test.html
+++ b/test/composer/press-composer-test/press-composer-test.html
@@ -117,20 +117,25 @@ POSSIBILITY OF SUCH DAMAGE.
     .example {
         background: #C00;
         position: absolute;
+        top: 100px;
         width: 50px;
         height: 50px;
     }
 
     .outerComponent {
         position: absolute;
+        top: 200px;
         width: 100px;
         height: 100px;
+        background: green;
     }
 
     .innerComponent {
         position: absolute;
         width: 50px;
         height: 50px;
+        background: yellow;
+
     }
 </style>
 

--- a/test/events/active-target-spec.js
+++ b/test/events/active-target-spec.js
@@ -28,13 +28,13 @@ TestPageLoader.queueTest("active-target-test/active-target-test", function (test
                     expect(proximalComponent.isActiveTarget).toBeTruthy();
                 });
 
-                if (window.Touch) {
+                if (!window.PointerEvent && !window.navigator.msPointerEnabled) {
                     it("should focus on a target when a target's own element receives touchstart", function () {
                         testPage.touchEvent({target: proximalElement}, "touchstart");
                         expect(eventManager.activeTarget).toBe(proximalComponent);
                         expect(proximalComponent.isActiveTarget).toBeTruthy();
                     });
-                } else {
+
                     it("should focus on a target when a target's own element receives mousedown", function () {
                         testPage.mouseEvent({target: proximalElement}, "mousedown");
                         expect(eventManager.activeTarget).toBe(proximalComponent);
@@ -45,7 +45,7 @@ TestPageLoader.queueTest("active-target-test/active-target-test", function (test
 
                 //TODO well this will work for now, but this whole forking strategy will need to be rethought (euphemism intended)
                 // The activation eventHandler still works in either/or mode for now
-                if (window.Touch) {
+                if (!window.PointerEvent && !window.navigator.msPointerEnabled) {
                     it("should focus on a target when a target's own element receives touchstart", function () {
                         testPage.touchEvent({target: proximalElement}, "touchstart");
                         expect(eventManager.activeTarget).toBe(proximalComponent);
@@ -122,13 +122,13 @@ TestPageLoader.queueTest("active-target-test/active-target-test", function (test
                     expect(proximalComponent.isActiveTarget).toBeFalsy();
                 });
 
-                if (!window.Touch) {
+                if (!window.PointerEvent && !window.navigator.msPointerEnabled) {
                     it("should focus on some nextTarget that accepts focus when the proximal target receives mousedown", function () {
                         testPage.mouseEvent({target: proximalElement}, "mousedown");
                         expect(eventManager.activeTarget).toBe(activeComponent);
                         expect(activeComponent.isActiveTarget).toBeTruthy();
                     });
-                } else {
+
                     it("must not focus on the proximal target when the target receives touchstart", function () {
                         testPage.touchEvent({target: proximalElement}, "touchstart");
                         expect(proximalComponent.isActiveTarget).toBeFalsy();


### PR DESCRIPTION
:warning: needs this PR to be merged first https://github.com/montagejs/montage/pull/1597

- Adds an option to disable the filtering of emulated mouse events.
- Disables the filtering of emulated mouse events for browsers that support Pointer Events.
- Fixes an issue that was blocking the logic for prepareForActionEvents, indeed ”ontouchstart" exists even on non-touch devices under Firefox.
- Fixes tests.