### PR TITLE
Fix assignment of listeners and other units on value elements

### DIFF
--- a/test/all.js
+++ b/test/all.js
@@ -82,7 +82,7 @@ module.exports = require("montage-testing").run(require, [
     {name: "spec/serialization/montage-serializer-spec"},
     {name: "spec/serialization/montage-serializer-element-spec", node: false},
     { name: "spec/serialization/montage-deserializer-spec", node: false },
-    { name: "spec/serialization/montage-deserializer-element-spec", node: false, karma: false},
+    { name: "spec/serialization/montage-deserializer-element-spec", node: false },
     // Trigger
     {name: "spec/trigger/trigger-spec", node: false},
     // UI

--- a/test/spec/serialization/montage-deserializer-element-spec.js
+++ b/test/spec/serialization/montage-deserializer-element-spec.js
@@ -66,8 +66,18 @@ describe("serialization/montage-deserializer-element-spec", function () {
             deserializer.init(serializationString, require);
 
             deserializer.deserialize(null, rootEl).then(function (objects) {
+                expect(defaultEventManager._registeredBubbleEventListeners.has("click")).toBe(true);
                 var registeredEventListeners = defaultEventManager._registeredBubbleEventListeners.get("click");
-                expect(registeredEventListeners.get(rootEl.firstElementChild) === objects.rootEl).toBe(true);
+                var proxyElement = registeredEventListeners.keysArray()[0];
+                return new Promise(function (resolve) {
+                    expect(proxyElement).toBeTruthy();
+                    objects.rootEl.addEventListener("action", function () {
+                        resolve();
+                    });
+                    proxyElement.dispatchEvent.call(proxyElement, new CustomEvent("action"));
+                }).timeout(500);
+            }).catch(function (err) {
+                fail(err);
             }).finally(function () {
                 done();
             });
@@ -86,7 +96,7 @@ describe("serialization/montage-deserializer-element-spec", function () {
                 }
             },
                 serializationString = JSON.stringify(serialization);
-            
+
             rootEl.innerHTML = '<div data-montage-id="id">content</div>';
             deserializer.init(serializationString, require);
 


### PR DESCRIPTION
Fixes #1933.

Also makes native element methods like `dispatchEvent` callable on element proxies. This didn't work before because the `this` would point to the proxy instead of the element and would be rejected by the native method.