### PR TITLE
Fix order of blueprint enumValues for Studio

### DIFF
--- a/ui/component.meta
+++ b/ui/component.meta
@@ -70,9 +70,9 @@
             "readOnly": false,
             "valueType": "enum",
             "enumValues": [
+                "inherit",
                 "true",
-                "false",
-                "inherit"
+                "false"
             ],
             "helpKey": ""
         }
@@ -126,9 +126,9 @@
             "readOnly": false,
             "valueType": "enum",
             "enumValues": [
+                "auto",
                 "true",
-                "false",
-                "auto"
+                "false"
             ],
             "helpKey": ""
         }


### PR DESCRIPTION
Alternative to https://github.com/montagestudio/palette/pull/43.

Supplement to https://github.com/montagestudio/palette/pull/42. Even though the property inspector now does not serialize its value until it has been changed once, the select dropdown itself will seem to indicate the wrong value initially. For example, adding a Montage text component reveals the following:

<img width="198" alt="screen shot 2016-02-10 at 1 32 44 am" src="https://cloud.githubusercontent.com/assets/8292702/12943445/3e2aed20-cf96-11e5-859f-4f4b619a7342.png">

Here contenteditable is shown by the select as true, even though it has not been added to the serialization and as a result defaults to "inherit":

<img width="643" alt="screen shot 2016-02-10 at 1 34 24 am" src="https://cloud.githubusercontent.com/assets/8292702/12943480/760feb00-cf96-11e5-9de2-1b23caa70870.png">

This PR reorders some of the enum property values in the respective blueprint so that the default value is always first, so as to not be misleading.

+: The user knows what the value of a property is by default, instead of having a blank select
-: Fix is in Montage itself, so the selects for enum property inspectors will still show the wrong value when opening a project that has an older version of Montage
-: If the default value ever changes, we will have to reorder the blueprints again. No automatic link between the select's initial value and the default value of the property (the property inspectors currently have no way of determining the default value of a property because they don't have access to the modified object's prototype, and even if they did the prototype defines attribute values as null)
-: All packages will have to follow the convention of putting the default value first in the blueprint (most do seem to follow this convention already)