### PR TITLE
Makes sure a component detaches all its child components when its domContent change.

### DIFF
--- a/ui/component.js
+++ b/ui/component.js
@@ -1064,7 +1064,8 @@ var Component = exports.Component = Target.specialize( /** @lends Component.prot
 
             // cleanup current content
             components = this.childComponents;
-            for (i = 0, component; (component = components[i]); i++) {
+
+            while ((component = components[0])) {
                 component.detachFromParentComponent();
             }
 


### PR DESCRIPTION
The property childComponents is an array, so the length is changing when an element is removed of it. Therefore, all child components were not detached.