### PR TITLE
Deserializer Improvements

### DIFF
--- a/core/converter/pipeline-converter.js
+++ b/core/converter/pipeline-converter.js
@@ -11,7 +11,11 @@ exports.PipelineConverter = Converter.specialize({
 
     deserializeSelf: {
         value: function (deserializer) {
-            this.converters = deserializer.getProperty("converters");
+            var value;
+            value = deserializer.getProperty("converters");
+            if (value !== void 0) {
+                this.converters = value;
+            }
         }
     },
 

--- a/core/criteria.js
+++ b/core/criteria.js
@@ -128,8 +128,15 @@ var Criteria = exports.Criteria = Montage.specialize({
 
     deserializeSelf: {
         value: function (deserializer) {
-            this._expression = deserializer.getProperty("expression") || deserializer.getProperty("path");
-            this.parameters = deserializer.getProperty("parameters");
+            var value;
+            value = deserializer.getProperty("expression") || deserializer.getProperty("path");
+            if (value !== void 0) {
+                this._expression = value;
+            }
+            value = deserializer.getProperty("parameters");
+            if (value !== void 0) {
+                this.parameters = value;
+            }
         }
     },
     __scope: {

--- a/core/meta/derived-descriptor.js
+++ b/core/meta/derived-descriptor.js
@@ -41,7 +41,7 @@ exports.DerivedDescriptor = PropertyDescriptor.specialize( /** @lends DerivedDes
     _getPropertyWithDefaults:{
         value:function (deserializer, propertyName) {
             var value = deserializer.getProperty(propertyName);
-            return value ? value : Defaults[propertyName];
+            return value || this[propertyName] || Defaults[propertyName];
         }
     },
 

--- a/core/meta/event-descriptor.js
+++ b/core/meta/event-descriptor.js
@@ -61,8 +61,15 @@ exports.EventDescriptor = Montage.specialize( /** @lends EventDescriptor# */ {
 
     deserializeSelf: {
         value:function (deserializer) {
-            this._name = deserializer.getProperty("name");
-            this._owner = deserializer.getProperty("objectDescriptor") || deserializer.getProperty("blueprint");
+            var value;
+            value = deserializer.getProperty("name");
+            if (value !== void 0) {
+                this._name = value;
+            }
+            value = deserializer.getProperty("objectDescriptor") || deserializer.getProperty("blueprint");
+            if (value !== void 0) {
+                this._owner = value;
+            }
             this.detailKeys = this._getPropertyWithDefaults(deserializer, "detailKeys");
             this.helpKey = this._getPropertyWithDefaults(deserializer, "helpKey");
         }
@@ -78,8 +85,8 @@ exports.EventDescriptor = Montage.specialize( /** @lends EventDescriptor# */ {
 
     _getPropertyWithDefaults: {
         value:function (deserializer, propertyName) {
-            var value = deserializer.getProperty(propertyName);
-            return value ? value : Defaults[propertyName];
+            var value = deserializer.getProperty(propertyName) || this[propertyName];
+            return value || this[propertyName] || Defaults[propertyName];
         }
     },
 

--- a/core/meta/model.js
+++ b/core/meta/model.js
@@ -64,17 +64,23 @@ var Model = exports.Model = Montage.specialize( /** @lends Model.prototype # */ 
     deserializeSelf: {
         value: function (deserializer) {
             var value = deserializer.getProperty("version");
-            if (value !== undefined) {
+            if (value !== void 0) {
                 this.version = value;
             }
 
-            this._name = deserializer.getProperty("name");
+            value = deserializer.getProperty("name");
+            if (value !== void 0) {
+                this._name = value;
+            }
             //copy contents into the objectDescriptors array
             value = deserializer.getProperty("objectDescriptors") || deserializer.getProperty("blueprints");
             if (value) {
                 this._objectDescriptors = value;
             }
-            this.modelInstanceModuleId = deserializer.getProperty("objectModelModuleId") || deserializer.getProperty("binderModuleId");
+            value = deserializer.getProperty("objectModelModuleId") || deserializer.getProperty("binderModuleId");
+            if (value !== void 0) {
+                this.modelInstanceModuleId = value;
+            }
         }
     },
 

--- a/core/meta/module-object-descriptor.js
+++ b/core/meta/module-object-descriptor.js
@@ -23,7 +23,7 @@ function getModuleRequire(parentRequire, moduleId) {
 
     return module.require;
 }
-    
+
 // Cache all loaded object descriptors
 var OBJECT_DESCRIPTOR_CACHE = Object.create(null);
 
@@ -66,8 +66,15 @@ var ModuleObjectDescriptor = exports.ModuleObjectDescriptor = ObjectDescriptor.s
     deserializeSelf: {
         value: function (deserializer) {
             this.super(deserializer);
-            this.module = deserializer.getProperty("module");
-            this.exportName = deserializer.getProperty("exportName");
+            var value;
+            value = deserializer.getProperty("module");
+            if (value !== void 0) {
+                this.module = value;
+            }
+            value = deserializer.getProperty("exportName") || this.exportName;
+            if (value !== void 0) {
+                this.exportName = value;
+            }
 
             if (!this.module) {
                 throw new Error("Cannot deserialize object descriptor without a module reference");
@@ -130,7 +137,7 @@ var ModuleObjectDescriptor = exports.ModuleObjectDescriptor = ObjectDescriptor.s
                     targetRequire = Deserializer.getModuleRequire(_require, moduleId);
                     return new Deserializer().init(JSON.stringify(object), targetRequire).deserializeObject();
                 }).then(function (objectDescriptor) {
-                    
+
                     // TODO: May want to relax this to being just an Object Descriptor
                     if (!ModuleObjectDescriptor.prototype.isPrototypeOf(objectDescriptor)) {
                         throw new Error("Object in " + moduleId + " is not a module-object-descriptor");

--- a/core/meta/object-descriptor.js
+++ b/core/meta/object-descriptor.js
@@ -85,18 +85,26 @@ var ObjectDescriptor = exports.ObjectDescriptor = Montage.specialize( /** @lends
     deserializeSelf: {
         value:function (deserializer) {
             var value, model, parentReference;
-            this._name = deserializer.getProperty("name");
+            value = deserializer.getProperty("name");
+            if (value !== void 0) {
+                this._name = value;
+            }
             value = deserializer.getProperty("model") || deserializer.getProperty("binder");
             if (value) {
                 this._model = value;
             }
-            this.objectDescriptorInstanceModule = deserializer.getProperty("objectDescriptorModule") || deserializer.getProperty("blueprintModule");
+            value = deserializer.getProperty("objectDescriptorModule") || deserializer.getProperty("blueprintModule");
+            if (value !== void 0) {
+                this.objectDescriptorInstanceModule = value;
+            }
             parentReference = deserializer.getProperty("parent");
-            if (parentReference && parentReference.promise && parentReference.valueFromReference) {
-                deprecate.deprecationWarningOnce("parent reference via ObjectDescriptorReference", "direct reference with object syntax");
-                this._parentReference = parentReference;
-            } else {
-                this._parent = parentReference;
+            if (parentReference) {
+                if (parentReference.promise && parentReference.valueFromReference) {
+                    deprecate.deprecationWarningOnce("parent reference via ObjectDescriptorReference", "direct reference with object syntax");
+                    this._parentReference = parentReference;
+                } else {
+                    this._parent = parentReference;
+                }
             }
 
             this.customPrototype = this._getPropertyWithDefaults(deserializer, "customPrototype");
@@ -136,7 +144,7 @@ var ObjectDescriptor = exports.ObjectDescriptor = Montage.specialize( /** @lends
     _getPropertyWithDefaults: {
         value:function (deserializer, propertyName) {
             var value = deserializer.getProperty(propertyName);
-            return value ? value : Defaults[propertyName];
+            return value || this[propertyName] || Defaults[propertyName];
         }
     },
 

--- a/core/meta/property-descriptor.js
+++ b/core/meta/property-descriptor.js
@@ -116,24 +116,31 @@ exports.PropertyDescriptor = Montage.specialize( /** @lends PropertyDescriptor# 
 
     deserializeSelf: {
         value:function (deserializer) {
-            this._name = deserializer.getProperty("name");
-            this._owner = deserializer.getProperty("objectDescriptor") || deserializer.getProperty("blueprint");
-            this.cardinality = this._getPropertyWithDefaults(deserializer, "cardinality");
+            var value;
+            value = deserializer.getProperty("name");
+            if (value !== void 0) {
+                this._name = value;
+            }
+            value = deserializer.getProperty("objectDescriptor") || deserializer.getProperty("blueprint");
+            if (value !== void 0) {
+                this._owner = value;
+            }
+            this._overridePropertyWithDefaults(deserializer, "cardinality");
             if (this.cardinality === -1) {
                 this.cardinality = Infinity;
             }
-            this.mandatory = this._getPropertyWithDefaults(deserializer, "mandatory");
-            this.readOnly = this._getPropertyWithDefaults(deserializer, "readOnly");
-            this.denyDelete = this._getPropertyWithDefaults(deserializer, "denyDelete");
-            this.valueType = this._getPropertyWithDefaults(deserializer, "valueType");
-            this.collectionValueType = this._getPropertyWithDefaults(deserializer, "collectionValueType");
-            this.valueObjectPrototypeName = this._getPropertyWithDefaults(deserializer, "valueObjectPrototypeName");
-            this.valueObjectModuleId = this._getPropertyWithDefaults(deserializer, "valueObjectModuleId");
-            this._valueDescriptorReference = this._getPropertyWithDefaults(deserializer, "valueDescriptor", "targetBlueprint");
-            this.enumValues = this._getPropertyWithDefaults(deserializer, "enumValues");
-            this.defaultValue = this._getPropertyWithDefaults(deserializer, "defaultValue");
-            this.helpKey = this._getPropertyWithDefaults(deserializer, "helpKey");
-            this.definition = this._getPropertyWithDefaults(deserializer, "definition");
+            this._overridePropertyWithDefaults(deserializer, "mandatory", "mandatory");
+            this._overridePropertyWithDefaults(deserializer, "readOnly", "readOnly");
+            this._overridePropertyWithDefaults(deserializer, "denyDelete", "denyDelete");
+            this._overridePropertyWithDefaults(deserializer, "valueType", "valueType");
+            this._overridePropertyWithDefaults(deserializer, "collectionValueType", "collectionValueType");
+            this._overridePropertyWithDefaults(deserializer, "valueObjectPrototypeName", "valueObjectPrototypeName");
+            this._overridePropertyWithDefaults(deserializer, "valueObjectModuleId", "valueObjectModuleId");
+            this._overridePropertyWithDefaults(deserializer, "_valueDescriptorReference", "valueDescriptor", "targetBlueprint");
+            this._overridePropertyWithDefaults(deserializer, "enumValues", "enumValues");
+            this._overridePropertyWithDefaults(deserializer, "defaultValue", "defaultValue");
+            this._overridePropertyWithDefaults(deserializer, "helpKey", "helpKey");
+            this._overridePropertyWithDefaults(deserializer, "definition", "definition");
 
         }
     },
@@ -154,6 +161,33 @@ exports.PropertyDescriptor = Montage.specialize( /** @lends PropertyDescriptor# 
                 value = deserializer.getProperty(propertyNames[i]);
             }
             return value || Defaults[propertyNames[0]];
+        }
+    },
+
+    /**
+     * Applies a property from the deserializer to the object. If no such
+     * property is defined on the deserializer, then the current value
+     * of the property on this object will be used. If neither are available,
+     * the default value will be used. The property assignment is done in-place,
+     * so there is no return value.
+     *
+     * @private
+     * @param {SelfDeserializer} deserializer
+     * @param {String} objectKey The key of the property on this object
+     * @param {String} deserializerKeys Rest parameters used as keys of the
+     * property on the deserializer. Each key will be used sequentially until
+     * a defined property value is found.
+     */
+    _overridePropertyWithDefaults: {
+        value: function (deserializer, objectKey /*, deserializerKeys... */) {
+            var propertyNames = Array.prototype.slice.call(arguments).slice(2, Infinity),
+                value, i, n;
+            for (i = 0, n = propertyNames.length; i < n && !value; i++) {
+                this[objectKey] = deserializer.getProperty(propertyNames[i]);
+            }
+            if (this[objectKey] === void 0) {
+                this[objectKey] = Defaults[propertyNames[0]];
+            }
         }
     },
 

--- a/core/meta/validation-rule.js
+++ b/core/meta/validation-rule.js
@@ -43,10 +43,20 @@ exports.PropertyValidationRule = Montage.specialize( /** @lends PropertyValidati
 
     deserializeSelf: {
         value: function (deserializer) {
-            this._name = deserializer.getProperty("name");
-            this._owner = deserializer.getProperty("objectDescriptor") || deserializer.getProperty("blueprint");
+            var value;
+            value = deserializer.getProperty("name");
+            if (value !== void 0) {
+                this._name = value;
+            }
+            value = deserializer.getProperty("objectDescriptor") || deserializer.getProperty("blueprint");
+            if (value !== void 0) {
+                this._owner = value;
+            }
             //            this._validationSelector = deserializer.getProperty("validationSelector");
-            this._messageKey = deserializer.getProperty("messageKey");
+            value = deserializer.getProperty("messageKey");
+            if (value !== void 0) {
+                this._messageKey = value;
+            }
             // FIXME [PJYF Jan 8 2013] There is an API issue in the deserialization
             // We should be able to write deserializer.getProperties sight!!!
             var propertyNames = Montage.getSerializablePropertyNames(this);

--- a/core/serialization/deserializer/montage-deserializer.js
+++ b/core/serialization/deserializer/montage-deserializer.js
@@ -23,31 +23,18 @@ var MontageDeserializer = exports.MontageDeserializer = Montage.specialize({
     },
 
     init: {
-        value: function (serializationString, _require, objectRequires, locationId, moduleContexts) {
-            this._serializationString = serializationString;
+        value: function (serialization, _require, objectRequires, locationId, moduleContexts) {
+            if (typeof serialization === "string") {
+                this._serializationString = serialization;
+            } else {
+                this._serializationString = JSON.stringify(serialization);
+            }
             this._require = _require;
             moduleContexts = moduleContexts || new Map();
             this._reviver = new MontageReviver().init(_require, objectRequires, locationId, moduleContexts);
 
             return this;
         }
-    },
-
-    initWithObject: {
-        value: function (serialization, _require, objectRequires, locationId, moduleContexts) {
-            this._serializationString = JSON.stringify(serialization);
-            this._require = require;
-            moduleContexts = moduleContexts || new Map();
-            this._reviver = new MontageReviver().init(_require, objectRequires, locationId, moduleContexts);
-
-            return this;
-        }
-    },
-
-    initWithObjectAndRequire: {
-        value: deprecate.deprecateMethod(void 0, function (serialization, _require, objectRequires) {
-            return this.initWithObject(serialization, _require, objectRequires);
-        }, "initWithObjectAndRequire", "initWithObject")
     },
 
     deserialize: {
@@ -156,6 +143,20 @@ var MontageDeserializer = exports.MontageDeserializer = Montage.specialize({
                 throw new Error(message);
             });
         }
+    },
+
+    // Deprecated methods
+
+    initWithObject: {
+        value: deprecate.deprecateMethod(void 0, function (serialization, _require, objectRequires, locationId, moduleContexts) {
+            return this.init(serialization, _require, objectRequires, locationId, moduleContexts);
+        }, "initWithObject", "init")
+    },
+
+    initWithObjectAndRequire: {
+        value: deprecate.deprecateMethod(void 0, function (serialization, _require, objectRequires) {
+            return this.init(serialization, _require, objectRequires);
+        }, "initWithObjectAndRequire", "init")
     }
 
 }, {

--- a/core/serialization/deserializer/montage-deserializer.js
+++ b/core/serialization/deserializer/montage-deserializer.js
@@ -31,23 +31,12 @@ var MontageDeserializer = exports.MontageDeserializer = Montage.specialize({
             }
             this._require = _require;
             this._locationId = locationId;
-            this._reviver = new MontageReviver().init(_require, objectRequires,
-                this._childConstructor.bind(this));
+            this._reviver = new MontageReviver().init(_require, objectRequires, this.constructor);
 
             return this;
         }
     },
 
-    _childConstructor: {
-        value: function (module, moduleId) {
-            return new this.constructor().init(
-                module,
-                this.constructor.getModuleRequire(this._require, moduleId),
-                void 0,
-                moduleId
-            );
-        }
-    },
 
     /**
      * @param {Object} instances Map-like object of external user objects to

--- a/core/serialization/deserializer/montage-deserializer.js
+++ b/core/serialization/deserializer/montage-deserializer.js
@@ -87,14 +87,19 @@ var MontageDeserializer = exports.MontageDeserializer = Montage.specialize({
             var serialization = JSON.parse(this._serializationString),
                 reviver = this._reviver,
                 moduleLoader = reviver.moduleLoader,
+                i, ii,
+                labels,
+                label,
                 object,
                 locationId,
                 locationDesc,
                 module,
                 promises = [];
 
-            for (var label in serialization) {
-                if (serialization.hasOwnProperty(label)) {
+            if (serialization !== null) {
+                labels = Object.keys(serialization);
+                for (i = 0, ii = labels.length; i < ii; ++i) {
+                    label = labels[i];
                     object = serialization[label];
                     locationId = object.prototype || object.object;
 

--- a/core/serialization/deserializer/montage-deserializer.js
+++ b/core/serialization/deserializer/montage-deserializer.js
@@ -87,7 +87,7 @@ var MontageDeserializer = exports.MontageDeserializer = Montage.specialize({
             var serialization = JSON.parse(this._serializationString),
                 reviver = this._reviver,
                 moduleLoader = reviver.moduleLoader,
-                i, ii,
+                i,
                 labels,
                 label,
                 object,
@@ -98,8 +98,7 @@ var MontageDeserializer = exports.MontageDeserializer = Montage.specialize({
 
             if (serialization !== null) {
                 labels = Object.keys(serialization);
-                for (i = 0, ii = labels.length; i < ii; ++i) {
-                    label = labels[i];
+                for (i = 0; (label = labels[i]); ++i) {
                     object = serialization[label];
                     locationId = object.prototype || object.object;
 

--- a/core/serialization/deserializer/montage-deserializer.js
+++ b/core/serialization/deserializer/montage-deserializer.js
@@ -30,13 +30,33 @@ var MontageDeserializer = exports.MontageDeserializer = Montage.specialize({
                 this._serializationString = JSON.stringify(serialization);
             }
             this._require = _require;
-            moduleContexts = moduleContexts || new Map();
-            this._reviver = new MontageReviver().init(_require, objectRequires, locationId, moduleContexts);
+            this._moduleContexts = moduleContexts || new Map();
+            this._reviver = new MontageReviver().init(_require, objectRequires,
+                locationId, this._moduleContexts, this._childConstructor.bind(this));
 
             return this;
         }
     },
 
+    _childConstructor: {
+        value: function (module, moduleId) {
+            return new this.constructor().init(
+                module,
+                this.constructor.getModuleRequire(this._require, moduleId),
+                void 0,
+                moduleId,
+                this._moduleContexts
+            );
+        }
+    },
+
+    /**
+     * @param {Object} instances Map-like object of external user objects to
+     * link against the serialization.
+     * @param {Element} element The root element to resolve element references
+     * against.
+     * @return {Promise}
+     */
     deserialize: {
         value: function (instances, element) {
             try {

--- a/core/serialization/deserializer/montage-interpreter.js
+++ b/core/serialization/deserializer/montage-interpreter.js
@@ -1,16 +1,21 @@
 var Montage = require("../../core").Montage,
     MontageReviver = require("./montage-reviver").MontageReviver,
     Promise = require("../../promise").Promise,
+    deprecate = require("../../deprecate"),
     ONE_ASSIGNMENT = "=",
     ONE_WAY = "<-",
     TWO_WAY = "<->";
 
+/**
+ * @deprecated
+ */
 var MontageInterpreter = Montage.specialize({
     _require: {value: null},
     _reviver: {value: null},
 
     init: {
         value: function (_require, reviver) {
+            deprecate.deprecationWarningOnce("MontageInterpreter", "MontageDeserializer");
             if (typeof _require !== "function") {
                 throw new Error("Function 'require' missing.");
             }
@@ -249,7 +254,7 @@ var MontageContext = Montage.specialize({
 
                     if ((typeof value === "object" && value &&
                         Object.keys(value).length === 1 &&
-                        (ONE_WAY in value || TWO_WAY in value || ONE_ASSIGNMENT in value)) || 
+                        (ONE_WAY in value || TWO_WAY in value || ONE_ASSIGNMENT in value)) ||
                         key.indexOf('.') > -1
                     ) {
                         bindings[key] = value;

--- a/core/serialization/deserializer/montage-reviver.js
+++ b/core/serialization/deserializer/montage-reviver.js
@@ -503,13 +503,9 @@ var MontageReviver = exports.MontageReviver = Montage.specialize(/** @lends Mont
                 }
                 // TODO: For now we need this because we need to set
                 // isDeserilizing before calling didCreate.
-                object = Object.create(module[objectName].prototype);
+                object = module[objectName];
+                object = (typeof object === "function") ? new object() : Object.create(object);
                 object.isDeserializing = true;
-                if (typeof object.didCreate === "function") {
-                    object.didCreate();
-                } else if (typeof object.constructor === "function") {
-                    object.constructor();
-                }
                 return object;
             } else if ("object" in value) {
                 if (value.object.endsWith(".json")) {

--- a/core/serialization/deserializer/montage-reviver.js
+++ b/core/serialization/deserializer/montage-reviver.js
@@ -466,8 +466,14 @@ var MontageReviver = exports.MontageReviver = Montage.specialize(/** @lends Mont
 
     getMjsonObject: {
         value: function (serialization, json, moduleId, context) {
-            var self = this;
-            return Promise.resolve(this._deserializerConstructor(json, moduleId))
+            var self = this,
+                deserializer = new this._deserializerConstructor().init(
+                    json,
+                    this._deserializerConstructor.getModuleRequire(this._require, moduleId),
+                    void 0,
+                    moduleId
+                );
+            return Promise.resolve(deserializer)
                 .then(function (deserializer) {
                     return deserializer.deserializeObject();
                 })
@@ -1027,6 +1033,6 @@ MontageReviver.findProxyForElement = function (element) {
 };
 
 if (typeof exports !== "undefined") {
-    
+
     exports.MontageReviver = MontageReviver;
 }

--- a/core/serialization/deserializer/montage-reviver.js
+++ b/core/serialization/deserializer/montage-reviver.js
@@ -982,7 +982,7 @@ var MontageReviver = exports.MontageReviver = Montage.specialize(/** @lends Mont
 
     addCustomObjectReviver: {
         value: function(reviver) {
-            var customObjectReviver;
+            var customObjectRevivers = this.customObjectRevivers;
 
             /* jshint forin: true */
             for (var methodName in reviver) {
@@ -996,9 +996,8 @@ var MontageReviver = exports.MontageReviver = Montage.specialize(/** @lends Mont
                     typeof reviver[methodName] === "function" &&
                         methodName.substr(0, 5) === "revive"
                 ) {
-                    customObjectReviver = this.customObjectRevivers.get(methodName);
-                    if (typeof customObjectReviver === "undefined") {
-                        customObjectReviver = reviver[methodName].bind(reviver);
+                    if (typeof (customObjectRevivers.get(methodName)) === "undefined") {
+                        customObjectRevivers.set(methodName, reviver[methodName].bind(reviver));
                     } else {
                         return new Error("Reviver '" + methodName + "' is already registered.");
                     }

--- a/test/spec/events/eventmanager-spec.js
+++ b/test/spec/events/eventmanager-spec.js
@@ -1133,13 +1133,18 @@ TestPageLoader.queueTest("eventmanagertest/eventmanagertest", function (testPage
                 var labels = {};
                 labels.actioneventlistener = handlerObject;
 
-                deserializer.init(
-                    serialization, require);
-                spyOn(MontageReviver._unitRevivers, "listeners").and.callThrough();
+                deserializer.init(serialization, require);
+
+                var listenersUnit = MontageReviver._unitRevivers.get("listeners"),
+                    listenersUnitCalled = false;
+                MontageReviver._unitRevivers.set("listeners", function () {
+                    MontageReviver._unitRevivers.set("listeners", listenersUnit);
+                    listenersUnitCalled = true;
+                });
 
                 deserializer.deserialize(labels).then(function (objects) {
                     object = objects.root;
-                    expect(MontageReviver._unitRevivers.listeners).toHaveBeenCalled();
+                    expect(listenersUnitCalled).toBe(true);
                     done();
                 });
              });

--- a/test/spec/serialization/montage-deserializer-element-spec.js
+++ b/test/spec/serialization/montage-deserializer-element-spec.js
@@ -222,14 +222,14 @@ describe("serialization/montage-deserializer-element-spec", function () {
            rootEl.innerHTML = '<div id="id">content1</div>' +
                             '<div data-montage-id="id">content2</div>';
 
-           deserializer.initWithObject({
+           deserializer.init({
                rootEl: {
                    value: {
                        "element": {"#": "id"}
                    }
                }
            });
-        
+
            for (var i = 0; i < 3; i++) {
                deserializer.deserializeObjectWithElement(rootEl, function (object) {
                    expect(object.element instanceof Element).toBe(true);
@@ -240,14 +240,14 @@ describe("serialization/montage-deserializer-element-spec", function () {
 
         it("should deserialize an element with id and data-montage-id", function () {
            rootEl.innerHTML = '<div id="realId" data-montage-id="id">content</div>';
-           deserializer.initWithObject({
+           deserializer.init({
                rootEl: {
                    value: {
                        "element": {"#": "id"}
                    }
                }
            });
-        
+
            for (var i = 0; i < 3; i++) {
                deserializer.deserializeObjectWithElement(rootEl, function (object) {
                    expect(object.element instanceof Element).toBe(true);
@@ -258,14 +258,14 @@ describe("serialization/montage-deserializer-element-spec", function () {
 
         it("should deserialize an element with the same id and data-montage-id", function () {
            rootEl.innerHTML = '<div id="id" data-montage-id="id">content</div>';
-           deserializer.initWithObject({
+           deserializer.init({
                rootEl: {
                    value: {
                        "element": {"#": "id"}
                    }
                }
            });
-        
+
            for (var i = 0; i < 3; i++) {
                deserializer.deserializeObjectWithElement(rootEl, function (object) {
                    expect(object.element instanceof Element).toBe(true);
@@ -276,7 +276,7 @@ describe("serialization/montage-deserializer-element-spec", function () {
 
         it("should deserialize an element reference through id w/ optimization", function () {
            rootEl.innerHTML = '<div id="id">content</div>';
-           deserializer.initWithObject({
+           deserializer.init({
                rootEl: {
                    value: {
                        "element": {"#": "id"}
@@ -284,7 +284,7 @@ describe("serialization/montage-deserializer-element-spec", function () {
                }
            });
            deserializer.optimizeForDocument(rootEl);
-        
+
            for (var i = 0; i < 3; i++) {
                deserializer.deserializeObjectWithElement(rootEl, function (object) {
                    expect(object.element instanceof Element).toBe(true);
@@ -296,7 +296,7 @@ describe("serialization/montage-deserializer-element-spec", function () {
 
         it("should deserialize an element reference through data-montage-id w/ optimization", function () {
            rootEl.innerHTML = '<div data-montage-id="id">content</div>';
-           deserializer.initWithObject({
+           deserializer.init({
                rootEl: {
                    value: {
                        "element": {"#": "id"}
@@ -304,7 +304,7 @@ describe("serialization/montage-deserializer-element-spec", function () {
                }
            });
            deserializer.optimizeForDocument(rootEl);
-        
+
            for (var i = 0; i < 3; i++) {
                deserializer.deserializeObjectWithElement(rootEl, function (object) {
                    expect(object.element instanceof Element).toBe(true);
@@ -317,7 +317,7 @@ describe("serialization/montage-deserializer-element-spec", function () {
         it("should deserialize an element reference through data-montage-id over id w/ optimization", function () {
            rootEl.innerHTML = '<div id="id">content1</div>' +
                             '<div data-montage-id="id">content2</div>';
-           deserializer.initWithObject({
+           deserializer.init({
                rootEl: {
                    value: {
                        "element": {"#": "id"}
@@ -325,7 +325,7 @@ describe("serialization/montage-deserializer-element-spec", function () {
                }
            });
            deserializer.optimizeForDocument(rootEl);
-        
+
            for (var i = 0; i < 3; i++) {
                deserializer.deserializeObjectWithElement(rootEl, function (object) {
                    expect(object.element instanceof Element).toBe(true);
@@ -337,7 +337,7 @@ describe("serialization/montage-deserializer-element-spec", function () {
 
         it("should deserialize an element with id and data-montage-id w/ optimization", function () {
            rootEl.innerHTML = '<div id="realId" data-montage-id="id">content</div>';
-           deserializer.initWithObject({
+           deserializer.init({
                rootEl: {
                    value: {
                        "element": {"#": "id"}
@@ -345,7 +345,7 @@ describe("serialization/montage-deserializer-element-spec", function () {
                }
            });
            deserializer.optimizeForDocument(rootEl);
-        
+
            for (var i = 0; i < 3; i++) {
                deserializer.deserializeObjectWithElement(rootEl, function (object) {
                    expect(object.element instanceof Element).toBe(true);
@@ -357,7 +357,7 @@ describe("serialization/montage-deserializer-element-spec", function () {
 
         it("should deserialize an element with the same id and data-montage-id w/ optimization", function () {
            rootEl.innerHTML = '<div id="id" data-montage-id="id">content</div>';
-           deserializer.initWithObject({
+           deserializer.init({
                rootEl: {
                    value: {
                        "element": {"#": "id"}
@@ -365,7 +365,7 @@ describe("serialization/montage-deserializer-element-spec", function () {
                }
            });
            deserializer.optimizeForDocument(rootEl);
-        
+
            for (var i = 0; i < 3; i++) {
                deserializer.deserializeObjectWithElement(rootEl, function (object) {
                    expect(object.element instanceof Element).toBe(true);

--- a/test/spec/serialization/montage-deserializer-spec.js
+++ b/test/spec/serialization/montage-deserializer-spec.js
@@ -393,7 +393,7 @@ describe("serialization/montage-deserializer-spec", function () {
            var instances = {root: null};
            var exports;
 
-           deserializer.initWithObject({
+           deserializer.init({
                root: {
                    module: "serialization/testobjects-v2",
                    name: "OneProp",
@@ -842,7 +842,7 @@ describe("serialization/montage-deserializer-spec", function () {
         it("should deserialize using instance after compilation", function (done) {
            var latch, objects;
 
-            deserializer.initWithObject({
+            deserializer.init({
                root: {
                    prototype: "montage",
                    values: {
@@ -871,7 +871,7 @@ describe("serialization/montage-deserializer-spec", function () {
         it("should deserialize using type after compilation", function (done) {
            var latch, objects;
 
-           deserializer.initWithObject({
+           deserializer.init({
                root: {
                    object: "montage",
                    values: {

--- a/test/spec/serialization/montage-deserializer-spec.js
+++ b/test/spec/serialization/montage-deserializer-spec.js
@@ -149,8 +149,7 @@ describe("serialization/montage-deserializer-spec", function () {
                     simple: simple
                 };
 
-            deserializer.init(
-                serializationString, require);
+            deserializer.init(serializationString, require);
 
             deserializer.deserializeObject(instances).then(function (root) {
                 expect(root.simple).toBe(simple);
@@ -742,7 +741,7 @@ describe("serialization/montage-deserializer-spec", function () {
             deserializer.init(serializationString, require);
             deserializer.deserializeObject().then(function (root) {
                 var info = Montage.getInfoForObject(root);
-                expect(info.moduleId).toBe("core/meta/object-descriptor");
+                expect(info.moduleId).toBe("core/core");
                 expect(info.isInstance).toBe(true);
                 expect(root.type).toBeUndefined();
                 expect(root.name).toBe("RootObjectDescriptor");
@@ -798,7 +797,7 @@ describe("serialization/montage-deserializer-spec", function () {
             deserializer.init(serializationString, require);
             deserializer.deserializeObject().then(function (root) {
                 var info = Montage.getInfoForObject(root);
-                expect(info.moduleId).toBe("core/meta/object-descriptor");
+                expect(info.moduleId).toBe("core/core");
                 expect(info.isInstance).toBe(true);
                 expect(root.type).toBeUndefined();
                 expect(root.name).toBe("RootObjectDescriptor");

--- a/test/spec/serialization/reviver-spec.js
+++ b/test/spec/serialization/reviver-spec.js
@@ -1,5 +1,5 @@
 var Reviver = require("montage/core/serialization/deserializer/montage-reviver").MontageReviver,
-    Interpreter = require("montage/core/serialization/deserializer/montage-interpreter").MontageInterpreter,
+    Context = require("montage/core/serialization/deserializer/montage-interpreter").MontageContext,
     Promise = require("montage/core/promise").Promise;
 
 
@@ -127,10 +127,11 @@ describe("reviver", function() {
     });
 
     describe("custom object revivers", function() {
-        var interpreter;
+        var reviver,
+            context;
 
         beforeEach(function() {
-            interpreter = new Interpreter().init(require, new Reviver().init(require));
+            reviver = new Reviver().init(require);
         });
         afterEach(function() {
             Reviver.resetCustomObjectRevivers();
@@ -160,7 +161,8 @@ describe("reviver", function() {
                     }
                 };
 
-            interpreter.instantiate(serialization).then(function(objects) {
+            context = new Context().init(serialization, reviver, void 0, void 0, require);
+            context.getObjects().then(function (objects) {
                 expect(objects.main.name).toBe("a custom1 object");
             }).finally(function () {
                 done();
@@ -206,7 +208,8 @@ describe("reviver", function() {
                     }
                 };
 
-            interpreter.instantiate(serialization).then(function(objects) {
+            context = new Context().init(serialization, reviver, void 0, void 0, require);
+            context.getObjects().then(function (objects) {
                 expect(objects.object1.name).toBe("a custom1 object");
                 expect(objects.object2.name).toBe("a custom2 object");
             }).finally(function () {
@@ -215,7 +218,7 @@ describe("reviver", function() {
         });
 
 
-        it("Should fail if 'prototype' property is missing explicitly", function(done) {
+        it("Should fail if 'prototype' property is missing explicitly", function () {
 
             var serialization = {
                 "object1": {
@@ -225,13 +228,12 @@ describe("reviver", function() {
                 }
             };
 
+            context = new Context().init(serialization, reviver, void 0, void 0, require);
             try {
-                interpreter.instantiate(serialization);
-                fail('Should throw error');
+                context.getObjects();
+                fail("Should throw error");
             } catch (err) {
                 expect(err.message).toBe('Error deserializing {"values":{"name":"a custom1 object"}}, might need "prototype" or "object" on label "object1"');
-            } finally {
-                done();
             }
         });
 
@@ -277,7 +279,8 @@ describe("reviver", function() {
                     }
                 };
 
-            interpreter.instantiate(serialization).then(function(objects) {
+            context = new Context().init(serialization, reviver, void 0, void 0, require);
+            context.getObjects().then(function (objects) {
                 expect(objects.main.name).toBe(objects.one.main.name);
                 expect(objects.main.name).toBe("a custom1 object");
             }).finally(function () {

--- a/test/spec/serialization/testmjson.mjson
+++ b/test/spec/serialization/testmjson.mjson
@@ -1,6 +1,6 @@
 {
     "root": {
-        "prototype": "montage/core/meta/object-descriptor",
+        "prototype": "montage/core/core[Montage]",
         "values": {
             "name": "RootObjectDescriptor"
         }


### PR DESCRIPTION
Fixes #1834.

- [x] Decouple deserializer from reviver
- [x] Add deserializer caching
- [x] Use new instead of Object.create() for constructor modules, remove didCreate()
- [x] Make `deserializeSelf` implementations reentrant so they can be called multiple times on the same instance.
- [x] Measure performance:

#### Performance Analysis

<img width="936" alt="screen shot 2017-09-20 at 5 42 56 pm" src="https://user-images.githubusercontent.com/8292702/30673904-42979402-9e2b-11e7-9716-f7ab677753a3.png">

When deserializing only JS modules, the performance difference with this change is negligible. There is a very small exponential speedup (about 5% faster over a sample size of 1.6 million deserializations) due to the change from Object.create() to new.

<img width="942" alt="screen shot 2017-09-07 at 10 58 08 am" src="https://user-images.githubusercontent.com/8292702/30177704-8081beb6-93bb-11e7-9420-1723439a8f7e.png">

We see massive performance gains when deserializing nested .mjson files thanks to deserialization caching. The deserializer is able to run this test with a better-than-linear time complexity, whereas the master implementation is exponential.