### PR TITLE
Add default buildIn & buildOut CSS to succession

### DIFF
--- a/ui/succession.reel/succession.js
+++ b/ui/succession.reel/succession.js
@@ -15,11 +15,17 @@ var Component = require("ui/component").Component;
 exports.Succession = Component.specialize(/** @lends Succession.prototype */{
 
     contentBuildInAnimation: {
-        value: undefined
+        value: {
+            fromCssClass: "montage-Succession--buildInFrom",
+            cssClass: "montage-Succession--buildIn"
+        }
     },
 
     contentBuildOutAnimation: {
-        value: undefined
+        value: {
+            cssClass: "montage-Succession--buildOut",
+            toCssClass: "montage-Succession--buildOutTo"
+        }
     },
 
     /**


### PR DESCRIPTION
Add default values to `succession.contentBuildInAnimation` and `succession.contentBuildInAnimation` to help facilitate animation.