### PR TITLE
Add targetElement property to longPress event

### DIFF
--- a/composer/press-composer.js
+++ b/composer/press-composer.js
@@ -867,7 +867,7 @@ var PressComposer = exports.PressComposer = Composer.specialize(/** @lends Press
                 var self = this;
 
                 this._longPressTimeout = setTimeout(function () {
-                    self._dispatchLongPress();
+                    self._dispatchLongPress(event.target);
                 }, this._longPressThreshold);
             }
         }
@@ -941,9 +941,12 @@ var PressComposer = exports.PressComposer = Composer.specialize(/** @lends Press
 
     _dispatchLongPress: {
         enumerable: false,
-        value: function (event) {
+        value: function (targetElement) {
+            var event, target;
             if (this._shouldDispatchLongPress) {
-                this.dispatchEvent(this._createPressEvent("longPress", event));
+                event = this._createPressEvent("longPress");
+                event.targetElement = targetElement;
+                this.dispatchEvent(event);
                 this._longPressTimeout = null;
             }
         }


### PR DESCRIPTION
Unlike "press",  "longPress" does not provide which element was pressed to generate the event. It only provides the component to which the listener was attached. This prevents the parent component from using event delegation if it would like to use long press.

For example, say you have a directory viewer that works similar to macOS finder and supports two interactions: 
1. Select a list item on press.
2. Enter "edit mode" for a list item on long press. 

The following handlePress works with the current API. handleLongPress does not: 
```javascript
handlePress: {
    value: function (event) {
        event.stopPropagation();
        var file = event.targetElement.component.file;
        this.selectFile(file);
    }
},

handleLongPress: {
    value: function (event) {
        event.stopPropagation();
        var file = event.targetElement.component.file;
        this.editFile(file);
    }
},
```


As for the changes, my understanding of the PressComposer is that longPress will be dispatched only if the cursor does not move for the duration of the press. Therefore, the targetElement of a longPress is the same as the target of the original pointerDown. 