### PR TITLE
Remove logging & optimize PipelineConverter

### DIFF
--- a/core/converter/pipeline-converter.js
+++ b/core/converter/pipeline-converter.js
@@ -33,27 +33,37 @@ exports.PipelineConverter = Converter.specialize({
 
     convert: {
         value: function (value) {
-            return this._convertWithNextConverter(value, this.converters.slice());
+            return this._convertWithNextConverter(value, 0);
         }
     },
 
     _convertWithNextConverter: {
-        value: function (input, converters) {
+        value: function (input, index) {
             var self = this,
-                converter = converters.shift(),
+                converter = this.converters[index],
                 output = converter.convert(input),
-                isFinalOutput = converters.length === 0,
+                isFinalOutput = index === (this.converters.length - 1),
                 isPromise = this._isThenable(output),
                 result;
+
+            index++;
+
+
 
             if (isFinalOutput) {
                 result = isPromise ? output : Promise.resolve(output);
             } else if (isPromise) {
+                if (this.converters[0].isRolesConverter) {
+                    debugger;
+                }
                 result = output.then(function (value) {
-                    return self._convertWithNextConverter(value, converters);
+                    if (self.converters[0].isRolesConverter) {
+                        debugger;
+                    }
+                    return self._convertWithNextConverter(value, index);
                 });
             } else {
-                result = this._convertWithNextConverter(output, converters);
+                result = this._convertWithNextConverter(output, index);
             }
 
             return result;
@@ -69,27 +79,29 @@ exports.PipelineConverter = Converter.specialize({
 
     revert: {
         value: function (value) {
-            return this._revertWithNextConverter(value, this.converters.slice());
+            return this._revertWithNextConverter(value, this.converters.length - 1);
         }
     },
 
     _revertWithNextConverter: {
-        value: function (input, converters) {
+        value: function (input, index) {
             var self = this,
-                converter = converters.pop(),
+                converter = this.converters[index],
                 output = converter.revert(input),
-                isFinalOutput = converters.length === 0,
+                isFinalOutput = index === 0,
                 isPromise = this._isThenable(output),
                 result;
+
+            index--;
 
             if (isFinalOutput) {
                 result = isPromise ? output : Promise.resolve(output);
             } else if (isPromise) {
                 result = output.then(function (value) {
-                    return self._revertWithNextConverter(value, converters);
+                    return self._revertWithNextConverter(value, index);
                 });
             } else {
-                result = this._revertWithNextConverter(output, converters);
+                result = this._revertWithNextConverter(output, index);
             }
 
             return result;

--- a/core/converter/pipeline-converter.js
+++ b/core/converter/pipeline-converter.js
@@ -33,11 +33,11 @@ exports.PipelineConverter = Converter.specialize({
 
     convert: {
         value: function (value) {
-            return this._convertWithNextConverter(value, 0);
+            return this._convertWithConverterAtIndex(value, 0);
         }
     },
 
-    _convertWithNextConverter: {
+    _convertWithConverterAtIndex: {
         value: function (input, index) {
             var self = this,
                 converter = this.converters[index],
@@ -53,17 +53,11 @@ exports.PipelineConverter = Converter.specialize({
             if (isFinalOutput) {
                 result = isPromise ? output : Promise.resolve(output);
             } else if (isPromise) {
-                if (this.converters[0].isRolesConverter) {
-                    debugger;
-                }
                 result = output.then(function (value) {
-                    if (self.converters[0].isRolesConverter) {
-                        debugger;
-                    }
-                    return self._convertWithNextConverter(value, index);
+                    return self._convertWithConverterAtIndex(value, index);
                 });
             } else {
-                result = this._convertWithNextConverter(output, index);
+                result = this._convertWithConverterAtIndex(output, index);
             }
 
             return result;
@@ -79,11 +73,11 @@ exports.PipelineConverter = Converter.specialize({
 
     revert: {
         value: function (value) {
-            return this._revertWithNextConverter(value, this.converters.length - 1);
+            return this._revertWithConverterAtIndex(value, this.converters.length - 1);
         }
     },
 
-    _revertWithNextConverter: {
+    _revertWithConverterAtIndex: {
         value: function (input, index) {
             var self = this,
                 converter = this.converters[index],
@@ -98,10 +92,10 @@ exports.PipelineConverter = Converter.specialize({
                 result = isPromise ? output : Promise.resolve(output);
             } else if (isPromise) {
                 result = output.then(function (value) {
-                    return self._revertWithNextConverter(value, index);
+                    return self._revertWithConverterAtIndex(value, index);
                 });
             } else {
-                result = this._revertWithNextConverter(output, index);
+                result = this._revertWithConverterAtIndex(output, index);
             }
 
             return result;

--- a/core/meta/model.js
+++ b/core/meta/model.js
@@ -367,7 +367,6 @@ var Model = exports.Model = Montage.specialize( /** @lends Model.prototype # */ 
             if (_group === null) {
                 _group = new ModelGroup();
                 _group.name = application ? application.name : "";
-                console.log("Default ModelGroup name is ",_group.name);
             }
             return _group;
         }


### PR DESCRIPTION
- Remove logging pushed by mistake

- Refactor PipelineConverter to use a pointer instead of array.slice()