### PR TITLE
Raise a Press Event when it’s “safe” for touch devices.

### DIFF
--- a/composer/press-composer.info/sample/ui/main.reel/config.json
+++ b/composer/press-composer.info/sample/ui/main.reel/config.json
@@ -105,6 +105,10 @@
                     "label": "selected"
                 }
             ]
+        },
+        {
+            "label": "press composer layers",
+            "arg": "press-composer-layers"
         }
     ]
 }

--- a/composer/press-composer.info/sample/ui/main.reel/main.html
+++ b/composer/press-composer.info/sample/ui/main.reel/main.html
@@ -187,9 +187,7 @@
                     <button data-montage-id="inner-press-list-number-label"></button>
                 </div>
             </div>
-            <div data-montage-id="press-composer-layers" data-arg="press-composer-layers">
-                <button ></button>
-            </div>
+            <div data-montage-id="press-composer-layers" data-arg="press-composer-layers"></div>
         </div>
         <footer>
             <div data-montage-id="captions" class="Captions">

--- a/composer/press-composer.info/sample/ui/main.reel/main.html
+++ b/composer/press-composer.info/sample/ui/main.reel/main.html
@@ -130,6 +130,13 @@
             }
         },
 
+        "pressComposerLayers": {
+            "prototype": "../press-composer-layers.reel",
+            "properties": {
+                "element": {"#": "press-composer-layers"}
+            }
+        },
+
         "captions": {
             "prototype": "montage/ui/repetition.reel",
             "properties": {
@@ -141,7 +148,7 @@
             }
         },
 
