### PR TITLE
Fix PropertyDescriptor._overridePropertyWithDefaults()

### DIFF
--- a/core/meta/property-descriptor.js
+++ b/core/meta/property-descriptor.js
@@ -125,10 +125,12 @@ exports.PropertyDescriptor = Montage.specialize( /** @lends PropertyDescriptor# 
             if (value !== void 0) {
                 this._owner = value;
             }
-            this._overridePropertyWithDefaults(deserializer, "cardinality");
+            this._overridePropertyWithDefaults(deserializer, "cardinality", "cardinality");
+          
             if (this.cardinality === -1) {
                 this.cardinality = Infinity;
             }
+
             this._overridePropertyWithDefaults(deserializer, "mandatory", "mandatory");
             this._overridePropertyWithDefaults(deserializer, "readOnly", "readOnly");
             this._overridePropertyWithDefaults(deserializer, "denyDelete", "denyDelete");
@@ -182,12 +184,17 @@ exports.PropertyDescriptor = Montage.specialize( /** @lends PropertyDescriptor# 
         value: function (deserializer, objectKey /*, deserializerKeys... */) {
             var propertyNames = Array.prototype.slice.call(arguments).slice(2, Infinity),
                 value, i, n;
+            
+            // [TJ] Prospective code
+            // if (propertyNames.length === 0) {
+            //     propertyNames = [objectKey];
+            // }
+
             for (i = 0, n = propertyNames.length; i < n && !value; i++) {
-                this[objectKey] = deserializer.getProperty(propertyNames[i]);
+                value = deserializer.getProperty(propertyNames[i]);
             }
-            if (this[objectKey] === void 0) {
-                this[objectKey] = Defaults[propertyNames[0]];
-            }
+
+            this[objectKey] = value === undefined ? Defaults[propertyNames[0]] : value;
         }
     },
 

--- a/core/meta/property-descriptor.js
+++ b/core/meta/property-descriptor.js
@@ -125,25 +125,24 @@ exports.PropertyDescriptor = Montage.specialize( /** @lends PropertyDescriptor# 
             if (value !== void 0) {
                 this._owner = value;
             }
-            this._overridePropertyWithDefaults(deserializer, "cardinality", "cardinality");
-          
+            this._overridePropertyWithDefaults(deserializer, "cardinality");
+
             if (this.cardinality === -1) {
                 this.cardinality = Infinity;
             }
 
-            this._overridePropertyWithDefaults(deserializer, "mandatory", "mandatory");
-            this._overridePropertyWithDefaults(deserializer, "readOnly", "readOnly");
-            this._overridePropertyWithDefaults(deserializer, "denyDelete", "denyDelete");
-            this._overridePropertyWithDefaults(deserializer, "valueType", "valueType");
-            this._overridePropertyWithDefaults(deserializer, "collectionValueType", "collectionValueType");
-            this._overridePropertyWithDefaults(deserializer, "valueObjectPrototypeName", "valueObjectPrototypeName");
-            this._overridePropertyWithDefaults(deserializer, "valueObjectModuleId", "valueObjectModuleId");
+            this._overridePropertyWithDefaults(deserializer, "mandatory");
+            this._overridePropertyWithDefaults(deserializer, "readOnly");
+            this._overridePropertyWithDefaults(deserializer, "denyDelete");
+            this._overridePropertyWithDefaults(deserializer, "valueType");
+            this._overridePropertyWithDefaults(deserializer, "collectionValueType");
+            this._overridePropertyWithDefaults(deserializer, "valueObjectPrototypeName");
+            this._overridePropertyWithDefaults(deserializer, "valueObjectModuleId");
             this._overridePropertyWithDefaults(deserializer, "_valueDescriptorReference", "valueDescriptor", "targetBlueprint");
-            this._overridePropertyWithDefaults(deserializer, "enumValues", "enumValues");
-            this._overridePropertyWithDefaults(deserializer, "defaultValue", "defaultValue");
-            this._overridePropertyWithDefaults(deserializer, "helpKey", "helpKey");
-            this._overridePropertyWithDefaults(deserializer, "definition", "definition");
-
+            this._overridePropertyWithDefaults(deserializer, "enumValues");
+            this._overridePropertyWithDefaults(deserializer, "defaultValue");
+            this._overridePropertyWithDefaults(deserializer, "helpKey");
+            this._overridePropertyWithDefaults(deserializer, "definition");
         }
     },
 
@@ -173,6 +172,8 @@ exports.PropertyDescriptor = Montage.specialize( /** @lends PropertyDescriptor# 
      * the default value will be used. The property assignment is done in-place,
      * so there is no return value.
      *
+     * If no deserializerKeys are specified, the objectKey will be used instead.
+     *
      * @private
      * @param {SelfDeserializer} deserializer
      * @param {String} objectKey The key of the property on this object
@@ -182,13 +183,13 @@ exports.PropertyDescriptor = Montage.specialize( /** @lends PropertyDescriptor# 
      */
     _overridePropertyWithDefaults: {
         value: function (deserializer, objectKey /*, deserializerKeys... */) {
-            var propertyNames = Array.prototype.slice.call(arguments).slice(2, Infinity),
-                value, i, n;
-            
-            // [TJ] Prospective code
-            // if (propertyNames.length === 0) {
-            //     propertyNames = [objectKey];
-            // }
+            var propertyNames, value, i, n;
+
+            if (arguments.length > 2) {
+                propertyNames = Array.prototype.slice.call(arguments, 2, Infinity);
+            } else {
+                propertyNames = [objectKey];
+            }
 
             for (i = 0, n = propertyNames.length; i < n && !value; i++) {
                 value = deserializer.getProperty(propertyNames[i]);


### PR DESCRIPTION
@cdebost 

The loop in overridePropertyWithDefaults method was not exiting properly. It checks for `!value`, but the loop was assigning `this[objectKey]` directly rather than assign `value`. So any property with more than one property name ended up with the value of the last property name. 

Also, `this._overridePropertyWithDefaults()` requires at least 3 arguments, but the call for only passed 2. The simplest fix was to call `this._overridePropertyWithDefaults(deserializer, "cardinality", "cardinality");`, but I also added a commented out snippet in `_overridePropertyWithDefaults` that could solve the problem in a more robust way. 

```javascript
// [TJ] Prospective code
// if (propertyNames.length === 0) {
 //     propertyNames = [objectKey];
 // }
```

Rather than require the developer to pass in the same string twice, we could assume that the key in the serialization is the same as the property key that we assign it to. Small thing, but it could make the deserializeSelf read a bit easier. 