### PR TITLE
object-to-raw-data mapping fixes

### DIFF
--- a/core/meta/object-descriptor.js
+++ b/core/meta/object-descriptor.js
@@ -404,35 +404,34 @@ var ObjectDescriptor = exports.ObjectDescriptor = Montage.specialize( /** @lends
         }
     },
 
-_preparePropertyDescriptorsCache: {
-    value: function () {
-        var ownDescriptors = this._ownPropertyDescriptors,
-            isReady = true,
-            descriptor, i, n;
-
-        if (!this._propertyDescriptorsAreCached)  {
-
-            for (i = 0, n = ownDescriptors.length; i < n && isReady; ++i) {
-                descriptor = ownDescriptors[i];
-                isReady = !!(descriptor && descriptor.name);
-            }
-
-            if (isReady) {
-                this._propertyDescriptorsAreCached = true;
-                this._propertyDescriptors = [];
-                this._propertyDescriptorsTable.clear();
-                for (i = 0, n = ownDescriptors.length; i < n; ++i) {
+    _preparePropertyDescriptorsCache: {
+        value: function () {
+            var ownDescriptors = this._ownPropertyDescriptors,
+                isReady = true,
+                descriptor, i, n;
+            if (!this._propertyDescriptorsAreCached)  {
+                
+                for (i = 0, n = ownDescriptors.length; i < n && isReady; ++i) {
                     descriptor = ownDescriptors[i];
-                    descriptor._owner = this;
-                    this._propertyDescriptors.push(descriptor);
-                    this._propertyDescriptorsTable.set(descriptor.name,  descriptor);
+                    isReady = !!(descriptor && descriptor.name);
                 }
-                this.addRangeAtPathChangeListener("_ownPropertyDescriptors", this, "_handlePropertyDescriptorsRangeChange");
-                this.addRangeAtPathChangeListener("parent.propertyDescriptors", this, "_handlePropertyDescriptorsRangeChange");
+
+                if (isReady) {
+                    this._propertyDescriptorsAreCached = true;
+                    this._propertyDescriptors = [];
+                    this._propertyDescriptorsTable.clear();
+                    for (i = 0, n = ownDescriptors.length; i < n; ++i) {
+                        descriptor = ownDescriptors[i];
+                        descriptor._owner = this;
+                        this._propertyDescriptors.push(descriptor);
+                        this._propertyDescriptorsTable.set(descriptor.name,  descriptor);
+                    }
+                    this.addRangeAtPathChangeListener("_ownPropertyDescriptors", this, "_handlePropertyDescriptorsRangeChange");
+                    this.addRangeAtPathChangeListener("parent.propertyDescriptors", this, "_handlePropertyDescriptorsRangeChange");
+                }
             }
         }
-    }
-},
+    },
 
     /**
      * PropertyDescriptors for this object descriptor, not including those

--- a/data/service/data-service.js
+++ b/data/service/data-service.js
@@ -1177,7 +1177,7 @@ exports.DataService = Montage.specialize(/** @lends DataService.prototype */ {
             var self = this,
                 propertyName = propertiesToRequest.shift(),
                 promise = this.getObjectProperties(object, propertyName);
-
+            
             if (promise) {
                 return promise.then(function () {
                     var result = null;
@@ -1295,29 +1295,40 @@ exports.DataService = Montage.specialize(/** @lends DataService.prototype */ {
         }
     },
 
+    _isAsync: {
+        value: function (object) {
+            return object && object.then && typeof object.then === "function";
+        }
+    },
+
     _fetchObjectPropertyWithPropertyDescriptor: {
         value: function (object, propertyName, propertyDescriptor) {
             var self = this,
                 objectDescriptor = propertyDescriptor.owner,
                 mapping = objectDescriptor && this.mappingWithType(objectDescriptor),
-                data = {};
+                data = {},
+                result;
+            
 
             if (mapping) {
-
                 Object.assign(data, this.snapshotForObject(object));
-
-                return mapping.mapObjectToCriteriaSourceForProperty(object, data, propertyName).then(function() {
+                result = mapping.mapObjectToCriteriaSourceForProperty(object, data, propertyName);
+                if (this._isAsync(result)) {
+                    return result.then(function() {
+                        Object.assign(data, self.snapshotForObject(object));
+                        return mapping.mapRawDataToObjectProperty(data, object, propertyName);
+                    });
+                } else {
                     Object.assign(data, self.snapshotForObject(object));
-                    return mapping.mapRawDataToObjectProperty(data, object, propertyName);
-                });
+                    result = mapping.mapRawDataToObjectProperty(data, object, propertyName);
+                    if (!this._isAsync(result)) {
+                        result = this.nullPromise;
+                    }
+                    return result;
+                }
             } else {
                 return this.nullPromise;
             }
-
-
-            //return mapping.
-            // (object,{}, propertyName);
-
         }
     },
 
@@ -1351,9 +1362,7 @@ exports.DataService = Montage.specialize(/** @lends DataService.prototype */ {
                     }
                 }
             }
-            // if (names.indexOf("geometryType")) {
-            //
-            // }
+
             // Return a promise that will be fulfilled only when all of the
             // requested data has been set on the object. If possible do this
             // without creating any additional promises.
@@ -1918,9 +1927,9 @@ exports.DataService = Montage.specialize(/** @lends DataService.prototype */ {
                 }
                 return mappingPromise.then(function () {
                         return self.saveRawData(record, object)
-                            .then(function () {
+                            .then(function (data) {
                                 self.rootService.createdDataObjects.delete(object);
-                                return null;
+                                return data;
                             });
                  });
             }

--- a/data/service/data-trigger.js
+++ b/data/service/data-trigger.js
@@ -526,10 +526,6 @@ Object.defineProperties(exports.DataTrigger, /** @lends DataTrigger */ {
                         }
                     });
                 }
-                    trigger = Object.create(this._getTriggerPrototype(service));
-                    trigger._objectPrototype = prototype;
-                    trigger._propertyName = name;
-                    trigger._isGlobal = descriptor.isGlobal;
 
             }
             return trigger;

--- a/data/service/data-trigger.js
+++ b/data/service/data-trigger.js
@@ -215,6 +215,7 @@ exports.DataTrigger.prototype = Object.create({}, /** @lends DataTrigger.prototy
             var prototype, descriptor, getter;
             // Start an asynchronous fetch of the property's value if necessary.
             this.getObjectProperty(object);
+            
             // Search the prototype chain for a getter for this property,
             // starting just after the prototype that called this method.
             prototype = Object.getPrototypeOf(this._objectPrototype);
@@ -408,12 +409,10 @@ Object.defineProperties(exports.DataTrigger, /** @lends DataTrigger */ {
                 propertyDescriptor, trigger, name, i;
 
             for (i = 0; (propertyDescriptor = propertyDescriptors[i]); i += 1) {
-                if (!requisitePropertyNames.has(propertyDescriptor.name)) {
-                    name = propertyDescriptor.name;
-                    trigger = this.addTrigger(service, objectDescriptor, prototype, name);
-                    if (trigger) {
-                        triggers[name] = trigger;
-                    }
+                name = propertyDescriptor.name;
+                trigger = this.addTrigger(service, objectDescriptor, prototype, name);
+                if (trigger) {
+                    triggers[name] = trigger;
                 }
             }
             return triggers;

--- a/data/service/expression-data-mapping.js
+++ b/data/service/expression-data-mapping.js
@@ -611,6 +611,8 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
                 propertyDescriptor = rule && rule.propertyDescriptor,
                 isRelationship = propertyDescriptor && propertyDescriptor.valueDescriptor,
                 result;
+
+
             if (isRelationship && rule.converter) {
                 this._prepareObjectToRawDataRule(rule);
                 result = this._revertRelationshipToRawData(data, propertyDescriptor, rule, scope);
@@ -642,7 +644,7 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
                 result, self;
 
             result = this.service.rootService.getObjectPropertyExpressions(object, requiredObjectProperties);
-            
+
             if (this._isAsync(result)) {
                 self = this;
                 result = result.then(function () {
@@ -683,9 +685,8 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
                         promises.push(result);
                     }
                 }
-
             }
-            return promises && promises.length && Promise.all(promises) || Promise.resolve(null);
+            return promises ? Promise.all(promises) : null;
         }
     },
     
@@ -794,7 +795,6 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
     },
 
     _isAsync: {
-
         value: function (object) {
             return object && object.then && typeof object.then === "function";
         }

--- a/data/service/expression-data-mapping.js
+++ b/data/service/expression-data-mapping.js
@@ -891,6 +891,20 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
         }
     },
 
+    _areRulesInitialized: {
+        value: false
+    },
+
+    _initializeRules: {
+        value: function () {
+            if (!this._areRulesInitialized) {
+                this._areRulesInitialized = true;
+                this._mapObjectMappingRules(this._rawOwnObjectMappingRules || {});
+                this._mapRawDataMappingRules(this._rawOwnRawDataMappingRules || {});
+            }
+        }
+    },
+
     _rawOwnObjectMappingRules: {
         value: undefined
     },
@@ -899,7 +913,7 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
         get: function () {
             if (!this.__ownObjectMappingRules) {
                 this.__ownObjectMappingRules = new Map();
-                this._mapObjectMappingRules(this._rawOwnObjectMappingRules || {});
+                this._initializeRules();
             }
             return this.__ownObjectMappingRules;
         }
@@ -926,7 +940,7 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
         get: function () {
             if (!this.__ownRawDataMappingRules) {
                 this.__ownRawDataMappingRules = new Map();
-                this._mapRawDataMappingRules(this._rawOwnRawDataMappingRules || {});
+                this._initializeRules();
             }
             return this.__ownRawDataMappingRules;
         }

--- a/data/service/expression-data-mapping.js
+++ b/data/service/expression-data-mapping.js
@@ -495,13 +495,24 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
 
     _revertRelationshipToRawData: {
         value: function (rawData, propertyDescriptor, rule, scope) {
+            var propertyName = propertyDescriptor.name,
+                self, result;
+
             if (!rule.converter.revert) {
                 console.log("Converter does not have a revert function for property (" + propertyDescriptor.name + ")");
             }
-            return rule.evaluate(scope).then(function (result) {
-                rawData[propertyDescriptor.name] = result;
-                return null;
-            });
+            result = rule.evaluate(scope);
+
+            if (this._isAsync(result)) {
+                self = this;
+                result.then(function (value) {
+                    rawData[propertyName] = result;
+                    return null;
+                });
+            } else {
+                rawData[propertyName] = result;
+            }
+            return result;
         }
     },
 

--- a/data/service/expression-data-mapping.js
+++ b/data/service/expression-data-mapping.js
@@ -583,7 +583,8 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
     },
 
     /**
-     * Maps the value of a single object property to raw data
+     * Maps the value of a single object property to raw data. Assumes that 
+     * the object property has been resolved
      *
      * @method
      * @argument {Object} object         - An object whose properties' values
@@ -592,14 +593,13 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
      * @argument {string} propertyName   - The name of the raw property to which
      *                                     to assign the values.
      */
-    mapObjectToRawDataProperty: {
+    _mapObjectToRawDataProperty: {
         value: function(object, data, propertyName) {
             var rule = this.rawDataMappingRules.get(propertyName),
                 scope = new Scope(object),
                 propertyDescriptor = rule && rule.propertyDescriptor,
                 isRelationship = propertyDescriptor && propertyDescriptor.valueDescriptor,
                 result;
-
             if (isRelationship && rule.converter) {
                 this._prepareObjectToRawDataRule(rule);
                 result = this._revertRelationshipToRawData(data, propertyDescriptor, rule, scope);
@@ -613,6 +613,37 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
         }
     },
 
+     /**
+     * Prefetches any object properties required to map the rawData property 
+     * and maps once the fetch is complete.
+     *
+     * @method
+     * @argument {Object} object         - An object whose properties' values
+     *                                     hold the model data.
+     * @argument {Object} data           - The object on which to assign the property
+     * @argument {string} propertyName   - The name of the raw property to which
+     *                                     to assign the values.
+     */
+    mapObjectToRawDataProperty: {
+        value: function (object, data, propertyName) {
+            var rule = this.rawDataMappingRules.get(propertyName),
+                requiredObjectProperties = rule ? rule.requirements : [],
+                result, self;
+
+            result = this.service.rootService.getObjectPropertyExpressions(object, requiredObjectProperties);
+            
+            if (this._isAsync(result)) {
+                self = this;
+                result = result.then(function () {
+                    return self._mapObjectToRawDataProperty(object, data, propertyName);
+                });
+            } else {
+                result = this._mapObjectToRawDataProperty(object, data, propertyName);
+            }
+            return result;
+        }
+    },
+    
     /**
      * Convert model object properties to the raw data properties present in the requirements
      * for a given propertyName
@@ -635,7 +666,7 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
 
             while ((key = keys.next().value)) {
                 if (rawRequirementsToMap.has(key)) {
-                    result = this._getAndMapObjectProperty(object, data, key, propertyName);
+                    result = this.mapObjectToRawDataProperty(object, data, key, propertyName);
                     if (this._isAsync(result)) {
                         promises = promises || [];
                         promises.push(result);
@@ -646,27 +677,7 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
             return promises && promises.length && Promise.all(promises) || Promise.resolve(null);
         }
     },
-
-    _getAndMapObjectProperty: {
-        value: function (object, data, propertyName) {
-            var rule = this.rawDataMappingRules.get(propertyName),
-                requiredObjectProperties = rule ? rule.requirements : [],
-                result, self;
-
-            result = this.service.rootService.getObjectPropertyExpressions(object, requiredObjectProperties);
-
-            if (this._isAsync(result)) {
-                self = this;
-                result = result.then(function () {
-                    return self.mapObjectToRawDataProperty(object, data, propertyName);
-                });
-            } else {
-                result = this.mapObjectToRawDataProperty(object, data, propertyName);
-            }
-            return result;
-        }
-    },
-
+    
     _prepareObjectToRawDataRule: {
         value: function (rule) {
             var converter = rule.converter,

--- a/data/service/expression-data-mapping.js
+++ b/data/service/expression-data-mapping.js
@@ -68,7 +68,7 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
             var value = deserializer.getProperty("objectDescriptor"),
                 self = this,
                 hasReferences = false,
-                result = null;
+                result = this;
             if (value instanceof ObjectDescriptorReference) {
                 this.objectDescriptorReference = value;
                 hasReferences = true;
@@ -95,25 +95,25 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
                 result = this.resolveReferences().then(function () {
                     value = deserializer.getProperty("objectMapping");
                     if (value) {
-                        self._mapObjectMappingRules(value.rules);
+                        self._rawOwnObjectMappingRules = value.rules;
                     }
                     value = deserializer.getProperty("rawDataMapping");
                     if (value) {
-                        self._mapRawDataMappingRules(value.rules);
+                        self._rawOwnRawDataMappingRules = value.rules;
                     }
                     return self;
                 });
             } else {
                 value = deserializer.getProperty("objectMapping");
                 if (value) {
-                    self._mapObjectMappingRules(value.rules);
+                    self._rawOwnObjectMappingRules = value.rules;
                 }
                 value = deserializer.getProperty("rawDataMapping");
                 if (value) {
-                    self._mapRawDataMappingRules(value.rules);
+                    self._rawOwnRawDataMappingRules = value.rules;
                 }
             }
-            return this;
+            return result;
         }
     },
 
@@ -869,10 +869,15 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
         }
     },
 
+    _rawOwnObjectMappingRules: {
+        value: undefined
+    },
+
     _ownObjectMappingRules: {
         get: function () {
             if (!this.__ownObjectMappingRules) {
                 this.__ownObjectMappingRules = new Map();
+                this._mapObjectMappingRules(this._rawOwnObjectMappingRules || {});
             }
             return this.__ownObjectMappingRules;
         }
@@ -891,11 +896,15 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
         }
     },
 
+    _rawOwnRawDataMappingRules: {
+        value: undefined
+    },
 
     _ownRawDataMappingRules: {
         get: function () {
             if (!this.__ownRawDataMappingRules) {
                 this.__ownRawDataMappingRules = new Map();
+                this._mapRawDataMappingRules(this._rawOwnRawDataMappingRules || {});
             }
             return this.__ownRawDataMappingRules;
         }

--- a/test/spec/data/logic/model/movie.js
+++ b/test/spec/data/logic/model/movie.js
@@ -6,6 +6,14 @@ var Montage = require("montage").Montage;
  */
 exports.Movie = Montage.specialize({
 
+    category: {
+        value: undefined
+    },
+
+    id: {
+        value: undefined
+    },
+
     /**
      * @type {boolean}
      */

--- a/test/spec/data/logic/service/category-service.js
+++ b/test/spec/data/logic/service/category-service.js
@@ -8,7 +8,6 @@ exports.CategoryService = RawDataService.specialize(/** @lends CategoryService.p
             var categoryId = stream.query.criteria.parameters.categoryID || -1,
                 isValidCategory = categoryId > 0 && CategoryNames.length >= categoryId,
                 categoryName = isValidCategory && CategoryNames[categoryId - 1] || "Unknown";
-            
             this.addRawData(stream, [{
                 name: categoryName
             }]);

--- a/test/spec/data/logic/service/movie-service.js
+++ b/test/spec/data/logic/service/movie-service.js
@@ -1,0 +1,12 @@
+var RawDataService = require("montage/data/service/raw-data-service").RawDataService,
+    CategoryNames = ["Action"];
+
+exports.MovieService = RawDataService.specialize(/** @lends MovieService.prototype */ {
+
+    saveRawData: {
+        value: function (record, object) {
+            return Promise.resolve(record);
+        }
+    }
+
+});

--- a/test/spec/data/logic/service/movie-service.mjson
+++ b/test/spec/data/logic/service/movie-service.mjson
@@ -9,7 +9,7 @@
     },
 
     "root": {
-        "prototype": "montage/data/service/raw-data-service",
+        "prototype": "spec/data/logic/service/movie-service",
         "properties": {
             "name": "RawDataService",
             "types": [

--- a/test/spec/data/logic/service/plot-summary-service.js
+++ b/test/spec/data/logic/service/plot-summary-service.js
@@ -7,7 +7,7 @@ exports.PlotSummaryService = RawDataService.specialize(/** @lends PlotSummarySer
             this.addRawData(stream, [{
                 summary: exports.PlotSummaryService.STAR_WARS_PLOT_SUMMARY
             }]);
-            stream.dataDone();
+            this.rawDataDone(stream);
         }
     }
 


### PR DESCRIPTION
PR addresses 3 issues.

**1. Reinstate lazy creation of mapping rules**
Rule creation was switched to be eager in an attempt to remove the raw serialization data from the `ExpressionDataMapping` object. (Lazy creation requires that the raw rules be stored on the object until we are ready to create the "cooked" rules).  
Unfortunately, rule creation requires that `ExpressionDataMapping.objectDescriptor` is fully deserialized. That is not the case when we do rule creation eagerly so back to lazy creation!

**2. Ensure model properties needed in rawData are fetched before mapping**
Given the following constraints: 
- Foo objects have 2 relationships, `bar` and `baz`, neither is prefetched.
- rawFoo.bar is required as a part of a PUT/POST to the remote foo service.

And the following actions.
1. Foo.baz is updated in the application. 
2. User triggers a save.  

Foo.bar is not yet on the model object so we cannot map it to rawFoo.bar in `mapObjectToRawData(object, rawData)`. 

This commit adds logic in `mapObjectToRawDataProperty()` to ensure that any model property required to build the rawData is fetched before the mapping occurs. 

**3. Add support for synchronous reversion of relationships**
Add support for a synchronous converter to map a relationship from object-to-raw-data.

