### PR TITLE
Only trigger Authorization logic for services that use it

### DIFF
--- a/data/service/data-service.js
+++ b/data/service/data-service.js
@@ -833,7 +833,7 @@ exports.DataService = Montage.specialize(/** @lends DataService.prototype */ {
     },
 
     /**
-     * Perform whatever tasks are necessary to authorize 
+     * Performs whatever tasks are necessary to authorize 
      * this service and returns a Promise that resolves with
      * an Authorization object.
      *

--- a/data/service/data-service.js
+++ b/data/service/data-service.js
@@ -833,17 +833,18 @@ exports.DataService = Montage.specialize(/** @lends DataService.prototype */ {
     },
 
     /**
-     *
+     * Perform whatever tasks are necessary to authorize 
+     * this service and returns a Promise that resolves with
+     * an Authorization object.
      *
      * @method
      * @returns Promise
      */
     authorize: {
-        value: function () {
-            console.warn("DataService.authorize() must be overridden by the implementing service", arguments);
-            return this.nullPromise;
-        }
+        value: undefined
     },
+
+
     /**
      *
      * @method

--- a/data/service/http-service.js
+++ b/data/service/http-service.js
@@ -282,10 +282,6 @@ var HttpService = exports.HttpService = RawDataService.specialize(/** @lends Htt
      * error the promise will be rejected with the error.
      */
 
-    _authRegexp: {
-        value: new RegExp(/error=\"([^&]*)\"/)
-    },
-
     _fetchHttpRawDataWithParsedArguments: {
         value: function (parsed) {
             var self = this,
@@ -354,11 +350,7 @@ var HttpService = exports.HttpService = RawDataService.specialize(/** @lends Htt
         }
     },
 
-    _isRequestUnauthorized: {
-        value: function (request) {
-            return request.status === 401 || (typeof this.didAuthorizationFail === "function" && this.didAuthorizationFail(request));
-        }
-    },
+    
 
     fetchHttpRawData: {
         value: function (url, headers, body, types, query, sendCredentials) {
@@ -451,6 +443,31 @@ var HttpService = exports.HttpService = RawDataService.specialize(/** @lends Htt
         value: function (value) {
             return typeof value === "boolean" || value instanceof Boolean;
         }
+    },
+
+    /***************************************************************************
+     * Authorization
+     */
+
+    _authRegexp: {
+        value: new RegExp(/error=\"([^&]*)\"/)
+    },
+
+    _isRequestUnauthorized: {
+        value: function (request) {
+            return request.status === 401 || (typeof this.didAuthorizationFail === "function" && this.didAuthorizationFail(request));
+        }
+    },
+
+    /**
+     *
+     *
+     * @method
+     * @returns Promise
+     */
+    authorize: {
+        //Must be overridden by the implementing service
+        value: undefined
     },
 
     /***************************************************************************

--- a/data/service/http-service.js
+++ b/data/service/http-service.js
@@ -459,17 +459,6 @@ var HttpService = exports.HttpService = RawDataService.specialize(/** @lends Htt
         }
     },
 
-    /**
-     *
-     *
-     * @method
-     * @returns Promise
-     */
-    authorize: {
-        //Must be overridden by the implementing service
-        value: undefined
-    },
-
     /***************************************************************************
      * Utilities
      */


### PR DESCRIPTION
HttpService automatically calls HttpService.authorize() if an XHR is unauthorized and the authorize function exists: 
```javascript
if (self._isRequestUnauthorized(request) && typeof self.authorize === "function") {
```
```javascript
_isRequestUnauthorized: {
    value: function (request) {
        return request.status === 401 || (typeof this.didAuthorizationFail === "function" && this.didAuthorizationFail(request));
    }
},
```

DataService.authorize() exists, but only logs a warning that authorize() must actually be implemented by the service inheriting from DataService:
```javascript
authorize: {
    value: function () {
        console.warn("DataService.authorize() must be overridden by the implementing service", arguments);
        return this.nullPromise;
    }
},
```

This results in an infinite loop if the ChildService does not implement `authorize()` and then gets a 401 status code. HttpService detects the DataService.authorize() implementation and proceeds as if authorize() acquired the authorization. 
  