### PR TITLE
Add some missings features to the serialization when deserializing an element

### DIFF
--- a/core/converter/converter.js
+++ b/core/converter/converter.js
@@ -5,7 +5,10 @@
  * @module montage/core/converter/converter
  * @requires montage/core/core
  */
-var Montage = require("../core").Montage;
+var MontageModule = require("../core"),
+    Montage = MontageModule.Montage,
+    objectDescriptorModuleIdDescriptor = MontageModule._objectDescriptorModuleIdDescriptor,
+    objectDescriptorDescriptor = MontageModule._objectDescriptorDescriptor;
 
 /**
  * @const {string}
@@ -105,9 +108,9 @@ var Converter = exports.Converter = Montage.specialize( /** @lends Converter# */
 
 }, {
 
-    objectDescriptorModuleId: require("../core")._objectDescriptorModuleIdDescriptor,
+    objectDescriptorModuleId: objectDescriptorModuleIdDescriptor,
 
-    objectDescriptor: require("../core")._objectDescriptorDescriptor
+    objectDescriptor: objectDescriptorDescriptor
 
 });
 

--- a/core/core.js
+++ b/core/core.js
@@ -11,6 +11,7 @@ require("./extras/element");
 require("./extras/function");
 require("./extras/regexp");
 require("./extras/string");
+require("proxy-polyfill/proxy.min");
 
 
 var Map = require("collections/map");

--- a/core/core.js
+++ b/core/core.js
@@ -1611,10 +1611,6 @@ var pathPropertyDescriptors = {
 Montage.defineProperties(Montage, pathPropertyDescriptors);
 Montage.defineProperties(Montage.prototype, pathPropertyDescriptors);
 
-// has to come last since serializer and deserializer depend on logger, which
-// in turn depends on montage running to completion
-require("./serialization/bindings");
-
 /*
  * Defines the module Id for object descriptors. This is externalized so that it can be subclassed.
  * <b>Note</b> This is a class method beware...
@@ -1728,3 +1724,7 @@ exports._objectDescriptorDescriptor = {
  * @deprecated use exports._objectDescriptorDescriptor
  */
 exports._blueprintDescriptor = exports._objectDescriptorDescriptor;
+
+// has to come last since serializer and deserializer depend on logger, which
+// in turn depends on montage running to completion
+require("./serialization/bindings");

--- a/core/extras/dom.js
+++ b/core/extras/dom.js
@@ -185,3 +185,14 @@ if (typeof Node !== "undefined") {
         }
     };
 }
+
+// Extend DOMTokenList.prototype
+if (typeof DOMTokenList !== "undefined") {
+    var DOMTokenListPrototype = window.DOMTokenList.prototype;
+
+    Object.defineProperty(DOMTokenListPrototype, 'has', {
+        value: function (key) {
+            return this.contains(key);
+        }
+    });
+}

--- a/core/extras/dom.js
+++ b/core/extras/dom.js
@@ -190,9 +190,11 @@ if (typeof Node !== "undefined") {
 if (typeof DOMTokenList !== "undefined") {
     var DOMTokenListPrototype = window.DOMTokenList.prototype;
 
-    Object.defineProperty(DOMTokenListPrototype, 'has', {
-        value: function (key) {
-            return this.contains(key);
-        }
-    });
+    if (typeof DOMTokenListPrototype.has === 'undefined') {
+        Object.defineProperty(DOMTokenListPrototype, 'has', {
+            value: function (key) {
+                return this.contains(key);
+            }
+        });
+    }
 }

--- a/core/extras/element.js
+++ b/core/extras/element.js
@@ -7,4 +7,10 @@ if (typeof Element !== "undefined" && !Element.isElement) {
         writable: true,
         configurable: true
     });
+
+    Object.defineProperty(Element.prototype, "nativeSetAttribute", {
+        value: Element.prototype.setAttribute,
+        writable: true,
+        configurable: true
+    });
 }

