### PR TITLE
Improvements with the localizer.

### DIFF
--- a/core/localizer.js
+++ b/core/localizer.js
@@ -635,7 +635,7 @@ var Localizer = exports.Localizer = Montage.specialize( /** @lends Localizer.pro
         }
     },
 
-    _dispatchLocaleChangeHasNeeded: {
+    _dispatchLocaleChangeAsNeeded: {
         value: function (previousLocale, component) {
             if (component && (component.localizer === null || component.localizer === void 0 || component.localizer === this)) {
                 if (typeof component.localizerDidChangeLocale === "function") {
@@ -655,7 +655,7 @@ var Localizer = exports.Localizer = Montage.specialize( /** @lends Localizer.pro
             if (!_component) {
                 _component = this.component || rootComponent;
 
-                if (!this._dispatchLocaleChangeHasNeeded(previousLocale, _component)) {
+                if (!this._dispatchLocaleChangeAsNeeded(previousLocale, _component)) {
                     return;
                 }
             }
@@ -670,7 +670,7 @@ var Localizer = exports.Localizer = Montage.specialize( /** @lends Localizer.pro
                 for (var i = 0; i < childComponents.length; i++) {
                     child = childComponents[i];
 
-                    if (this._dispatchLocaleChangeHasNeeded(previousLocale, child)) {
+                    if (this._dispatchLocaleChangeAsNeeded(previousLocale, child)) {
                         if (child._childComponents) {
                             this._dispatchLocaleChange(previousLocale, child);
                         }

--- a/core/localizer.js
+++ b/core/localizer.js
@@ -61,9 +61,10 @@ var Localizer = exports.Localizer = Montage.specialize( /** @lends Localizer.pro
                 defaultLocaleStored = window.localStorage.getItem(LOCALE_STORAGE_KEY);
             }
 
-            var defaultLocale = this.callDelegateMethod("localizerWillUseLocale", this);
+            var locateCandidate = locale || defaultLocaleStored || window.navigator.userLanguage || window.navigator.language || Localizer.defaultLocale,
+                defaultLocale = this.callDelegateMethod("localizerWillUseLocale", this, locateCandidate);
 
-            this.locale = defaultLocale || defaultLocaleStored || locale || window.navigator.userLanguage || window.navigator.language || Localizer.defaultLocale;
+            this.locale = defaultLocale || locateCandidate;
             this._isInitialized = true;
 
             this.loadMessages();
@@ -634,8 +635,8 @@ var Localizer = exports.Localizer = Montage.specialize( /** @lends Localizer.pro
         }
     },
 
-    _dispatchLocaleChangeIfNeeded: {
-        value: function (component, previousLocale) {
+    _dispatchLocaleChangeHasNeeded: {
+        value: function (previousLocale, component) {
             if (component && (component.localizer === null || component.localizer === void 0 || component.localizer === this)) {
                 if (typeof component.localizerDidChangeLocale === "function") {
                     component.localizerDidChangeLocale(this, previousLocale, this._locale);
@@ -654,7 +655,7 @@ var Localizer = exports.Localizer = Montage.specialize( /** @lends Localizer.pro
             if (!_component) {
                 _component = this.component || rootComponent;
 
-                if (!this._dispatchLocaleChangeIfNeeded(_component, previousLocale)) {
+                if (!this._dispatchLocaleChangeHasNeeded(previousLocale, _component)) {
                     return;
                 }
             }
@@ -669,7 +670,7 @@ var Localizer = exports.Localizer = Montage.specialize( /** @lends Localizer.pro
                 for (var i = 0; i < childComponents.length; i++) {
                     child = childComponents[i];
 
-                    if (this._dispatchLocaleChangeIfNeeded(child, previousLocale)) {
+                    if (this._dispatchLocaleChangeHasNeeded(previousLocale, child)) {
                         if (child._childComponents) {
                             this._dispatchLocaleChange(previousLocale, child);
                         }

--- a/test/core/localizer-spec.js
+++ b/test/core/localizer-spec.js
@@ -165,8 +165,8 @@ describe("core/localizer-spec", function () {
                 expect(localized).toBe("Hello, after");
             });
         });
-        
-        
+
+
 //https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/Promise.jsm/Deferred
         it("waits for the localizer to have messages", function waitsForTheLocalizerToHaveMessages() {
             var resolveTrigger = function resolveTrigger(resolveHandler) {
@@ -199,11 +199,11 @@ describe("core/localizer-spec", function () {
     describe("Localizer", function (){
         var l;
         beforeEach(function () {
-            l = new Localizer.Localizer().init("en");
+            l = new Localizer.Localizer().initWithLocale("en");
         });
 
         it("can be created with a foreign language code", function () {
-            var l = new Localizer.Localizer().init("no");
+            var l = new Localizer.Localizer().initWithLocale("no");
             expect(l.messageFormat).not.toBe(null);
         });
 
@@ -359,7 +359,7 @@ describe("core/localizer-spec", function () {
             });
 
             it("loads non-English messages", function () {
-                var l = new Localizer.Localizer().init("no");
+                var l = new Localizer.Localizer().initWithLocale("no");
                 return require.loadPackage(module.directory + "localizer/fallback/", {}).then(function (r){
                     l.require = r;
                     return l.loadMessages();
@@ -370,7 +370,7 @@ describe("core/localizer-spec", function () {
             });
 
             it("loads the fallback messages", function () {
-                var l = new Localizer.Localizer().init("no-x-compiled");
+                var l = new Localizer.Localizer().initWithLocale("no-x-compiled");
                 return require.loadPackage(module.directory + "localizer/fallback/", {}).then(function (r){
                     l.require = r;
                     return l.loadMessages();
@@ -404,16 +404,17 @@ describe("core/localizer-spec", function () {
         describe("delegate", function () {
             it("is called to determine the default locale to use", function () {
                 var delegate = {
-                    getDefaultLocale: function () {
+                    localizerWillUseLocale: function () {
                         return "en-x-delegate";
                     }
                 };
 
-                spyOn(delegate, 'getDefaultLocale').andCallThrough();
+                spyOn(delegate, 'localizerWillUseLocale').andCallThrough();
 
                 Localizer.defaultLocalizer.delegate = delegate;
+                Localizer.defaultLocalizer.initWithLocale();
 
-                expect(delegate.getDefaultLocale).toHaveBeenCalled();
+                expect(delegate.localizerWillUseLocale).toHaveBeenCalled();
                 expect(Localizer.defaultLocalizer.locale).toBe("en-x-delegate");
             });
         });


### PR DESCRIPTION
Improvements with the Localizer.
- Resolves an issue that was not update the messages when the locale property of the defaultLocalizer changes.
- Add a method `localizerDidChangeLocale` that can be implemented by components in order to be aware when the locale property of the defaultLocalizer changes.
- Add a delegate method `localizerWillLoadMessages` that can provide a ”messages" object with a combination of keys/messages.
- Add a static method `defaultLocalizerWithDelegate` on Localizer in order to set the delegate of the defaultLocalizer. (Returns the defaultLocalizer)
- Add a static method `defaultLocalizer` on Localizer in order to get the defaultLocalizer.
- Merge “class” Localizer and DefaultLocalizer.
- Add a flag to activate the locale storage, `shouldStoreLocale`.
- Tests updated.