### PR TITLE
Fix for chrome 55.

### DIFF
--- a/core/event/event-manager.js
+++ b/core/event/event-manager.js
@@ -1259,7 +1259,7 @@ if (typeof window !== "undefined") { // client-side
                 // before finding event handlers that were registered for these events
                 if (window.PointerEvent) {
                     aWindow.nativeAddEventListener("pointerdown", this._activationHandler, true);
-                    aWindow.nativeAddEventListener("pointerenter", this._activationHandler, true);
+                    aWindow.document.nativeAddEventListener("pointerenter", this._activationHandler, true);
 
                 } else if (window.MSPointerEvent && window.navigator.msPointerEnabled) {
                     aWindow.nativeAddEventListener("MSPointerDown", this._activationHandler, true);


### PR DESCRIPTION
Chrome 55 support the pointer events, but pointerenter events are not dispatched from window under Chrome.