### PR TITLE
Add configurable:true to Promise property descriptor

### DIFF
--- a/montage.js
+++ b/montage.js
@@ -767,6 +767,7 @@ if (!String.prototype.endsWith) {
 
                 window.nativePromise = window.Promise;
                 Object.defineProperty(window,"Promise", {
+                    configurable: true,
                     set: function(PromiseValue) {
                         Object.defineProperty(window,"Promise",{value:PromiseValue});
 


### PR DESCRIPTION
IE11 throws an error when defineProperty is called on window.Promise,
(the property is “non-configurable”) unless the property descriptor
explicitly defines configurable = true.