### PR TITLE
Minor performance improvements.

### DIFF
--- a/core/converter/date-converter.js
+++ b/core/converter/date-converter.js
@@ -719,7 +719,7 @@ var Montage = require("../core").Montage,
         var n = this.getTimezoneOffset() * -10 / 6, r;
         if (n < 0) {
             r = (n - 10000).toString();
-            return r.charAt(0) + r.substr(2);
+            return r[0] + r.substr(2);
         } else {
             r = (n + 10000).toString();
             return "+" + r.substr(1);
@@ -884,7 +884,7 @@ var Montage = require("../core").Montage,
 
         return format ? format.replace(/(\\)?(dd?d?d?|MM?M?M?|yy?y?y?|hh?|HH?|mm?|ss?|tt?|S)/g,
             function (m) {
-                if (m.charAt(0) === "\\") {
+                if (m[0] === "\\") {
                     return m.replace("\\", "");
                 }
                 x.h = x.getHours;
@@ -1279,7 +1279,7 @@ var Montage = require("../core").Montage,
 
         return format ? format.replace(/(\\)?(dd?d?d?|MM?M?M?|yy?y?y?|hh?|HH?|mm?|ss?|tt?|S)/g,
             function (m) {
-                if (m.charAt(0) === "\\") {
+                if (m[0] === "\\") {
                     return m.replace("\\", "");
                 }
                 x.h = x.getHours;

--- a/core/core.js
+++ b/core/core.js
@@ -21,7 +21,7 @@ var ATTRIBUTE_PROPERTIES = "AttributeProperties",
     ENUMERABLE = "enumerable",
     DISTINCT = "distinct",
     SERIALIZABLE = "serializable",
-    MODIFY = "modify";
+    UNDERSCORE_UNICODE = 95;
 
 var ARRAY_PROTOTYPE = Array.prototype;
 
@@ -288,8 +288,7 @@ Object.defineProperty(Montage, "defineProperty", {
             }
         }
 
-
-        if (!descriptor.hasOwnProperty(ENUMERABLE) && prop.charAt(0) === UNDERSCORE) {
+        if (!descriptor.hasOwnProperty(ENUMERABLE) && prop.charCodeAt(0) === UNDERSCORE_UNICODE) {
             descriptor.enumerable = false;
         }
         if (!descriptor.hasOwnProperty(SERIALIZABLE)) {

--- a/core/extras/string.js
+++ b/core/extras/string.js
@@ -49,7 +49,7 @@ Object.defineProperty(String.prototype, "contains", {
  */
 Object.defineProperty(String.prototype, "toCapitalized", {
     value: function () {
-        return this.charAt(0).toUpperCase() + this.slice(1);
+        return this[0].toUpperCase() + this.slice(1);
     },
     writable: true,
     configurable: true

--- a/core/meta/blueprint.js
+++ b/core/meta/blueprint.js
@@ -946,7 +946,7 @@ var Blueprint = exports.Blueprint = Montage.specialize( /** @lends Blueprint.pro
                 var newBlueprint = new this();
 
                 for (var name in target) {
-                    if ((name.charAt(0) !== "_") && (target.hasOwnProperty(name))) {
+                    if ((name[0] !== "_") && (target.hasOwnProperty(name))) {
                         // We don't want to list private properties
                         var value = target[name];
                         var propertyBlueprint;


### PR DESCRIPTION
- Use brackets to get characters instead of using the `charAt()` method.
- Use the `charCodeAt` method instead of the `charAt()` method, up to 40% faster under Chrome 46 and 30% under Safari 9, no noticeable difference under Firefox.