### PR TITLE
Composers should cancel their work when in some new cases.

### DIFF
--- a/composer/translate-composer.js
+++ b/composer/translate-composer.js
@@ -737,6 +737,14 @@ var TranslateComposer = exports.TranslateComposer = Composer.specialize(/** @len
         }
     },
 
+    captureScroll: {
+        value: function (event) {
+            if (event.target.contains(this.element)) {
+                this._cancel(event);
+            }
+        }
+    },
+
 
     /*------------------------------------------------------------------------------------------------------------------
      *                                             Private Functions.
@@ -820,6 +828,8 @@ var TranslateComposer = exports.TranslateComposer = Composer.specialize(/** @len
                     this._element.addEventListener("touchcancel", this, false);
                 }
             }
+
+            document.addEventListener("scroll", this, true);
 
             if (this.isAnimating) {
                 this.isAnimating = false;
@@ -1083,6 +1093,8 @@ var TranslateComposer = exports.TranslateComposer = Composer.specialize(/** @len
                     this._element.removeEventListener("touchcancel", this, false);
                 }
             }
+
+            document.removeEventListener("scroll", this, true);
 
             if (this.eventManager.isPointerClaimedByComponent(this._observedPointer, this)) {
                 this.eventManager.forfeitPointer(this._observedPointer, this);

--- a/ui/repetition.reel/repetition.js
+++ b/ui/repetition.reel/repetition.js
@@ -1821,15 +1821,6 @@ var Repetition = exports.Repetition = Component.specialize(/** @lends Repetition
     _selectionPointer: {value: null},
 
 
-    /**
-     * Represents an allowed radius of pixels between a touchstart/mousedown and a touchmove/mousemove
-     * to still consider it as a selection.
-     *
-     * @type {number}
-     * @private
-     */
-    _threshold: { value: 10 },
-
 
     /**
      * Original vertical coordinate of a touchstart/mousedown
@@ -1906,9 +1897,6 @@ var Repetition = exports.Repetition = Component.specialize(/** @lends Repetition
                 this.__pressComposer.addEventListener("press", this, false);
                 this.__pressComposer.addEventListener("pressCancel", this, false);
 
-                this.element.addEventListener("touchmove", this, false);
-                document.addEventListener("scroll", this, true);
-
                 iteration.shouldBecomeActive = true;
                 this._currentActiveIteration = iteration;
             }
@@ -1933,58 +1921,6 @@ var Repetition = exports.Repetition = Component.specialize(/** @lends Repetition
 
             this.__pressComposer.removeEventListener("press", this, false);
             this.__pressComposer.removeEventListener("pressCancel", this, false);
-
-            this.element.removeEventListener("touchmove", this, false);
-            document.removeEventListener("scroll", this, true);
-        }
-    },
-
-
-    /**
-     * @private
-     */
-    handleTouchmove: {
-        value: function (event) {
-            var changedTouches = event.changedTouches,
-                touch;
-
-            for (var i = 0, length = changedTouches.length; i < length; i++) {
-                if (changedTouches[i].identifier === this.__pressComposer._observedPointer) {
-                    touch = changedTouches[i];
-                    break;
-                }
-            }
-
-            if (touch) {
-                this._handleMove(touch.clientX, touch.clientY);
-            }
-        }
-    },
-
-
-    /**
-     * @private
-     */
-    captureScroll: {
-        value: function (event) {
-            this._ignoreSelection();
-        }
-    },
-
-
-    /**
-     * @private
-     */
-    _handleMove: {
-        value: function (positionX, positionY) {
-            var threshold = this._threshold,
-                dX = positionX - this._startX,
-                dY = positionY - this._startY;
-
-            // Check if the current position is inside the allowed radius of pixels between a touchstart/mousedown and a touchmove/mousemove.
-            if (dX * dX + dY * dY > threshold * threshold) {
-                this._ignoreSelection();
-            }
         }
     },
 


### PR DESCRIPTION
- The TranslateComposer cancel a translate when a scroll event is raised.
- The PressComposer cancel a press when its element’s position has changed or when a scroll event is raised.
- The repetition doesn’t handle scroll, move anymore.