### PR TITLE
Add warning for non-object-descriptor Types

### DIFF
--- a/data/service/data-service.js
+++ b/data/service/data-service.js
@@ -966,14 +966,20 @@ exports.DataService = Montage.specialize(/** @lends DataService.prototype */ {
      */
     _getPrototypeForType: {
         value: function (type) {
-            var prototype;
+            var info, triggers, prototype;
             type = this._objectDescriptorForType(type);
             prototype = this._dataObjectPrototypes.get(type);
             if (type && !prototype) {
                 prototype = Object.create(type.objectPrototype || Montage.prototype);
                 this._dataObjectPrototypes.set(type, prototype);
-                this._dataObjectTriggers.set(type, DataTrigger.addTriggers(this, type, prototype));
-
+                if (type instanceof ObjectDescriptor || type instanceof DataObjectDescriptor) {
+                    triggers = DataTrigger.addTriggers(this, type, prototype);
+                } else {
+                    info = Montage.getInfoForObject(type.prototype);
+                    console.warn("Data Triggers cannot be created for this type. (" + (info && info.objectName) + ") is not an ObjectDescriptor");
+                    triggers = [];
+                }
+                this._dataObjectTriggers.set(type, triggers);
                 //We add a property that returns an object's snapshot
                 //We add a property that returns an object's primaryKey
                 //Let's postponed this for now and revisit when we need


### PR DESCRIPTION
DataTrigger was throwing errors when passed a constructor instead of an ObjectDescriptor. This occurs when DataService has a constructor that does not have an associated ObjectDescriptor. Which in turn happens when a RawDataService is added via addChildService() and it's types array has a constructor. For example:

```javascript
var Foo = require("logic/model/foo").Foo;
exports.FooService = HttpService.specialize({

    types: {
        value: [Foo]
    }

});
```

The line that fails is this one from DataTrigger._addTriggers:
```javascript
for (i = 0, n = objectDescriptor.propertyDescriptors.length; i < n; i += 1) {
```
https://github.com/montagejs/montage/blob/master/data/service/data-trigger.js#L407

It previously used a `for...in`. It wouldn't throw an error, but it also wouldn't create triggers. 

This PR represents only a minor improvement. All it does is add a warning that a constructor without an object descriptor will not have triggers. At some point, we may want to add logic to create an ObjectDescriptor on-the-fly for types that do not have one already. However, the function that does that, `ObjectDescriptor.createDefaultObjectDescriptorForObject()`, is asynchronous and the only function that runs into this issue thus far, `DataService.addChildService()`, is synchronous so even that won't suit this case. It may be that if a developer needs Montage to dynamically create an ObjectDescriptor, then he must use the async `DataService.registerChildService()`. 

https://github.com/montagejs/montage/blob/master/core/meta/object-descriptor.js#L1268
