### PR TITLE
Quick Fix for the Translate composer on iOS 11+

### DIFF
--- a/composer/translate-composer.js
+++ b/composer/translate-composer.js
@@ -816,18 +816,21 @@ var TranslateComposer = exports.TranslateComposer = Composer.specialize(/** @len
                 document.addEventListener("pointermove", this, true);
                 document.addEventListener("pointerup", this, false);
                 document.addEventListener("pointercancel", this, false);
+                document.addEventListener("scroll", this, true);
 
             } else if (window.MSPointerEvent && window.navigator.msPointerEnabled) {
                 this._element.addEventListener("MSPointerDown", this, false);
                 document.addEventListener("MSPointerMove", this, true);
                 document.addEventListener("MSPointerUp", this, false);
                 document.addEventListener("MSPointerCancel", this, false);
+                document.addEventListener("scroll", this, true);
 
             } else {
                 if (this._observedPointer === this._MOUSE_POINTER) {
                     this._element.addEventListener("mousedown", this, false);
                     document.addEventListener("mousemove", this, true);
                     document.addEventListener("mouseup", this, false);
+                    document.addEventListener("scroll", this, true);
 
                 } else {
                     this._element.addEventListener("touchstart", this, false);
@@ -836,8 +839,6 @@ var TranslateComposer = exports.TranslateComposer = Composer.specialize(/** @len
                     this._element.addEventListener("touchcancel", this, false);
                 }
             }
-
-            document.addEventListener("scroll", this, true);
 
             if (this.isAnimating) {
                 this.isAnimating = false;
@@ -1113,18 +1114,21 @@ var TranslateComposer = exports.TranslateComposer = Composer.specialize(/** @len
                 document.removeEventListener("pointermove", this, true);
                 document.removeEventListener("pointerup", this, false);
                 document.removeEventListener("pointercancel", this, false);
+                document.removeEventListener("scroll", this, true);
 
             } else if (window.MSPointerEvent && window.navigator.msPointerEnabled) {
                 this._element.removeEventListener("MSPointerDown", this, false);
                 document.removeEventListener("MSPointerMove", this, true);
                 document.removeEventListener("MSPointerUp", this, false);
                 document.removeEventListener("MSPointerCancel", this, false);
+                document.removeEventListener("scroll", this, true);
 
             } else {
                 if (this._observedPointer === this._MOUSE_POINTER) {
                     this._element.removeEventListener("mousedown", this, false);
                     document.removeEventListener("mousemove", this, true);
                     document.removeEventListener("mouseup", this, false);
+                    document.removeEventListener("scroll", this, true);
 
                 } else {
                     this._element.removeEventListener("touchstart", this, false);
@@ -1134,7 +1138,6 @@ var TranslateComposer = exports.TranslateComposer = Composer.specialize(/** @len
                 }
             }
 
-            document.removeEventListener("scroll", this, true);
 
             if (this.eventManager.isPointerClaimedByComponent(this._observedPointer, this)) {
                 this.eventManager.forfeitPointer(this._observedPointer, this);


### PR DESCRIPTION
The translate composer won’t listen to scroll events after a touch start, Safari raises scroll events all time even if there is nothing to scroll. (Bouncing?).
Need more investigation.