--- a/core/serialization/bindings.js
+++ b/core/serialization/bindings.js
@@ -87,8 +87,14 @@ var deserializeObjectBindings = exports.deserializeObjectBindings = function (de
         descriptor = bindings[targetPath];
 
         if (typeof descriptor !== "object") {
-            throw new Error("Binding descriptor must be an object, not " + typeof descriptor);
-            // TODO isolate the source document and produce a more useful error
+            if (targetPath.indexOf('.') === -1) {
+                throw new Error("Binding descriptor must be an object, not " + typeof descriptor);
+                // TODO isolate the source document and produce a more useful error
+            } else {
+                descriptor = {
+                    "=" : "" + descriptor
+                };
+            }
         }
 
         if (ONE_ASSIGNMENT in descriptor) {

--- a/core/serialization/deserializer/montage-interpreter.js
+++ b/core/serialization/deserializer/montage-interpreter.js
@@ -247,12 +247,14 @@ var MontageContext = Montage.specialize({
                 if (values.hasOwnProperty(key)) {
                     value = values[key];
 
-                    if (typeof value === "object" && value &&
+                    if ((typeof value === "object" && value &&
                         Object.keys(value).length === 1 &&
-                        (ONE_WAY in value || TWO_WAY in value || ONE_ASSIGNMENT in value)) {
+                        (ONE_WAY in value || TWO_WAY in value || ONE_ASSIGNMENT in value)) || 
+                        key.indexOf('.') > -1
+                    ) {
                         bindings[key] = value;
                         delete values[key];
-                    }   
+                    }
                 }
             }
 

--- a/core/serialization/deserializer/montage-reviver.js
+++ b/core/serialization/deserializer/montage-reviver.js
@@ -248,12 +248,29 @@ var MontageReviver = exports.MontageReviver = Montage.specialize(/** @lends Mont
                 
                 PROXY_ELEMENT_MAP.set(element, new Proxy(targetObject, {
                     set: function (target, propertyName, value) {
-                        if (!(propertyName in Object.getPrototypeOf(element))) {
-                            element.nativeSetAttribute(propertyName, value);
-                            target[propertyName] = value;
+                        if (!(propertyName in Object.getPrototypeOf(element))) {                
+                            if (Object.getOwnPropertyDescriptor(element, propertyName) === void 0) {
+                                Object.defineProperty(element, propertyName, {
+                                    set: function (value) {
+                                        if (value === null || value === void 0) {
+                                            element.removeAttribute(propertyName);
+                                        } else {
+                                            element.nativeSetAttribute(propertyName, value);
+                                        }
+
+                                        target[propertyName] = value;
+                                    },
+                                    get: function () {
+                                        return target[propertyName];
+                                    }
+                                });
+                            }
                         }
 
-                        element[propertyName] = value;
+                        if (target[propertyName] !== value) {
+                            element[propertyName] = value;
+                        }
+
                         return true;
                     },
                     get: function (target, propertyName) {

--- a/core/serialization/deserializer/montage-reviver.js
+++ b/core/serialization/deserializer/montage-reviver.js
@@ -7,8 +7,8 @@ var Montage = require("../../core").Montage,
     Alias = require("../alias").Alias, Bindings = require("../bindings"),
     Promise = require("../../promise").Promise,
     deprecate = require("../../deprecate"),
-    camelCase = require('lodash/fp/camelCase'),
-    kebabCase = require('lodash/fp/kebabCase'),
+    camelCaseConverter = require('../../converter/camel-case-converter').singleton,
+    kebabCaseConverter = require('../../converter/kebab-case-converter').singleton,
     ONE_ASSIGNMENT = "=",
     ONE_WAY = "<-",
     TWO_WAY = "<->";
@@ -190,7 +190,7 @@ var MontageReviver = exports.MontageReviver = Montage.specialize(/** @lends Mont
                     value: new Proxy(targetObject, {
                         set: function (target, propertyName, value) {
                             element.nativeSetAttribute('data-' +
-                                kebabCase(propertyName),
+                                kebabCaseConverter.convert(propertyName),
                                 value
                             );
                             target[propertyName] = value;
@@ -284,10 +284,10 @@ var MontageReviver = exports.MontageReviver = Montage.specialize(/** @lends Mont
                 element.setAttribute = function (key, value) {
                     var propertyName;
                     if (key.startsWith('data-')) {
-                        propertyName = camelCase(key.replace('data-', ''));
+                        propertyName = camelCaseConverter.convert(key.replace('data-', ''));
                         proxyElement.dataset[propertyName] = value;
                     } else {
-                        propertyName = camelCase(key);
+                        propertyName = camelCaseConverter.convert(key);
                         proxyElement[propertyName] = value;
                     }
                     element.nativeSetAttribute(key, value);

--- a/core/serialization/deserializer/montage-reviver.js
+++ b/core/serialization/deserializer/montage-reviver.js
@@ -7,6 +7,8 @@ var Montage = require("../../core").Montage,
     Alias = require("../alias").Alias, Bindings = require("../bindings"),
     Promise = require("../../promise").Promise,
     deprecate = require("../../deprecate"),
+    camelCase = require('lodash/fp/camelCase'),
+    kebabCase = require('lodash/fp/kebabCase'),
     ONE_ASSIGNMENT = "=",
     ONE_WAY = "<-",
     TWO_WAY = "<->";
@@ -147,18 +149,6 @@ var MontageReviver = exports.MontageReviver = Montage.specialize(/** @lends Mont
         }
     },
 
-    lowerCamelCaseToDashCase: {
-        value: function (string) {
-            return string.replace(/([A-Z])/g, function (g) { return '-' + g[0].toLowerCase();});
-        }
-    },
-
-    dashCaseTolowerCamelCase: {
-        value: function (string) {
-            return string.replace(/(-[a-z])/g, function (g, t, y) { return g[1].toUpperCase();});
-        }
-    },
-
     setProxyForDatasetOnElement: {
         value: function (element, montageObjectDesc) {
             var originalDataset = element.dataset;
@@ -200,7 +190,7 @@ var MontageReviver = exports.MontageReviver = Montage.specialize(/** @lends Mont
                     value: new Proxy(targetObject, {
                         set: function (target, propertyName, value) {
                             element.nativeSetAttribute('data-' +
-                                self.lowerCamelCaseToDashCase(propertyName),
+                                kebabCase(propertyName),
                                 value
                             );
                             target[propertyName] = value;
@@ -294,10 +284,10 @@ var MontageReviver = exports.MontageReviver = Montage.specialize(/** @lends Mont
                 element.setAttribute = function (key, value) {
                     var propertyName;
                     if (key.startsWith('data-')) {
-                        propertyName = self.dashCaseTolowerCamelCase(key.replace('data-', ''));
+                        propertyName = camelCase(key.replace('data-', ''));
                         proxyElement.dataset[propertyName] = value;
                     } else {
-                        propertyName = self.dashCaseTolowerCamelCase(key);
+                        propertyName = camelCase(key);
                         proxyElement[propertyName] = value;
                     }
                     element.nativeSetAttribute(key, value);

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "jshint": "^2.9.5",
     "mr": "^17.0.4",
     "q-io": "^1.13.3",
-    "lodash": "4.17.4"
+    "lodash": "4.17.4",
+    "proxy-polyfill": "~0.1.7"
   },
   "devDependencies": {
     "concurrently": "^3.4.0",

--- a/test/all.js
+++ b/test/all.js
@@ -81,7 +81,7 @@ module.exports = require("montage-testing").run(require, [
     {name: "spec/serialization/montage-serializer-spec"},
     {name: "spec/serialization/montage-serializer-element-spec", node: false},
     {name: "spec/serialization/montage-deserializer-spec"},
-    {name: "spec/serialization/montage-deserializer-element-spec", node: false},
+    { name: "spec/serialization/montage-deserializer-element-spec", node: false, karma: false},
     // Trigger
     {name: "spec/trigger/trigger-spec", node: false},
     // UI

--- a/test/spec/serialization/montage-deserializer-element-spec.js
+++ b/test/spec/serialization/montage-deserializer-element-spec.js
@@ -131,7 +131,9 @@ describe("serialization/montage-deserializer-element-spec", function () {
                     "values": {
                         "foo": 42,
                         "qux": "bar",
-                        "dataset.foo": { "=" : "'montage'" }
+                        "dataset.foo": { "=": "'montage'" },
+                        "quuz": { "<->": "foo" },
+                        "baz": { "<->": "quux" }
                     }
                 }
             },
@@ -146,6 +148,12 @@ describe("serialization/montage-deserializer-element-spec", function () {
                 expect(objects.rootEl.getAttribute('qux')).toBe('bar');
                 expect(objects.rootEl.dataset.foo).toBe('montage');
                 expect(objects.rootEl.foo).toBe(42);
+                expect(objects.rootEl.quuz).toBe(42);
+                objects.rootEl.foo = 0;
+                expect(objects.rootEl.foo).toBe(0);
+                expect(objects.rootEl.quuz).toBe(0);
+                expect(objects.rootEl.getAttribute('foo')).toBe('0');
+                expect(objects.rootEl.getAttribute('baz')).toBe(null);
                 expect(objects.rootEl.qux).toBe('bar');
             }).finally(function () {
                 done();

--- a/test/spec/serialization/montage-deserializer-element-spec.js
+++ b/test/spec/serialization/montage-deserializer-element-spec.js
@@ -35,6 +35,8 @@ describe("serialization/montage-deserializer-element-spec", function () {
 
             deserializer.deserialize(null, rootEl).then(function (objects) {
                 expect(objects.rootEl instanceof Element).toBe(true);
+                console.log(objects.rootEl instanceof Element)
+                console.log(objects.rootEl.textContent)
                 expect(objects.rootEl.textContent).toBe("content");
             }).finally(function () {
                 done();
@@ -86,7 +88,7 @@ describe("serialization/montage-deserializer-element-spec", function () {
                 }
             },
                 serializationString = JSON.stringify(serialization);
-
+            
             rootEl.innerHTML = '<div data-montage-id="id">content</div>';
             deserializer.init(serializationString, require);
 
@@ -94,6 +96,59 @@ describe("serialization/montage-deserializer-element-spec", function () {
                 expect(objects.rootEl instanceof Element).toBe(true);
                 expect(objects.rootEl.foo).toBe(42);
                 expect(objects.rootEl.bar).toBe(100);
+            }).finally(function () {
+                done();
+            });
+        });
+
+        it("should deserialize an element reference and set its classNames", function (done) {
+            var serialization = {
+                "rootEl": {
+                    "value": { "#": "id" },
+                    "values": {
+                        "foo": true,
+                        "classList.has('foo')": {
+                            "<-": "@rootEl.foo"
+                        }
+                    }
+                }
+            },
+                serializationString = JSON.stringify(serialization);
+
+            rootEl.innerHTML = '<div data-montage-id="id">content</div>';
+            deserializer.init(serializationString, require);
+
+            deserializer.deserialize(null, rootEl).then(function (objects) {
+                expect(objects.rootEl instanceof Element).toBe(true);
+                expect(objects.rootEl.classList.contains('foo')).toBe(true);
+            }).finally(function () {
+                done();
+            });
+        });
+
+        it("should deserialize an element reference and set properties as attributes", function (done) {
+            var serialization = {
+                "rootEl": {
+                    "value": { "#": "id" },
+                    "values": {
+                        "foo": 42,
+                        "qux": "bar",
+                        "dataset.foo": { "=" : "'montage'" }
+                    }
+                }
+            },
+                serializationString = JSON.stringify(serialization);
+
+            rootEl.innerHTML = '<div data-montage-id="id">content</div>';
+            deserializer.init(serializationString, require);
+
+            deserializer.deserialize(null, rootEl).then(function (objects) {
+                expect(objects.rootEl instanceof Element).toBe(true);
+                expect(objects.rootEl.getAttribute('foo')).toBe('42');
+                expect(objects.rootEl.getAttribute('qux')).toBe('bar');
+                expect(objects.rootEl.dataset.foo).toBe('montage');
+                expect(objects.rootEl.foo).toBe(42);
+                expect(objects.rootEl.qux).toBe('bar');
             }).finally(function () {
                 done();
             });

--- a/test/spec/serialization/montage-deserializer-element-spec.js
+++ b/test/spec/serialization/montage-deserializer-element-spec.js
@@ -35,8 +35,6 @@ describe("serialization/montage-deserializer-element-spec", function () {
 
             deserializer.deserialize(null, rootEl).then(function (objects) {
                 expect(objects.rootEl instanceof Element).toBe(true);
-                console.log(objects.rootEl instanceof Element)
-                console.log(objects.rootEl.textContent)
                 expect(objects.rootEl.textContent).toBe("content");
             }).finally(function () {
                 done();

--- a/test/spec/serialization/montage-deserializer-spec.js
+++ b/test/spec/serialization/montage-deserializer-spec.js
@@ -238,6 +238,27 @@ describe("serialization/montage-deserializer-spec", function () {
                 done();
             });
         });
+        
+        it("should deserialize a complex key assignment", function (done) {
+            var serialization = {
+                "root": {
+                    "value": {
+                        "bar": {}
+                    },
+                    "values": {
+                        "foo": 10,
+                        "bar.quz": 42
+                    }
+                }
+            },
+                serializationString = JSON.stringify(serialization);
+            deserialize(serializationString, require).then(function (object) {
+                expect(object.foo).toBe(10);
+                expect(object.bar.quz).toBe(42);
+            }).finally(function () {
+                done();
+            });
+        });
 
         it("should deserialize a simple one-time assignment in normal form", function (done) {
             var serialization = {

--- a/test/spec/ui/slider-spec.js
+++ b/test/spec/ui/slider-spec.js
@@ -1,7 +1,6 @@
 /*global describe, it, expect */
 var Montage = require("montage").Montage;
 var Slider = require("montage/ui/slider.reel").Slider;
-var MockDOM = require("mocks/dom");
 var MockEvent = require("mocks/event");
 
 describe("test/ui/slider-spec", function () {
@@ -20,7 +19,7 @@ describe("test/ui/slider-spec", function () {
             aSlider;
         beforeEach(function () {
             aSlider = new SpecializedSlider();
-            aSlider.element = MockDOM.element();
+            aSlider.element = document.createElement('div');
         });
 
         // Inspired by


### PR DESCRIPTION
- Add the ability to set/bind element's properties as DOM attributes.
- Add the ability to bind classList directly on an DOM element.
- Add Proxy polyfill
- Wrap setAttribute in order to set the element's property.
- Allow to use a path as property name within the serialization.
#1836