### PR TITLE
Support .mjson circular referencing

### DIFF
--- a/core/serialization/deserializer/montage-deserializer.js
+++ b/core/serialization/deserializer/montage-deserializer.js
@@ -27,22 +27,22 @@ var MontageDeserializer = exports.MontageDeserializer = Montage.specialize({
     },
 
     init: {
-        value: function (serializationString, _require, objectRequires, locationId, deserializedModules) {
+        value: function (serializationString, _require, objectRequires, locationId, moduleContexts) {
             this._serializationString = serializationString;
-            deserializedModules = deserializedModules || new Map();
+            moduleContexts = moduleContexts || new Map();
             this._interpreter = new MontageInterpreter().init(_require,
-                new MontageReviver().init(_require, objectRequires, locationId, deserializedModules));
+                new MontageReviver().init(_require, objectRequires, locationId, moduleContexts));
 
             return this;
         }
     },
 
     initWithObject: {
-        value: function (serialization, _require, objectRequires, locationId, deserializedModules) {
+        value: function (serialization, _require, objectRequires, locationId, moduleContexts) {
             this._serializationString = JSON.stringify(serialization);
-            deserializedModules = deserializedModules || new Map();
+            moduleContexts = moduleContexts || new Map();
             this._interpreter = new MontageInterpreter().init(_require,
-                new MontageReviver().init(_require, objectRequires, locationId, deserializedModules));
+                new MontageReviver().init(_require, objectRequires, locationId, moduleContexts));
 
             return this;
         }

--- a/core/serialization/deserializer/montage-deserializer.js
+++ b/core/serialization/deserializer/montage-deserializer.js
@@ -1,6 +1,7 @@
 var Montage = require("../../core").Montage,
     MontageInterpreter = require("./montage-interpreter").MontageInterpreter,
     MontageReviver = require("./montage-reviver").MontageReviver,
+    Map = require("collections/map").Map,
     deprecate = require("../../deprecate");
 
 var MontageDeserializer = exports.MontageDeserializer = Montage.specialize({
@@ -26,18 +27,23 @@ var MontageDeserializer = exports.MontageDeserializer = Montage.specialize({
     },
 
     init: {
-        value: function (serializationString, _require, objectRequires) {
+        value: function (serializationString, _require, objectRequires, locationId, deserializedModules) {
             this._serializationString = serializationString;
-            this._interpreter = new MontageInterpreter().init(_require, objectRequires);
+            deserializedModules = deserializedModules || new Map();
+            this._interpreter = new MontageInterpreter().init(_require,
+                new MontageReviver().init(_require, objectRequires, locationId, deserializedModules));
 
             return this;
         }
     },
 
     initWithObject: {
-        value: function (serialization, _require, objectRequires) {
+        value: function (serialization, _require, objectRequires, locationId, deserializedModules) {
             this._serializationString = JSON.stringify(serialization);
-            this._interpreter = new MontageInterpreter().init(_require, objectRequires);
+            deserializedModules = deserializedModules || new Map();
+            this._interpreter = new MontageInterpreter().init(_require,
+                new MontageReviver().init(_require, objectRequires, locationId, deserializedModules));
+
             return this;
         }
     },

--- a/core/serialization/deserializer/montage-interpreter.js
+++ b/core/serialization/deserializer/montage-interpreter.js
@@ -10,13 +10,12 @@ var MontageInterpreter = Montage.specialize({
     _reviver: {value: null},
 
     init: {
-        value: function (_require, objectRequires) {
+        value: function (_require, reviver) {
             if (typeof _require !== "function") {
                 throw new Error("Function 'require' missing.");
             }
 
-            this._reviver = new MontageReviver()
-                .init(_require, objectRequires);
+            this._reviver = reviver;
             this._require = _require;
 
             return this;

--- a/test/spec/serialization/circular/a.mjson
+++ b/test/spec/serialization/circular/a.mjson
@@ -1,0 +1,13 @@
+{
+    "b": {
+        "object": "spec/serialization/circular/b.mjson"
+    },
+
+    "root": {
+        "prototype": "montage",
+        "values": {
+            "bRef": {"@": "b"},
+            "myAProp": "foo"
+        }
+    }
+}

--- a/test/spec/serialization/circular/b.mjson
+++ b/test/spec/serialization/circular/b.mjson
@@ -1,0 +1,13 @@
+{
+    "a": {
+        "object": "spec/serialization/circular/a.mjson"
+    },
+
+    "root": {
+        "prototype": "montage",
+        "values": {
+            "aRef": {"@": "a"},
+            "myBProp": "bar"
+        }
+    }
+}

--- a/test/spec/serialization/interpreter-spec.js
+++ b/test/spec/serialization/interpreter-spec.js
@@ -1,11 +1,12 @@
-var Interpreter = require("montage/core/serialization/deserializer/montage-interpreter").MontageInterpreter;
+var Interpreter = require("montage/core/serialization/deserializer/montage-interpreter").MontageInterpreter,
+    Reviver = require("montage/core/serialization/deserializer/montage-reviver").MontageReviver;
 
 
 describe("interpreter", function() {
     var interpreter;
 
     beforeEach(function() {
-        interpreter = new Interpreter().init(require);
+        interpreter = new Interpreter().init(require, new Reviver().init(require));
     });
 
     describe("native values with labels", function() {

--- a/test/spec/serialization/montage-deserializer-spec.js
+++ b/test/spec/serialization/montage-deserializer-spec.js
@@ -1361,4 +1361,22 @@ describe("serialization/montage-deserializer-spec", function () {
             })
         });
     });
+
+    it("handles circular references", function (done) {
+        var serialization = {
+            "root": {
+                "object": "spec/serialization/circular/a.mjson"
+            }
+        };
+        var deserializer = new Deserializer().init(JSON.stringify(serialization), require);
+        deserializer.deserializeObject()
+            .then(function (result) {
+                expect(result.bRef.myBProp).toBe("bar");
+                expect(result.bRef.aRef).toBe(result);
+            }).catch(function (err) {
+                fail(err);
+            }).finally(function () {
+                done();
+            });
+    });
 });

--- a/test/spec/serialization/reviver-spec.js
+++ b/test/spec/serialization/reviver-spec.js
@@ -130,7 +130,7 @@ describe("reviver", function() {
         var interpreter;
 
         beforeEach(function() {
-            interpreter = new Interpreter().init(require);
+            interpreter = new Interpreter().init(require, new Reviver().init(require));
         });
         afterEach(function() {
             Reviver.resetCustomObjectRevivers();


### PR DESCRIPTION
Allows circular references between separate .mjson modules. Modifies the Deserializer so that it caches objects it deserializes and prevents any sub-deserializers that it spawns from re-deserializing an object.

This is necessary to be able to remove all of our meta reference objects and use the "object": "..." syntax instead.

Also affords some visibility into circular referencing. If we wanted to disallow inter-module circular referencing we would do that here: https://github.com/montagejs/montage/pull/1840/files#diff-1a82e587bb20d5de4f38d99b98fc5e91R310.

This isn't as clean of a solution as I would like, due to the fact that our current deserialization process is strictly single-phased and the Deserializer is a closed system that creates other deserializers of its own volition. I think a better design would be to have the Deserializer spawn a series of `SerializationCompiler`s that revive objects without resolving references, and then a `SerializationLinker` that takes all the compilers and resolves references between them. I'll work on a proposal for this once I have time.