### PR TITLE
Remove circular references in meta/

### DIFF
--- a/core/converter/bytes-converter.meta
+++ b/core/converter/bytes-converter.meta
@@ -11,16 +11,7 @@
         }
     },
     "converter_blueprint_reference": {
-        "prototype": "core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "Converter",
-                "prototypeName": "Converter",
-                "blueprintModule": {
-                    "%": "core/converter/converter.meta"
-                }
-            }
-        }
+        "object": "core/converter/converter.meta"
     },
     "root": {
         "prototype": "core/meta/module-blueprint",

--- a/core/converter/currency-converter.meta
+++ b/core/converter/currency-converter.meta
@@ -11,16 +11,7 @@
         }
     },
     "number_converter_blueprint_reference": {
-        "prototype": "core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "NumberConverter",
-                "prototypeName": "NumberConverter",
-                "blueprintModule": {
-                    "%": "core/converter/number-converter.meta"
-                }
-            }
-        }
+        "object": "core/converter/number-converter.meta"
     },
     "currencyConverter_showCurrencyBeforeNumber": {
         "prototype": "core/meta/property-blueprint",

--- a/core/converter/date-converter.meta
+++ b/core/converter/date-converter.meta
@@ -22,16 +22,7 @@
         }
     },
     "converter_blueprint_reference": {
-        "prototype": "core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "Converter",
-                "prototypeName": "Converter",
-                "blueprintModule": {
-                    "%": "core/converter/converter.meta"
-                }
-            }
-        }
+        "object": "core/converter/converter.meta"
     },
     "root": {
         "prototype": "core/meta/module-blueprint",

--- a/core/converter/expression-converter.meta
+++ b/core/converter/expression-converter.meta
@@ -1,15 +1,6 @@
 {
     "converter_object-descriptor_reference": {
-        "prototype": "core/meta/object-descriptor-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "Converter",
-                "prototypeName": "Converter",
-                "blueprintModule": {
-                    "%": "core/converter/converter.meta"
-                }
-            }
-        }
+        "object": "core/converter/converter.meta"
     },
     "convertExpression": {
         "prototype": "core/meta/property-descriptor",

--- a/core/converter/invert-converter.meta
+++ b/core/converter/invert-converter.meta
@@ -1,15 +1,6 @@
 {
     "converter_blueprint_reference": {
-        "prototype": "core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "Converter",
-                "prototypeName": "Converter",
-                "blueprintModule": {
-                    "%": "core/converter/converter.meta"
-                }
-            }
-        }
+        "object": "core/converter/converter.meta"
     },
     "root": {
         "prototype": "core/meta/module-blueprint",

--- a/core/converter/lower-case-converter.meta
+++ b/core/converter/lower-case-converter.meta
@@ -1,15 +1,6 @@
 {
     "converter_blueprint_reference": {
-        "prototype": "core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "Converter",
-                "prototypeName": "Converter",
-                "blueprintModule": {
-                    "%": "core/converter/converter.meta"
-                }
-            }
-        }
+        "object": "core/converter/converter.meta"
     },
     "root": {
         "prototype": "core/meta/module-blueprint",

--- a/core/converter/new-line-to-br-converter.meta
+++ b/core/converter/new-line-to-br-converter.meta
@@ -1,15 +1,6 @@
 {
     "converter_blueprint_reference": {
-        "prototype": "core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "Converter",
-                "prototypeName": "Converter",
-                "blueprintModule": {
-                    "%": "core/converter/converter.meta"
-                }
-            }
-        }
+        "object": "core/converter/converter.meta"
     },
     "root": {
         "prototype": "core/meta/module-blueprint",

--- a/core/converter/number-converter.meta
+++ b/core/converter/number-converter.meta
@@ -66,16 +66,7 @@
         }
     },
     "converter_blueprint_reference": {
-        "prototype": "core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "Converter",
-                "prototypeName": "Converter",
-                "blueprintModule": {
-                    "%": "core/converter/converter.meta"
-                }
-            }
-        }
+        "object": "core/converter/converter.meta"
     },
     "root": {
         "prototype": "core/meta/module-blueprint",

--- a/core/converter/trim-converter.meta
+++ b/core/converter/trim-converter.meta
@@ -1,15 +1,6 @@
 {
     "converter_blueprint_reference": {
-        "prototype": "core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "Converter",
-                "prototypeName": "Converter",
-                "blueprintModule": {
-                    "%": "core/converter/converter.meta"
-                }
-            }
-        }
+        "object": "core/converter/converter.meta"
     },
     "root": {
         "prototype": "core/meta/module-blueprint",

--- a/core/converter/upper-case-converter.meta
+++ b/core/converter/upper-case-converter.meta
@@ -1,15 +1,6 @@
 {
     "converter_blueprint_reference": {
-        "prototype": "core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "Converter",
-                "prototypeName": "Converter",
-                "blueprintModule": {
-                    "%": "core/converter/converter.meta"
-                }
-            }
-        }
+        "object": "core/converter/converter.meta"
     },
     "root": {
         "prototype": "core/meta/module-blueprint",

--- a/core/meta/association-blueprint.meta
+++ b/core/meta/association-blueprint.meta
@@ -14,16 +14,7 @@
         }
     },
     "property_blueprint_reference": {
-        "prototype": "core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "PropertyBlueprint",
-                "prototypeName": "PropertyBlueprint",
-                "blueprintModule": {
-                    "%": "core/meta/property-blueprint.meta"
-                }
-            }
-        }
+        "object": "core/meta/property-blueprint.meta"
     },
     "root": {
         "prototype": "core/meta/module-blueprint",

--- a/core/meta/derived-descriptor.mjson
+++ b/core/meta/derived-descriptor.mjson
@@ -48,16 +48,7 @@
         }
     },
     "property_descriptor_reference": {
-        "prototype": "core/meta/object-descriptor-reference",
-        "values": {
-            "valueReference": {
-                "objectDescriptorName": "PropertyDescriptor",
-                "prototypeName": "PropertyDescriptor",
-                "objectDescriptorModule": {
-                    "%": "core/meta/property-descriptor.mjson"
-                }
-            }
-        }
+        "object": "core/meta/property-descriptor.mjson"
     },
     "root": {
         "prototype": "core/meta/module-object-descriptor",

--- a/core/meta/event-descriptor.mjson
+++ b/core/meta/event-descriptor.mjson
@@ -1,15 +1,6 @@
 {
     "owner_reference": {
-        "prototype": "core/meta/object-descriptor-reference",
-        "values": {
-            "valueReference": {
-                "objectDescriptorName": "ObjectDescriptor",
-                "prototypeName": "ObjectDescriptor",
-                "objectDescriptorModule": {
-                    "%": "core/meta/object-descriptor.mjson"
-                }
-            }
-        }
+        "object": "core/meta/object-descriptor.mjson"
     },
     "name": {
         "prototype": "core/meta/property-descriptor",

--- a/core/meta/model.mjson
+++ b/core/meta/model.mjson
@@ -1,15 +1,6 @@
 {
     "object_descriptor_reference": {
-        "prototype": "core/meta/object-descriptor-reference",
-        "values": {
-            "valueReference": {
-                "objectDescriptorName": "ObjectDescriptor",
-                "prototypeName": "ObjectDescriptor",
-                "objectDescriptorModule": {
-                    "%": "core/meta/object-descriptor.mjson"
-                }
-            }
-        }
+        "object": "core/meta/object-descriptor"
     },
     "model_objectDescriptors": {
         "prototype": "core/meta/property-descriptor",

--- a/core/meta/object-descriptor.mjson
+++ b/core/meta/object-descriptor.mjson
@@ -1,39 +1,12 @@
 {
     "model_reference": {
-        "prototype": "core/meta/model-reference",
-        "values": {
-            "valueReference": {
-                "objectDescriptorName": "Model",
-                "prototypeName": "Model",
-                "objectDescriptorModule": {
-                    "%": "core/meta/model.mjson"
-                }
-            }
-        }
+        "object": "core/meta/model.mjson"
     },
     "property_descriptor_reference": {
-        "prototype": "core/meta/object-descriptor-reference",
-        "values": {
-            "valueReference": {
-                "objectDescriptorName": "PropertyDescriptor",
-                "prototypeName": "PropertyDescriptor",
-                "objectDescriptorModule": {
-                    "%": "core/meta/property-descriptor.mjson"
-                }
-            }
-        }
+        "object": "core/meta/property-descriptor.mjson"
     },
     "property_validation_rules_reference": {
-        "prototype": "core/meta/object-descriptor-reference",
-        "values": {
-            "valueReference": {
-                "objectDescriptorName": "PropertyValidationRule",
-                "prototypeName": "PropertyValidationRule",
-                "objectDescriptorModule": {
-                    "%": "core/meta/validation-rule.mjson"
-                }
-            }
-        }
+        "object": "core/meta/validation-rule.mjson"
     },
     "name": {
         "prototype": "core/meta/property-descriptor",

--- a/core/meta/property-descriptor.js
+++ b/core/meta/property-descriptor.js
@@ -1,5 +1,5 @@
 var Montage = require("../core").Montage,
-    ObjectDescriptorReference = require("./object-descriptor-reference").ObjectDescriptorReference,
+    Promise = require("../promise").Promise,
     deprecate = require("../deprecate"),
     logger = require("../logger").logger("objectDescriptor");
 
@@ -321,11 +321,17 @@ exports.PropertyDescriptor = Montage.specialize( /** @lends PropertyDescriptor# 
     valueDescriptor: {
         serializable: false,
         get: function () {
-            return this._valueDescriptorReference && this._valueDescriptorReference.promise(this.require);
+            // TODO: Needed for backwards compatibility with ObjectDescriptorReference.
+            // Remove eventually, this can become completely sync
+            if (typeof this._valueDescriptorReference.promise === "function") {
+                deprecate.deprecationWarningOnce("valueDescriptor reference via ObjectDescriptorReference", "direct reference via object syntax");
+                return this._valueDescriptorReference.promise(this.require);
+            } else {
+                return Promise.resolve(this._valueDescriptorReference);
+            }
         },
         set: function (descriptor) {
-
-            this._valueDescriptorReference = new ObjectDescriptorReference().initWithValue(descriptor);
+            this._valueDescriptorReference = descriptor;
         }
     },
 

--- a/core/meta/property-descriptor.mjson
+++ b/core/meta/property-descriptor.mjson
@@ -1,15 +1,6 @@
 {
     "owner_reference": {
-        "prototype": "core/meta/object-descriptor-reference",
-        "values": {
-            "valueReference": {
-                "objectDescriptorName": "ObjectDescriptor",
-                "prototypeName": "ObjectDescriptor",
-                "objectDescriptorModule": {
-                    "%": "core/meta/object-descriptor.mjson"
-                }
-            }
-        }
+        "object": "core/meta/object-descriptor.mjson"
     },
     "property_name": {
         "prototype": "core/meta/property-descriptor",

--- a/core/meta/validation-rule.mjson
+++ b/core/meta/validation-rule.mjson
@@ -1,15 +1,6 @@
 {
     "owner_reference": {
-        "prototype": "core/meta/object-descriptor-reference",
-        "values": {
-            "valueReference": {
-                "objectDescriptorName": "ObjectDescriptor",
-                "prototypeName": "ObjectDescriptor",
-                "objectDescriptorModule": {
-                    "%": "core/meta/object-descriptor.mjson"
-                }
-            }
-        }
+        "object": "core/meta/object-descriptor.mjson"
     },
     "validation_rule_object_descriptor_name": {
         "prototype": "core/meta/property-descriptor",

--- a/test/spec/meta/blueprint-spec.js
+++ b/test/spec/meta/blueprint-spec.js
@@ -19,8 +19,6 @@ var logger = require("montage/core/logger").logger("./blueprint-spec.js");
 // Require to deserialize
 // TODO add proper deps to montage modules
 require('montage/core/meta/object-descriptor');
-require('montage/core/meta/object-descriptor-reference');
-require('montage/core/meta/blueprint-reference');
 require('montage/core/meta/property-blueprint');
 require('montage/core/meta/module-blueprint');
 

--- a/test/spec/meta/blueprint/package/node_modules/dependency/thing.meta
+++ b/test/spec/meta/blueprint/package/node_modules/dependency/thing.meta
@@ -1,13 +1,6 @@
 {
     "blueprint_parent": {
-        "prototype": "montage/core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "Thing",
-                "blueprintModule": {"%": "dependency2/thing.meta"},
-                "prototypeName": "Thing"
-            }
-        }
+        "object": "dependency2/thing.meta"
     },
     "root": {
         "prototype": "montage/core/meta/module-blueprint",

--- a/test/spec/meta/blueprint/package/thing.meta
+++ b/test/spec/meta/blueprint/package/thing.meta
@@ -1,13 +1,6 @@
 {
     "blueprint_parent": {
-        "prototype": "montage/core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "Thing",
-                "blueprintModule": {"%": "dependency/thing.meta"},
-                "prototypeName": "Thing"
-            }
-        }
+        "object": "dependency/thing.meta"
     },
     "root": {
         "prototype": "montage/core/meta/module-blueprint",

--- a/test/spec/meta/controller-blueprint-test/child-controller.meta
+++ b/test/spec/meta/controller-blueprint-test/child-controller.meta
@@ -16,16 +16,7 @@
         }
     },
     "blueprint_parentcontroller_reference": {
-        "prototype": "montage/core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "ParentController",
-                "prototypeName": "ParentController",
-                "blueprintModule": {
-                    "%": "spec/meta/controller-blueprint-test/parent-controller.meta"
-                }
-            }
-        }
+        "object": "spec/meta/controller-blueprint-test/parent-controller.meta"
     },
     "root": {
         "prototype": "montage/core/meta/module-blueprint",

--- a/ui/base/abstract-alert.meta
+++ b/ui/base/abstract-alert.meta
@@ -16,16 +16,7 @@
         }
     },
     "blueprint_parent": {
-        "prototype": "core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "Component",
-                "prototypeName": "Component",
-                "blueprintModule": {
-                    "%": "ui/component.meta"
-                }
-            }
-        }
+        "object": "ui/component.meta"
     },
     "root": {
         "prototype": "core/meta/module-blueprint",

--- a/ui/base/abstract-button.meta
+++ b/ui/base/abstract-button.meta
@@ -40,16 +40,7 @@
         }
     },
     "blueprint_parent": {
-        "prototype": "core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "AbstractControl",
-                "prototypeName": "AbstractControl",
-                "blueprintModule": {
-                    "%": "ui/base/abstract-control.meta"
-                }
-            }
-        }
+        "object": "ui/base/abstract-control.meta"
     },
     "root": {
         "prototype": "core/meta/module-blueprint",

--- a/ui/base/abstract-checkbox.meta
+++ b/ui/base/abstract-checkbox.meta
@@ -40,16 +40,7 @@
         }
     },
     "blueprint_parent": {
-        "prototype": "core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "AbstractControl",
-                "prototypeName": "AbstractControl",
-                "blueprintModule": {
-                    "%": "ui/base/abstract-control.meta"
-                }
-            }
-        }
+        "object": "ui/base/abstract-control.meta"
     },
     "root": {
         "prototype": "core/meta/module-blueprint",

--- a/ui/base/abstract-confirm.meta
+++ b/ui/base/abstract-confirm.meta
@@ -16,16 +16,7 @@
         }
     },
     "blueprint_parent": {
-        "prototype": "core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "AbstractAlert",
-                "prototypeName": "AbstractAlert",
-                "blueprintModule": {
-                    "%": "ui/base/abstract-alert.meta"
-                }
-            }
-        }
+        "object": "ui/base/abstract-alert.meta"
     },
     "root": {
         "prototype": "core/meta/module-blueprint",

--- a/ui/base/abstract-control.meta
+++ b/ui/base/abstract-control.meta
@@ -12,16 +12,7 @@
         }
     },
     "blueprint_parent": {
-        "prototype": "core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "Component",
-                "prototypeName": "Component",
-                "blueprintModule": {
-                    "%": "ui/component.meta"
-                }
-            }
-        }
+        "object": "ui/component.meta"
     },
     "root": {
         "prototype": "core/meta/module-blueprint",

--- a/ui/base/abstract-image.meta
+++ b/ui/base/abstract-image.meta
@@ -46,16 +46,7 @@
         }
     },
     "blueprint_parent": {
-        "prototype": "core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "Component",
-                "prototypeName": "Component",
-                "blueprintModule": {
-                    "%": "ui/component.meta"
-                }
-            }
-        }
+        "object": "ui/component.meta"
     },
     "root": {
         "prototype": "core/meta/module-blueprint",

--- a/ui/base/abstract-link.meta
+++ b/ui/base/abstract-link.meta
@@ -50,16 +50,7 @@
         }
     },
     "blueprint_parent": {
-        "prototype": "core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "AbstractControl",
-                "prototypeName": "AbstractControl",
-                "blueprintModule": {
-                    "%": "ui/base/abstract-control.meta"
-                }
-            }
-        }
+        "object": "ui/base/abstract-control.meta"
     },
     "root": {
         "prototype": "core/meta/module-blueprint",

--- a/ui/base/abstract-number-field.meta
+++ b/ui/base/abstract-number-field.meta
@@ -50,16 +50,7 @@
         }
     },
     "blueprint_parent": {
-        "prototype": "core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "AbstractControl",
-                "prototypeName": "AbstractControl",
-                "blueprintModule": {
-                    "%": "ui/base/abstract-control.meta"
-                }
-            }
-        }
+        "object": "ui/base/abstract-control.meta"
     },
     "root": {
         "prototype": "core/meta/module-blueprint",

--- a/ui/base/abstract-progress-bar.meta
+++ b/ui/base/abstract-progress-bar.meta
@@ -20,16 +20,7 @@
         }
     },
     "blueprint_parent": {
-        "prototype": "core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "AbstractControl",
-                "prototypeName": "AbstractControl",
-                "blueprintModule": {
-                    "%": "ui/base/abstract-control.meta"
-                }
-            }
-        }
+        "object": "ui/base/abstract-control.meta"
     },
     "root": {
         "prototype": "core/meta/module-blueprint",

--- a/ui/base/abstract-radio-button.meta
+++ b/ui/base/abstract-radio-button.meta
@@ -40,16 +40,7 @@
         }
     },
     "blueprint_parent": {
-        "prototype": "core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "AbstractControl",
-                "prototypeName": "AbstractControl",
-                "blueprintModule": {
-                    "%": "ui/base/abstract-control.meta"
-                }
-            }
-        }
+        "object": "ui/base/abstract-control.meta"
     },
     "root": {
         "prototype": "core/meta/module-blueprint",

--- a/ui/base/abstract-select.meta
+++ b/ui/base/abstract-select.meta
@@ -70,16 +70,7 @@
         }
     },
     "blueprint_parent": {
-        "prototype": "core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "AbstractControl",
-                "prototypeName": "AbstractControl",
-                "blueprintModule": {
-                    "%": "ui/base/abstract-control.meta"
-                }
-            }
-        }
+        "object": "ui/base/abstract-control.meta"
     },
     "root": {
         "prototype": "core/meta/module-blueprint",

--- a/ui/base/abstract-slider.meta
+++ b/ui/base/abstract-slider.meta
@@ -65,16 +65,7 @@
         }
     },
     "blueprint_parent": {
-        "prototype": "core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "AbstractControl",
-                "prototypeName": "AbstractControl",
-                "blueprintModule": {
-                    "%": "ui/base/abstract-control.meta"
-                }
-            }
-        }
+        "object": "ui/base/abstract-control.meta"
     },
     "root": {
         "prototype": "core/meta/module-blueprint",

--- a/ui/base/abstract-text-area.meta
+++ b/ui/base/abstract-text-area.meta
@@ -30,16 +30,7 @@
         }
     },
     "blueprint_parent": {
-        "prototype": "core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "Component",
-                "prototypeName": "Component",
-                "blueprintModule": {
-                    "%": "ui/component.meta"
-                }
-            }
-        }
+        "object": "ui/component.meta"
     },
     "root": {
         "prototype": "core/meta/module-blueprint",

--- a/ui/base/abstract-text-field.meta
+++ b/ui/base/abstract-text-field.meta
@@ -30,16 +30,7 @@
         }
     },
     "blueprint_parent": {
-        "prototype": "core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "AbstractControl",
-                "prototypeName": "AbstractControl",
-                "blueprintModule": {
-                    "%": "ui/base/abstract-control.meta"
-                }
-            }
-        }
+        "object": "ui/base/abstract-control.meta"
     },
     "root": {
         "prototype": "core/meta/module-blueprint",

--- a/ui/base/abstract-toggle-button.meta
+++ b/ui/base/abstract-toggle-button.meta
@@ -50,16 +50,7 @@
         }
     },
     "blueprint_parent": {
-        "prototype": "core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "AbstractControl",
-                "prototypeName": "AbstractControl",
-                "blueprintModule": {
-                    "%": "ui/base/abstract-control.meta"
-                }
-            }
-        }
+        "object": "ui/base/abstract-control.meta"
     },
     "root": {
         "prototype": "core/meta/module-blueprint",

--- a/ui/base/abstract-toggle-switch.meta
+++ b/ui/base/abstract-toggle-switch.meta
@@ -10,16 +10,7 @@
         }
     },
     "blueprint_parent": {
-        "prototype": "core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "AbstractControl",
-                "prototypeName": "AbstractControl",
-                "blueprintModule": {
-                    "%": "ui/base/abstract-control.meta"
-                }
-            }
-        }
+        "object": "ui/base/abstract-control.meta"
     },
     "root": {
         "prototype": "core/meta/module-blueprint",

--- a/ui/base/abstract-video.meta
+++ b/ui/base/abstract-video.meta
@@ -65,14 +65,7 @@
         }
     },
     "blueprint_parent": {
-        "prototype": "core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "Component",
-                "blueprintModuleId": "ui/component.meta",
-                "prototypeName": "Component"
-            }
-        }
+        "object": "ui/component.meta"
     },
     "root": {
         "prototype": "core/meta/blueprint",

--- a/ui/button.reel/button.meta
+++ b/ui/button.reel/button.meta
@@ -142,16 +142,7 @@
         }
     },
     "blueprint_control_reference": {
-        "prototype": "core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "Control",
-                "prototypeName": "Control",
-                "blueprintModule": {
-                    "%": "ui/control.meta"
-                }
-            }
-        }
+        "object": "ui/control.meta"
     },
     "root": {
         "prototype": "core/meta/module-blueprint",

--- a/ui/checkbox.reel/checkbox.meta
+++ b/ui/checkbox.reel/checkbox.meta
@@ -10,16 +10,7 @@
         }
     },
     "blueprint_parent": {
-        "prototype": "core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "Control",
-                "prototypeName": "Control",
-                "blueprintModule": {
-                    "%": "ui/control.meta"
-                }
-            }
-        }
+        "object": "ui/control.meta"
     },
     "root": {
         "prototype": "core/meta/module-blueprint",

--- a/ui/condition.reel/condition.meta
+++ b/ui/condition.reel/condition.meta
@@ -25,16 +25,7 @@
         }
     },
     "blueprint_component_reference": {
-        "prototype": "core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "Component",
-                "prototypeName": "Component",
-                "blueprintModule": {
-                    "%": "ui/component.meta"
-                }
-            }
-        }
+        "object": "ui/component.meta"
     },
     "root": {
         "prototype": "core/meta/module-blueprint",

--- a/ui/control.meta
+++ b/ui/control.meta
@@ -106,16 +106,7 @@
         }
     },
     "blueprint_component_reference": {
-        "prototype": "core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "Component",
-                "prototypeName": "Component",
-                "blueprintModule": {
-                    "%": "ui/component.meta"
-                }
-            }
-        }
+        "object": "ui/component.meta"
     },
     "root": {
         "prototype": "core/meta/module-blueprint",

--- a/ui/flow.reel/flow.meta
+++ b/ui/flow.reel/flow.meta
@@ -113,16 +113,7 @@
         }
     },
     "blueprint_component_reference": {
-        "prototype": "core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "Component",
-                "prototypeName": "Component",
-                "blueprintModule": {
-                    "%": "ui/component.meta"
-                }
-            }
-        }
+        "object": "ui/component.meta"
     },
     "root": {
         "prototype": "core/meta/module-blueprint",

--- a/ui/label.reel/label.meta
+++ b/ui/label.reel/label.meta
@@ -23,28 +23,10 @@
         }
     },
     "component_reference": {
-        "prototype": "core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "Component",
-                "prototypeName": "Component",
-                "blueprintModule": {
-                    "%": "ui/component.meta"
-                }
-            }
-        }
+        "object": "ui/component.meta"
     },
     "text_reference": {
-        "prototype": "core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "Text",
-                "prototypeName": "Text",
-                "blueprintModule": {
-                    "%": "ui/text.reel/text.meta"
-                }
-            }
-        }
+        "object": "ui/text.reel/text.meta"
     },
     "root": {
         "prototype": "core/meta/module-blueprint",

--- a/ui/loader.reel/loader.meta
+++ b/ui/loader.reel/loader.meta
@@ -90,16 +90,7 @@
         }
     },
     "blueprint_component_reference": {
-        "prototype": "core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "Component",
-                "prototypeName": "Component",
-                "blueprintModule": {
-                    "%": "ui/component.meta"
-                }
-            }
-        }
+        "object": "ui/component.meta"
     },
     "root": {
         "prototype": "core/meta/module-blueprint",

--- a/ui/modal-overlay.reel/modal-overlay.meta
+++ b/ui/modal-overlay.reel/modal-overlay.meta
@@ -1,15 +1,6 @@
 {
     "blueprint_component_reference": {
-        "prototype": "core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "Overlay",
-                "prototypeName": "Overlay",
-                "blueprintModule": {
-                    "%": "ui/overlay.reel/overlay.meta"
-                }
-            }
-        }
+        "object": "ui/overlay.reel/overlay.meta"
     },
     "root": {
         "prototype": "core/meta/module-blueprint",

--- a/ui/overlay.reel/overlay.meta
+++ b/ui/overlay.reel/overlay.meta
@@ -40,16 +40,7 @@
         }
     },
     "blueprint_component_reference": {
-        "prototype": "core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "Component",
-                "prototypeName": "Component",
-                "blueprintModule": {
-                    "%": "ui/component.meta"
-                }
-            }
-        }
+        "object": "ui/component.meta"
     },
     "root": {
         "prototype": "core/meta/module-blueprint",

--- a/ui/repetition.reel/repetition.meta
+++ b/ui/repetition.reel/repetition.meta
@@ -62,16 +62,7 @@
         }
     },
     "blueprint_component_reference": {
-        "prototype": "core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "Component",
-                "prototypeName": "Component",
-                "blueprintModule": {
-                    "%": "ui/component.meta"
-                }
-            }
-        }
+        "object": "ui/component.meta"
     },
     "root": {
         "prototype": "core/meta/module-blueprint",

--- a/ui/slider.reel/slider.meta
+++ b/ui/slider.reel/slider.meta
@@ -64,16 +64,7 @@
         }
     },
     "blueprint_parent": {
-        "prototype": "core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "Control",
-                "prototypeName": "Control",
-                "blueprintModule": {
-                    "%": "ui/control.meta"
-                }
-            }
-        }
+        "object": "ui/control.meta"
     },
     "root": {
         "prototype": "core/meta/module-blueprint",

--- a/ui/slot.reel/slot.meta
+++ b/ui/slot.reel/slot.meta
@@ -20,16 +20,7 @@
         }
     },
     "blueprint_component_reference": {
-        "prototype": "core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "Component",
-                "prototypeName": "Component",
-                "blueprintModule": {
-                    "%": "ui/component.meta"
-                }
-            }
-        }
+        "object": "ui/component.meta"
     },
     "root": {
         "prototype": "core/meta/module-blueprint",

--- a/ui/substitution.reel/substitution.meta
+++ b/ui/substitution.reel/substitution.meta
@@ -29,16 +29,7 @@
         }
     },
     "blueprint_component_reference": {
-        "prototype": "core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "Component",
-                "prototypeName": "Component",
-                "blueprintModule": {
-                    "%": "ui/component.meta"
-                }
-            }
-        }
+        "object": "ui/component.meta"
     },
     "root": {
         "prototype": "core/meta/module-blueprint",

--- a/ui/text-field.reel/text-field.meta
+++ b/ui/text-field.reel/text-field.meta
@@ -26,16 +26,7 @@
         }
     },
     "blueprint_control_reference": {
-        "prototype": "core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "Control",
-                "prototypeName": "Control",
-                "blueprintModule": {
-                    "%": "ui/control.meta"
-                }
-            }
-        }
+        "object": "ui/control.meta"
     },
     "root": {
         "prototype": "core/meta/module-blueprint",

--- a/ui/text.reel/text.meta
+++ b/ui/text.reel/text.meta
@@ -25,28 +25,10 @@
         }
     },
     "blueprint_converter_reference": {
-        "prototype": "core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "Converter",
-                "prototypeName": "Converter",
-                "blueprintModule": {
-                    "%": "core/converter/converter.meta"
-                }
-            }
-        }
+        "object": "core/converter/converter.meta"
     },
     "blueprint_component_reference": {
-        "prototype": "core/meta/blueprint-reference",
-        "values": {
-            "valueReference": {
-                "blueprintName": "Component",
-                "prototypeName": "Component",
-                "blueprintModule": {
-                    "%": "ui/component.meta"
-                }
-            }
-        }
+        "object": "ui/component.meta"
     },
     "root": {
         "prototype": "core/meta/module-blueprint",


### PR DESCRIPTION
Fixes #1832. Depends on #1840.

The goal here is to use the new {"object": "xxx.mjson"} serialization syntax courtesy of @thibaultzanini to stop using meta reference objects (ObjectDescriptorReference, ModuleDescriptorReference etc.), which are the primary cause for circular references.