### PR TITLE
Remove duplicate trigger creation

### DIFF
--- a/data/service/data-trigger.js
+++ b/data/service/data-trigger.js
@@ -527,11 +527,6 @@ Object.defineProperties(exports.DataTrigger, /** @lends DataTrigger */ {
                         }
                     });
                 }
-                    trigger = Object.create(this._getTriggerPrototype(service));
-                    trigger._objectPrototype = prototype;
-                    trigger._propertyName = name;
-                    trigger._isGlobal = descriptor.isGlobal;
-
             }
             return trigger;
         }


### PR DESCRIPTION
This removes a typo that creates a duplicate trigger for every property passed into `DataTrigger._addTrigger()`