### PR TITLE
Fix issue that prevented scrolling over buttons on touch devices

### DIFF
--- a/ui/button.reel/button.js
+++ b/ui/button.reel/button.js
@@ -213,10 +213,6 @@ var Button = exports.Button = Control.specialize(/** @lends module:"montage/ui/n
                 // it scrolls and not the webpage
                 document.addEventListener("touchmove", this, false);
             }
-
-            if (!this._preventFocus) {
-                this._element.focus();
-            }
         }
     },
 
@@ -228,6 +224,9 @@ var Button = exports.Button = Control.specialize(/** @lends module:"montage/ui/n
             this.active = false;
             this._dispatchActionEvent();
             document.removeEventListener("touchmove", this, false);
+            if (!this._preventFocus) {
+                this._element.focus();
+            }
         }
     },
 

--- a/ui/button.reel/button.js
+++ b/ui/button.reel/button.js
@@ -207,12 +207,6 @@ var Button = exports.Button = Control.specialize(/** @lends module:"montage/ui/n
     handlePressStart: {
         value: function(event) {
             this.active = true;
-
-            if (event.touch) {
-                // Prevent default on touchmove so that if we are inside a scroller,
-                // it scrolls and not the webpage
-                document.addEventListener("touchmove", this, false);
-            }
         }
     },
 
@@ -223,7 +217,6 @@ var Button = exports.Button = Control.specialize(/** @lends module:"montage/ui/n
         value: function(event) {
             this.active = false;
             this._dispatchActionEvent();
-            document.removeEventListener("touchmove", this, false);
             if (!this._preventFocus) {
                 this._element.focus();
             }
@@ -260,12 +253,6 @@ var Button = exports.Button = Control.specialize(/** @lends module:"montage/ui/n
         value: function(event) {
             this.active = false;
             document.removeEventListener("touchmove", this, false);
-        }
-    },
-
-    handleTouchmove: {
-        value: function(event) {
-            event.preventDefault();
         }
     },
 


### PR DESCRIPTION
Fixes #1677 

Note: In order for scrolling over buttons to work, they must respond to touch up events, i.e. press instead of pressStart. This seems appropriate. The behavior on non-touch clicks, however, is still to activate the button on mouse down rather than mouse up.