### PR TITLE
RangeController: Fix undefined self reference

### DIFF
--- a/core/range-controller.js
+++ b/core/range-controller.js
@@ -73,11 +73,7 @@ Object.defineProperty(_RangeSelection.prototype, "clone", {
         return this.slice();
     }
 });
-var oldSwap = self.swap;
-Object.defineProperty(_RangeSelection.prototype, "oldSwap", {
-    configurable: false,
-    value: observableArrayProperties.swap.value
-});
+_RangeSelection.prototype.oldSwap = observableArrayProperties.swap.value;
 Object.defineProperty(_RangeSelection.prototype, "swap", {
     configurable: false,
     value: function(start, howMany, itemsToAdd) {

--- a/test/all.js
+++ b/test/all.js
@@ -36,7 +36,7 @@ module.exports = require("montage-testing").run(require, [
     "spec/core/set-spec",
     {name: "spec/core/dom-spec", node: false, karma: false},
     {name: "spec/core/extras/url", node: false},
-    {name: "spec/core/range-controller-spec", node: false, karma: false},
+    "spec/core/range-controller-spec",
     {name: "spec/core/media-controller-spec", node: false},
     {name: "spec/core/radio-button-controller-spec", node: false},
     // Base

--- a/test/spec/core/range-controller-spec.js
+++ b/test/spec/core/range-controller-spec.js
@@ -314,7 +314,10 @@ describe("core/range-controller-spec", function () {
             };
             var content = rangeController.addContent();
             expect(content).toEqual(jasmine.objectContaining({x: 10}));
-            expect(rangeController.content).toContain(jasmine.objectContaining({x: 10}));
+            var insertedObject = rangeController.content.filter(function (elem) {
+                return elem.x === 10;
+            })[0];
+            expect(insertedObject).toBeTruthy();
         });
 
         it("should defer to the content type of the backing collection", function () {


### PR DESCRIPTION
RangeSelection uses self in its outer scope without having declared it. Not sure why RangeSelection.oldSwap is set in this way while RangeSelection.oldPush a few lines down does it differently.

Notes
* This bug was being masked in the browser (self points to window), so I enabled this spec for testing under a node env (and also Karma, though it also points self onto window).
* The change in range-controller-spec is for compatibility with Karma, but is semantically identical. Jasmine throws an error when running expect(arr).toContain(...) under Karma.
* Though self pointing to window under a browser or Karma environment prevents an exception, it is definitely not the correct logic (self.oldSwap is always undefined), and it's likely this bug was breaking swapping on range controllers in some cases.
* Not sure if self pointing to window is intended behavior. If not it's likely that some code in the montage core is accidentally defining self in the global scope.