-         "caption": {
+        "caption": {
             "prototype": "../caption.reel",
             "properties": {
                 "element": {"#": "caption"}
@@ -179,6 +186,9 @@
                 <div class="Cell">
                     <button data-montage-id="inner-press-list-number-label"></button>
                 </div>
+            </div>
+            <div data-montage-id="press-composer-layers" data-arg="press-composer-layers">
+                <button ></button>
             </div>
         </div>
         <footer>

--- a/composer/press-composer.info/sample/ui/press-composer-layers.reel/press-composer-layers.css
+++ b/composer/press-composer.info/sample/ui/press-composer-layers.reel/press-composer-layers.css
@@ -1,0 +1,41 @@
+.PressComposerLayers {
+    position: absolute;
+    top: 100px;
+    left: 0;
+}
+
+.PressComposerLayers > input {
+    outline: none;
+    border: 1px solid #d7d7d7;
+    width: 100px;
+    height: 30px;
+}
+
+
+.PressComposerLayers > button {
+    width: 100px;
+    height: 30px;
+    background: #31de7c;
+    color: white;
+    outline: none;
+    border-radius: 4px;
+    border: none;
+}
+
+.PressComposerLayers-Overlay > button {
+    width: 100px;
+    height: 30px;
+    background: #ff341e;
+    color: white;
+    outline: none;
+    border-radius: 4px;
+    border: none;
+}
+
+.PressComposerLayers > button:active {
+    background: #2bb462;
+}
+
+.PressComposerLayers-Overlay > button:active {
+    background: #bb2616;
+}

--- a/composer/press-composer.info/sample/ui/press-composer-layers.reel/press-composer-layers.html
+++ b/composer/press-composer.info/sample/ui/press-composer-layers.reel/press-composer-layers.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title></title>
+    <link rel="stylesheet" type="text/css" href="press-composer-layers.css">
+    <script type="text/montage-serialization">
+    {
+        "owner": {
+            "properties": {
+                "element": {"#": "owner"},
+                "overlay": {"@": "overlay"}
+            }
+        },
+
+        "showOverlay": {
+            "prototype": "montage/ui/button.reel",
+            "properties": {
+                "element": {"#": "show-overlay-button"},
+                "label": "Show Overlay"
+            }
+        },
+
+        "textField": {
+            "prototype": "montage/ui/text-field.reel",
+            "properties": {
+                "element": {"#": "text-field"}
+            }
+        },
+
+        "overlay": {
+            "prototype": "montage/ui/overlay.reel",
+            "properties": {
+                "element": {"#": "overlay"},
+                "position" : {
+                    "left" : 105,
+                    "top" : 100
+                }
+            }
+        },
+
+        "dismissOverlay": {
+            "prototype": "montage/ui/button.reel",
+            "properties": {
+                "element": {"#": "dismiss-overlay-button"},
+                "label": "Hide Overlay"
+            }
+        }
+    }
+    </script>
+</head>
+<body>
+    <div data-montage-id="owner" class="PressComposerLayers">
+        <button data-montage-id="show-overlay-button">Show Overlay</button>
+        <input data-montage-id="text-field" type="text" />
+
+        <div data-montage-id="overlay" class="PressComposerLayers-Overlay">
+            <button data-montage-id="dismiss-overlay-button">Show Overlay</button>
+        </div>
+    </div>
+</body>
+</html>

--- a/composer/press-composer.info/sample/ui/press-composer-layers.reel/press-composer-layers.js
+++ b/composer/press-composer.info/sample/ui/press-composer-layers.reel/press-composer-layers.js
@@ -1,0 +1,31 @@
+/**
+ * @module ui/press-composer-layers.reel
+ */
+var Component = require("montage/ui/component").Component;
+
+/**
+ * @class PressComposerLayers
+ * @extends Component
+ */
+exports.PressComposerLayers = Component.specialize(/** @lends PressComposerLayers# */ {
+    enterDocument: {
+        value: function (firstTime) {
+            if (firstTime) {
+                this.addEventListener("action", this);
+                this.overlay.addEventListener("action", this);
+            }
+        }
+    },
+
+    handleShowOverlayAction: {
+        value: function () {
+            this.overlay.show();
+        }
+    },
+
+    handleDismissOverlayAction: {
+        value: function () {
+            this.overlay.hide();
+        }
+    }
+});

--- a/composer/press-composer.js
+++ b/composer/press-composer.js
@@ -736,7 +736,7 @@ var PressComposer = exports.PressComposer = Composer.specialize(/** @lends Press
 
                 if (this._needDispatchSafePress || event.defaultPrevented) {// no simulated event when a touchMove has been raised
                     var self = this,
-                        eventManager = this.element.ownerDocument.defaultView.defaultEventManager;
+                        eventManager = document.defaultView.defaultEventManager;
 
                     // Raise a Press event after the simulated mousedown event has been raised,
                     // in order to avoid elements that are not on the same layer  to get the focus.

--- a/composer/press-composer.js
+++ b/composer/press-composer.js
@@ -747,7 +747,7 @@ var PressComposer = exports.PressComposer = Composer.specialize(/** @lends Press
                     // @example: @see press-composer.info
                     window.nativeAddEventListener("mousedown", function _dispatchSafePress (mouseDownEvent) {
                         if (touchEndTargetElement === mouseDownEvent.target ||
-                            eventManager._couldEmulatedEventHasWrongTarget(
+                            eventManager._couldEmulatedEventHaveWrongTarget(
                                 event.changedTouches[0],
                                 mouseDownEvent,
                                 eventManager._emulatedEventRadiusThreshold,

--- a/core/event/event-manager.js
+++ b/core/event/event-manager.js
@@ -2306,7 +2306,7 @@ if (typeof window !== "undefined") { // client-side
                     touch = trackingTouchList.get(key);
 
                     if (touch.target === mouseTarget ||
-                        this._couldEmulatedEventHasWrongTarget(
+                        this._couldEmulatedEventHaveWrongTarget(
                             touch,
                             mouseEvent,
                             this._emulatedEventRadiusThreshold,
@@ -2329,7 +2329,7 @@ if (typeof window !== "undefined") { // client-side
          * Indeed, Touch Events and simulated Mouse Events can have a different target and not the same position on Chrome.
          *
          */
-        _couldEmulatedEventHasWrongTarget: {
+        _couldEmulatedEventHaveWrongTarget: {
             value: function (touch, mouseEvent, radiusThreshold, timestampThreshold) {
 
                 if (/*dTimestamp*/(mouseEvent.timeStamp - touch.timeStamp) <= timestampThreshold) {

--- a/core/event/event-manager.js
+++ b/core/event/event-manager.js
@@ -2297,12 +2297,13 @@ if (typeof window !== "undefined") { // client-side
             value: function (mouseEvent, trackingTouchList) {
                 var mouseTarget = mouseEvent.target,
                     identifier = -1,
+                    key,
                     touch,
                     mapIter;
 
                 mapIter = trackingTouchList.keys();
-                while (identifier = mapIter.next().value) {
-                    touch = trackingTouchList.get(identifier);
+                while (key = mapIter.next().value) {
+                    touch = trackingTouchList.get(key);
 
                     if (touch.target === mouseTarget ||
                         this._couldEmulatedEventHasWrongTarget(
@@ -2310,7 +2311,11 @@ if (typeof window !== "undefined") { // client-side
                             mouseEvent,
                             this._emulatedEventRadiusThreshold,
                             this._emulatedEventTimestampThreshold
-                        )) break;
+                        )) {
+
+                        identifier = key;
+                        break;
+                    }
                 }
 
                 return identifier;
@@ -2331,7 +2336,7 @@ if (typeof window !== "undefined") { // client-side
                     var dX = touch.clientX - mouseEvent.clientX,
                         dY = touch.clientY - mouseEvent.clientY;
 
-                    return dX * dX + dY * dY > radiusThreshold * radiusThreshold;
+                    return dX * dX + dY * dY <= radiusThreshold * radiusThreshold;
                 }
 
                 return false;

--- a/test/composer/press-composer-spec.js
+++ b/test/composer/press-composer-spec.js
@@ -53,10 +53,13 @@ TestPageLoader.queueTest("press-composer-test/press-composer-test", function (te
                         var cancelListener = testPage.addListener(test.press_composer, null, "pressCancel");
 
                         testPage.touchEvent({target: test.example.element}, "touchend");
+                        // no event filtering within test so the state test need to before raising the mousedown event.
+                        expect(test.press_composer.state).toBe(PressComposer.UNPRESSED);
+
+                        testPage.mouseEvent({target: test.example.element}, "mousedown"); //simulate event emulation
 
                         expect(pressListener).toHaveBeenCalled();
                         expect(cancelListener).not.toHaveBeenCalled();
-                        expect(test.press_composer.state).toBe(PressComposer.UNPRESSED);
                     });
                 }
 
@@ -160,9 +163,11 @@ TestPageLoader.queueTest("press-composer-test/press-composer-test", function (te
                             expect(test.press_composer.state).toBe(PressComposer.PRESSED);
 
                             testPage.touchEvent({target: test.example.element}, "touchend");
-
-                            expect(pressListener).toHaveBeenCalled();
+                            // no event filtering within test so the state test need to before raising the mousedown event.
                             expect(test.press_composer.state).toBe(PressComposer.UNPRESSED);
+
+                            testPage.mouseEvent({target: test.example.element}, "mousedown"); //simulate event emulation
+                            expect(pressListener).toHaveBeenCalled();
                         }
                     });
                 });
@@ -340,6 +345,7 @@ TestPageLoader.queueTest("press-composer-test/press-composer-test", function (te
 
                         testPage.touchEvent({clientX:clientX, clientY: clientY, target: test.innerComponent.element}, "touchstart");
                         testPage.touchEvent({clientX:clientX, clientY: clientY, target: test.innerComponent.element}, "touchend");
+                        testPage.mouseEvent({target: test.innerComponent.element}, "mousedown"); //simulate event emulation
 
                         expect(inner_listener).toHaveBeenCalled();
                         expect(outer_listener).not.toHaveBeenCalled();


### PR DESCRIPTION
Knowing that, the simulated mouse events are not dispatched by the event manager, but they are still walking the dom. An issue could happen here when the positioning of elements is changing (z-index) after the press event has been raised, which could result to giving the focus to a wrong element. (see example in press-composer.info for user case)
- Updates specs.
- Add user case to the press-composer.info.