### PR TITLE
Addresses an issue where buttons would display a focus ring when inte…

### DIFF
--- a/test/ui/button-spec.js
+++ b/test/ui/button-spec.js
@@ -96,7 +96,7 @@ describe("test/ui/button-spec", function () {
                 aButton.element = anElement;
                 aButton._draw();
                 aButton.draw();
-                expect(anElement.setAttribute).toHaveBeenCalledWith("tabindex", "-1");
+                expect(anElement.setAttribute).toHaveBeenCalledWith("tabindex", "0");
                 aButton.preventFocus = true;
                 aButton._draw();
                 aButton.draw();

--- a/ui/button.info/sample/ui/main.reel/main.css
+++ b/ui/button.info/sample/ui/main.reel/main.css
@@ -29,7 +29,6 @@ header {
 .button {
     height: 80px;
     width: 200px;
-    outline: none;
     font-size: 15px;
     box-sizing: border-box;
     padding: 0;

--- a/ui/button.info/sample/ui/main.reel/main.html
+++ b/ui/button.info/sample/ui/main.reel/main.html
@@ -74,6 +74,9 @@
             <button data-montage-id="button-native" class="button native"></button>
             <button data-montage-id="button-promise" class="button"></button>
             <span data-montage-id="text"></span>
+            <br>
+            <button>Bare Button</button>
+
         </section>
     </div>
 </body>

--- a/ui/button.reel/button.js
+++ b/ui/button.reel/button.js
@@ -298,10 +298,6 @@ var Button = exports.Button = Control.specialize(/** @lends module:"montage/ui/n
                 this.active = true;
                 this._addEventListeners();
             }
-
-            if (!this._preventFocus) {
-                this._element.focus();
-            }
         }
     },
 
@@ -424,28 +420,10 @@ var Button = exports.Button = Control.specialize(/** @lends module:"montage/ui/n
         }
     },
 
-    _elementNeedsTabIndexRegex: {
-        value: /INPUT|TEXTAREA|A|SELECT|BUTTON|LABEL/
-    },
-
-    _elementNeedsTabIndex: {
-        value: function () {
-            return this.element.tagName.match(this._elementNeedsTabIndexRegex) === null;
-        }
-    },
 
     draw: {
         value: function () {
             this.super();
-
-            if (this._elementNeedsTabIndex()) {
-                if (this._preventFocus) {
-                    this.element.removeAttribute("tabindex");
-                } else {
-                    this.element.setAttribute("tabindex", "-1");
-                }
-            }
-
             this._drawLabel(this._label);
         }
     }

--- a/ui/button.reel/button.js
+++ b/ui/button.reel/button.js
@@ -64,26 +64,6 @@ var Button = exports.Button = Control.specialize(/** @lends module:"montage/ui/n
         @param {Event} event
     */
 
-    _preventFocus: {
-        enumerable: false,
-        value: false
-    },
-
-/**
-    Specifies whether the button should receive focus or not.
-    @type {boolean}
-    @default false
-    @event longpress @benoit: no events here?
-*/
-    preventFocus: {
-        get: function () {
-            return this._preventFocus;
-        },
-        set: function (value) {
-            this._preventFocus = !!value;
-            this.needsDraw = true;
-        }
-    },
     standardElementTagName: {
         value: "BUTTON"
     },

--- a/ui/control.js
+++ b/ui/control.js
@@ -184,15 +184,38 @@ var Control = exports.Control = Component.specialize(/** @lends module:montage/u
         enumerable: false,
         value: false
     },
-    // drawValue {
-    //     value: function () {
-    //     }
-    // },
+
+    _elementNeedsTabIndexRegex: {
+        value: /INPUT|TEXTAREA|A|SELECT|BUTTON|LABEL/
+    },
+
+    _elementNeedsTabIndex: {
+        value: function () {
+            return this.element.tagName.match(this._elementNeedsTabIndexRegex) === null;
+        }
+    },
+
+    enterDocument: {
+        value: function (firstDraw) {
+            this.super(firstDraw);
+            if(firstDraw) {
+                if (this._elementNeedsTabIndex()) {
+                    if (this._preventFocus) {
+                        this.element.removeAttribute("tabindex");
+                    } else {
+                        this.element.setAttribute("tabindex", "0");
+                    }
+                }
+            }
+
+        }
+    },
+
     draw: {
         value: function () {
             if (this._focusBlur === 1) {
                 this._element.focus();
-            } else if (this._focusBlur === 0) {
+            } else if (this._focusBlur === 0 || !this.drawsFocusOnPointerActivation) {
                 this._element.blur();
             }
             this._focusBlur = void 0;
@@ -231,6 +254,10 @@ var Control = exports.Control = Component.specialize(/** @lends module:montage/u
         }
     },
 
+    drawsFocusOnPointerActivation : {
+        value: false
+    },
+
     /**
      * Description TODO
      * @function
@@ -240,6 +267,7 @@ var Control = exports.Control = Component.specialize(/** @lends module:montage/u
         enumerable: false,
         value: function (event) {
             this.hasFocus = true;
+            this.drawsFocusOnPointerActivation = true;
         }
     },
 
@@ -247,6 +275,7 @@ var Control = exports.Control = Component.specialize(/** @lends module:montage/u
         enumerable: false,
         value: function (event) {
             this.hasFocus = false;
+            this.drawsFocusOnPointerActivation = false;
             this.callDelegateMethod("didEndEditing", this);
             //This create an issue in textfield, to investigate
             this.dispatchActionEvent();

--- a/ui/control.js
+++ b/ui/control.js
@@ -195,25 +195,17 @@ var Control = exports.Control = Component.specialize(/** @lends module:montage/u
         }
     },
 
-    enterDocument: {
-        value: function (firstDraw) {
-            this.super(firstDraw);
-            if(firstDraw) {
-                if (this._elementNeedsTabIndex()) {
-                    if (this._preventFocus) {
-                        this.element.removeAttribute("tabindex");
-                    } else {
-                        this.element.setAttribute("tabindex", "0");
-                    }
-                }
-            }
-
-        }
-    },
-
     draw: {
         value: function () {
-            if (this._focusBlur === 1) {
+        if (this._elementNeedsTabIndex()) {
+            if (this._preventFocus) {
+                this.element.removeAttribute("tabindex");
+            } else {
+                this.element.setAttribute("tabindex", "0");
+            }
+        }
+
+          if (this._focusBlur === 1) {
                 this._element.focus();
             } else if (this._focusBlur === 0 || !this.drawsFocusOnPointerActivation) {
                 this._element.blur();
@@ -251,6 +243,27 @@ var Control = exports.Control = Component.specialize(/** @lends module:montage/u
             }
 
             return true;
+        }
+    },
+
+    _preventFocus: {
+        enumerable: false,
+        value: false
+    },
+
+/**
+    Specifies whether the button should receive focus or not.
+    @type {boolean}
+    @default false
+    @event longpress @benoit: no events here?
+*/
+    preventFocus: {
+        get: function () {
+            return this._preventFocus;
+        },
+        set: function (value) {
+            this._preventFocus = !!value;
+            this.needsDraw = true;
         }
     },
 

--- a/ui/text-input.js
+++ b/ui/text-input.js
@@ -96,6 +96,10 @@ var TextInput = exports.TextInput =  Control.specialize(/** @lends module:montag
         }
     },
 
+    drawsFocusOnPointerActivation : {
+        value: true
+    },
+
     draw: {
         enumerable: false,
         value: function() {


### PR DESCRIPTION
…racted with a pointer, they should only get that when tabbed to with a keyboard. Extends that behavior to all controls. Introduces a new property, drawsFocusOnPointerActivation to control rendering of focus when interacted with a pointer. Also addresses a bug where when taking control of some css properties, browsers suddenly starts rendering a focus ring on click when the don’t otherwise. This changes makes sure that we counter that with a .blur() in draw if drawsFocusOnPointerActivation is false