### PR TITLE
Remove references to "lifecyle" from documentation

### DIFF
--- a/ui/base/abstract-number-field.js
+++ b/ui/base/abstract-number-field.js
@@ -14,7 +14,7 @@ var AbstractNumberField = exports.AbstractNumberField = AbstractControl.speciali
 /** @lends AbstractNumberField# */
 {
 
-    // Lifecycle
+    // Life Cycle
 
     constructor: {
         value: function AbstractNumberField() {
@@ -91,7 +91,6 @@ var AbstractNumberField = exports.AbstractNumberField = AbstractControl.speciali
         }
     },
 
-
     prepareForActivationEvents: {
         value: function() {
             this._upKeyComposer.addEventListener("keyPress", this, false);
@@ -110,8 +109,7 @@ var AbstractNumberField = exports.AbstractNumberField = AbstractControl.speciali
     },
 
 
-    // Event Handlers
-
+    // Event Handling
 
     acceptsActiveTarget: {
         value: true

--- a/ui/base/abstract-slider.js
+++ b/ui/base/abstract-slider.js
@@ -19,7 +19,7 @@ var AbstractControl = require("./abstract-control").AbstractControl,
  */
 var AbstractSlider = exports.AbstractSlider = AbstractControl.specialize( /** @lends AbstractSlider# */ {
 
-    // Lifecycle
+    // Life Cycle
 
     /**
      * @private
@@ -156,7 +156,7 @@ var AbstractSlider = exports.AbstractSlider = AbstractControl.specialize( /** @l
         }
     },
 
-    // Event Handlers
+    // Event Handling
 
     acceptsActiveTarget: {
         value: true

--- a/ui/component.js
+++ b/ui/component.js
@@ -913,8 +913,7 @@ var Component = exports.Component = Target.specialize(/** @lends Component# */ {
     },
 
     /**
-     * Lifecycle method called when this component is removed from the
-     * document's DOM tree.
+     * Called when this component is removed from the document's DOM tree.
      * @method
      */
     exitDocument: {

--- a/ui/repetition.reel/repetition.js
+++ b/ui/repetition.reel/repetition.js
@@ -586,8 +586,8 @@ var Repetition = exports.Repetition = Component.specialize(/** @lends Repetition
      * "active" CSS class) when the user touches or clicks it, and toggles
      * whether the corresponding content is selected.
      *
-     * Selection may be enabled and disabled at any time in the life cycle of
-     * the repetition.  The repetition watches changes to this property.
+     * Selection may be enabled and disabled at any time.  The repetition
+     * watches changes to this property.
      *
      * All repetitions support selection, whether it is used or not.  This
      * property merely dictates whether the repetition handles gestures for


### PR DESCRIPTION
There are a couple of places in the documentation that have unnecessary
references to the concept of an object life cycle. This commit removes
them to simplify the documentation.

There are also a couple of places in the code where comments refer to
"lifecycle". This commit does not attempt to get rid of these but it
does correct the misspelling in the comments to "life cycle".
