### PR TITLE
DataTrigger does not respect serializable attribute

### DIFF
--- a/data/service/data-trigger.js
+++ b/data/service/data-trigger.js
@@ -494,6 +494,7 @@ Object.defineProperties(exports.DataTrigger, /** @lends DataTrigger */ {
     _addTrigger: {
         value: function (service, objectDescriptor, prototype, name) {
             var descriptor = objectDescriptor.propertyDescriptorForName(name),
+                serializable = Montage.getPropertyAttribute(prototype, name, "serializable"),
                 trigger;
             if (descriptor) {
                 trigger = Object.create(this._getTriggerPrototype(service));
@@ -515,6 +516,7 @@ Object.defineProperties(exports.DataTrigger, /** @lends DataTrigger */ {
                         }
                     });
                 } else {
+                    console.log("Serializable", name, serializable);
                     Montage.defineProperty(prototype, name, {
                         get: function () {
                             return trigger._getValue(this);

--- a/test/spec/data/data-trigger.js
+++ b/test/spec/data/data-trigger.js
@@ -1,0 +1,72 @@
+var DataOperation = require("montage/data/service/data-operation").DataOperation,
+    DataTrigger = require("montage/data/service/data-trigger").DataTrigger,
+    DataService = require("montage/data/service/data-service").DataService,
+    DataOperationType = require("montage/data/service/data-operation-type").DataOperationType,
+    Deserializer = require("montage/core/serialization/deserializer/montage-deserializer").MontageDeserializer,
+    deserialize = require("montage/core/serialization/deserializer/montage-deserializer").deserialize,
+    Serializer = require("montage/core/serialization/serializer/montage-serializer").MontageSerializer,
+    serialize = require("montage/core/serialization/serializer/montage-serializer").serialize,
+    Montage = require("montage").Montage,
+    ObjectDescriptor = require("montage/core/meta/object-descriptor").ObjectDescriptor,
+    PropertyDescriptor = require("montage/core/meta/property-descriptor").PropertyDescriptor;
+
+
+
+var ModelObject = Montage.specialize({
+
+    children: {
+        get: function () {
+            if (!this._children) {
+                this._children = [];
+            }
+            return this._children;
+        },
+        serializable: false
+    },
+
+    ancestors: {
+        get: function () {
+            if (!this._ancestors) {
+                this._ancestors = [];
+            }
+            return this._ancestors;
+        }
+    }
+});
+
+var ModelDescriptor = new ObjectDescriptor().initWithName("ModelObject");
+ModelDescriptor.addPropertyDescriptor(new PropertyDescriptor().initWithNameObjectDescriptorAndCardinality("children", ModelDescriptor, 1));
+ModelDescriptor.addPropertyDescriptor(new PropertyDescriptor().initWithNameObjectDescriptorAndCardinality("ancestors", ModelDescriptor, 1));
+
+describe("A DataTrigger", function() {
+    
+    it("can respect serializable property", function () {
+        // Mimics DataService#_prototypeForType
+        var prototype = Object.create(ModelObject.prototype),
+            requisites = new Set("children", "ancestors"),
+            service = new DataService(),
+            cleanInstanceObjectCreate, cleanObjectCreatePropertyNames,
+            cleanInstanceConstructor, cleanInstancePropertyNames,
+            triggerInstance, triggerPropertyNames,
+            propertyNames;
+    
+        DataTrigger.addTriggers(service, ModelDescriptor, prototype, requisites);
+
+        triggerInstance = Object.create(prototype);
+        cleanInstanceObjectCreate = Object.create(ModelObject.prototype),
+        cleanInstanceConstructor = new ModelObject();
+
+        triggerPropertyNames = Montage.getSerializablePropertyNames(triggerInstance);
+        console.log("Triggered", propertyNames);
+
+        cleanObjectCreatePropertyNames = Montage.getSerializablePropertyNames(cleanInstanceObjectCreate);        
+        console.log("Object.create", propertyNames);
+
+        cleanInstancePropertyNames = Montage.getSerializablePropertyNames(cleanInstanceConstructor);        
+        console.log("Constructor", propertyNames);
+        expect(triggerPropertyNames).toEqual(["children", "ancestors", "identifier"]);
+        expect(triggerPropertyNames).toEqual(cleanObjectCreatePropertyNames);
+        expect(cleanObjectCreatePropertyNames).toEqual(cleanInstancePropertyNames);
+    });
+
+});


### PR DESCRIPTION
`DataTrigger.addTrigger()` overrides the getter and setter for a property on a prototype to route that property through montage-data. However, `addTrigger()` does not include the `serializable` attribute for that property as defined in the model. 

This means that if a prototype declares a property as not serializable: 
```
var MyClass = Montage.specialize({
   children: {
       value: undefined,
       writable: false
   }
});
```
A serialized instance of that class will not include `children`. This is expected.
However, if DataTrigger.addTriggers() is called on the prototype and then we use the result to create an instance. That serialized instance will include `children`.
```javascript
var myClassA = new MyClass();
var myClassB = Object.create(MyClass.prototype);


// Add triggers using the DataService, ObjectDescriptor, and Prototype
// This is the prototype that the DataService will cache and use to create instances
var montageDataPrototype = Object.create(MyClass.prototype);

DataTriggers.addTriggers(aService, objectDescriptor, montageDataPrototype) 
var myClassC = Object.create(montageDataPrototype); 

var serializedA = serializer.serializeObject(myClassA); //No children
var serializedB = serializer.serializeObject(myClassB); //No children

var serializedC = serializer.serializeObject(myClassC); //Has children
```