### PR TITLE
Fix minor montage-data bugs

### DIFF
--- a/core/meta/property-descriptor.js
+++ b/core/meta/property-descriptor.js
@@ -11,6 +11,7 @@ var Defaults = {
     mandatory: false,
     readOnly: false,
     denyDelete: false,
+    inversePropertyName: void 0,
     valueType: "string",
     collectionValueType: "list",
     valueObjectPrototypeName: "",
@@ -110,6 +111,7 @@ exports.PropertyDescriptor = Montage.specialize( /** @lends PropertyDescriptor# 
             this._setPropertyWithDefaults(serializer, "defaultValue", this.defaultValue);
             this._setPropertyWithDefaults(serializer, "helpKey", this.helpKey);
             this._setPropertyWithDefaults(serializer, "definition", this.definition);
+            this._setPropertyWithDefaults(serializer, "inversePropertyName", this.inversePropertyName);
 
         }
     },
@@ -144,6 +146,7 @@ exports.PropertyDescriptor = Montage.specialize( /** @lends PropertyDescriptor# 
             this._overridePropertyWithDefaults(deserializer, "defaultValue");
             this._overridePropertyWithDefaults(deserializer, "helpKey");
             this._overridePropertyWithDefaults(deserializer, "definition");
+            this._overridePropertyWithDefaults(deserializer, "inversePropertyName");
         }
     },
 
@@ -424,6 +427,21 @@ exports.PropertyDescriptor = Montage.specialize( /** @lends PropertyDescriptor# 
         value: true
     },
 
+    /**
+     * Property name on the object on the opposite side of the relationship
+     * to which the value of this property should be assigned.
+     * 
+     * For example, take the following relationship: 
+     * 
+     * Foo.bars <------->> Bar.foo
+     * 
+     * Each Bar object in Foo.bars will have Foo assigned to it's Bar.foo property. Therefore, 
+     * the inversePropertyName on the 'bars' propertyDescriptor would be 'foo'. 
+     */
+    inversePropertyName: {
+        value: undefined
+    },
+
     /********************************************************
      * Deprecated functions
      */
@@ -451,6 +469,9 @@ exports.PropertyDescriptor = Montage.specialize( /** @lends PropertyDescriptor# 
     },
 
     blueprintDescriptorModuleId: require("../core")._objectDescriptorModuleIdDescriptor,
-    blueprint: require("../core")._objectDescriptorDescriptor
+    blueprint: require("../core")._objectDescriptorDescriptor,
+
+
+    
 
 });

--- a/data/service/data-service.js
+++ b/data/service/data-service.js
@@ -87,6 +87,11 @@ exports.DataService = Montage.specialize(/** @lends DataService.prototype */ {
                 this.delegate = value;
             }
 
+            value = deserializer.getProperty("isUniquing");
+            if (value !== undefined) {
+                this.isUniquing = value;
+            }
+            
             return result;
         }
     },

--- a/data/service/data-service.js
+++ b/data/service/data-service.js
@@ -1295,8 +1295,8 @@ exports.DataService = Montage.specialize(/** @lends DataService.prototype */ {
 
             // Check if property is included in debugProperties. Intended for debugging
             if (debug) {
-                console.log("DataService.fetchObjectProperty", object, propertyName);
-                console.log("To debug DataService.mapRawDataToObjectProperty for " + propertyName + ", place a breakpoint at this line in your browser's developer tools.");
+                console.debug("DataService.fetchObjectProperty", object, propertyName);
+                console.debug("To debug ExpressionDataMapping.mapRawDataToObjectProperty for " + propertyName + ", set a breakpoint here.");
             }
 
             return  useDelegate ?                       this.fetchRawObjectProperty(object, propertyName) :

--- a/data/service/data-service.js
+++ b/data/service/data-service.js
@@ -56,7 +56,7 @@ exports.DataService = Montage.specialize(/** @lends DataService.prototype */ {
     deserializeSelf: {
         value:function (deserializer) {
             var self = this,
-                result = null,
+                result = this,
                 value;
 
             value = deserializer.getProperty("childServices");
@@ -1037,12 +1037,13 @@ exports.DataService = Montage.specialize(/** @lends DataService.prototype */ {
     },
 
     _dataObjectPrototypes: {
-        get: function () {
-            if (!this.__dataObjectPrototypes){
-                this.__dataObjectPrototypes = new Map();
-            }
-            return this.__dataObjectPrototypes;
-        }
+        // get: function () {
+        //     if (!this.__dataObjectPrototypes){
+        //         this.__dataObjectPrototypes = new Map();
+        //     }
+        //     return this.__dataObjectPrototypes;
+        // },
+        value: new Map()
     },
 
     __dataObjectPrototypes: {
@@ -1755,6 +1756,7 @@ exports.DataService = Montage.specialize(/** @lends DataService.prototype */ {
 
             // make sure type is an object descriptor or a data object descriptor.
             query.type = this._objectDescriptorForType(query.type);
+
             // Set up the stream.
             stream = stream || new DataStream();
             stream.query = query;

--- a/data/service/data-service.js
+++ b/data/service/data-service.js
@@ -1290,18 +1290,13 @@ exports.DataService = Montage.specialize(/** @lends DataService.prototype */ {
                 delegateFunction = !useDelegate && isHandler && this._delegateFunctionForPropertyName(propertyName),
                 propertyDescriptor = !useDelegate && !delegateFunction && isHandler && this._propertyDescriptorForObjectAndName(object, propertyName),
                 childService = !isHandler && this._getChildServiceForObject(object),
-                debug = exports.DataService.debugProperties.has(propertyName),
-                trace = debug || exports.DataService.traceProperties.has(propertyName);
+                debug = exports.DataService.debugProperties.has(propertyName);
 
 
-            // Check if property is included in the traceProperties or debugProperties 
-            // collections. Intended for debugging
-            if (trace) {
-                console.log("DataService.fetchObjectProperty", object, propertyName);
-            }
-            
+            // Check if property is included in debugProperties. Intended for debugging
             if (debug) {
-                debugger; // jshint ignore:line
+                console.log("DataService.fetchObjectProperty", object, propertyName);
+                console.log("To debug DataService.mapRawDataToObjectProperty for " + propertyName + ", place a breakpoint at this line in your browser's developer tools.");
             }
 
             return  useDelegate ?                       this.fetchRawObjectProperty(object, propertyName) :
@@ -2582,10 +2577,6 @@ exports.DataService = Montage.specialize(/** @lends DataService.prototype */ {
 
      debugProperties: {
          value: new Set()
-     },
-
-     traceProperties: {
-        value: new Set()
-    }
+     }
 
 });

--- a/data/service/data-service.js
+++ b/data/service/data-service.js
@@ -1293,11 +1293,15 @@ exports.DataService = Montage.specialize(/** @lends DataService.prototype */ {
                 debug = exports.DataService.debugProperties.has(propertyName),
                 trace = debug || exports.DataService.traceProperties.has(propertyName);
 
+
+            // Check if property is included in the traceProperties or debugProperties 
+            // collections. Intended for debugging
             if (trace) {
                 console.log("DataService.fetchObjectProperty", object, propertyName);
             }
+            
             if (debug) {
-                debugger;
+                debugger; // jshint ignore:line
             }
 
             return  useDelegate ?                       this.fetchRawObjectProperty(object, propertyName) :

--- a/data/service/data-service.js
+++ b/data/service/data-service.js
@@ -1288,7 +1288,16 @@ exports.DataService = Montage.specialize(/** @lends DataService.prototype */ {
                 useDelegate = isHandler && typeof this.fetchRawObjectProperty === "function",
                 delegateFunction = !useDelegate && isHandler && this._delegateFunctionForPropertyName(propertyName),
                 propertyDescriptor = !useDelegate && !delegateFunction && isHandler && this._propertyDescriptorForObjectAndName(object, propertyName),
-                childService = !isHandler && this._getChildServiceForObject(object);
+                childService = !isHandler && this._getChildServiceForObject(object),
+                debug = exports.DataService.debugProperties.has(propertyName),
+                trace = debug || exports.DataService.traceProperties.has(propertyName);
+
+            if (trace) {
+                console.log("DataService.fetchObjectProperty", object, propertyName);
+            }
+            if (debug) {
+                debugger;
+            }
 
             return  useDelegate ?                       this.fetchRawObjectProperty(object, propertyName) :
                     delegateFunction ?                  delegateFunction.call(this, object) :
@@ -2538,6 +2547,19 @@ exports.DataService = Montage.specialize(/** @lends DataService.prototype */ {
 
     authorizationManager: {
         value: AuthorizationManager
+    },
+
+
+    /***************************************************************************
+     * Debugging
+     */
+
+     debugProperties: {
+         value: new Set()
+     },
+
+     traceProperties: {
+        value: new Set()
     }
 
 });

--- a/data/service/data-service.js
+++ b/data/service/data-service.js
@@ -1929,6 +1929,26 @@ exports.DataService = Montage.specialize(/** @lends DataService.prototype */ {
     },
 
     /**
+     * Resets an object to the last value in the snapshot.
+     * @method
+     * @argument {Object} object - The object who will be reset.
+     * @returns {external:Promise} - A promise fulfilled when the object has
+     * been mapped back to its last known state.
+     */
+    resetDataObject: {
+        value: function (object) {
+            var service = this._getChildServiceForObject(object),
+                promise;
+
+            if (service) {
+                promise = service.resetDataObject(object);
+            }
+
+            return promise;
+        }
+    },
+    
+    /**
      * Save changes made to a data object.
      *
      * @method

--- a/data/service/data-stream.js
+++ b/data/service/data-stream.js
@@ -357,6 +357,16 @@ exports.DataStream = DataProvider.specialize(/** @lends DataStream.prototype */ 
             stream.query = selector;
             return stream;
         }
+    },
+
+    withTypeOrQuery: {
+        value: function (typeOrQuery) {
+            var type = typeOrQuery instanceof DataObjectDescriptor && typeOrQuery,
+                query = type && DataQuery.withTypeAndCriteria(type) || typeOrQuery,
+                stream = new this();
+            stream.query = query;
+            return stream;
+        }
     }
 
 });

--- a/data/service/data-stream.js
+++ b/data/service/data-stream.js
@@ -1,6 +1,6 @@
 // Note: Montage's promises are used even if ECMAScript 6 promises are available.
 var DataProvider = require("data/service/data-provider").DataProvider,
-    DataObjectDescriptor = require("data/model/data-object-descriptor").DataObjectDescriptor,
+    ObjectDescriptor = require("core/meta/object-descriptor").ObjectDescriptor,
     DataQuery = require("data/model/data-query").DataQuery,
     Promise = require("core/promise").Promise,
     deprecate = require("core/deprecate"),
@@ -346,22 +346,16 @@ exports.DataStream = DataProvider.specialize(/** @lends DataStream.prototype */ 
 
 }, /** @lends DataStream */ {
 
-    /**
-     * @todo Document.
-     */
     withTypeOrSelector: {
-        value: function (typeOrSelector) {
-            var type = typeOrSelector instanceof DataObjectDescriptor && typeOrSelector,
-                selector = type && DataQuery.withTypeAndCriteria(type) || typeOrSelector,
-                stream = new this();
-            stream.query = selector;
-            return stream;
-        }
+        // value: deprecate.deprecateMethod(scope, deprecatedFunction, name, alternative, once)
+        value: deprecate.deprecateMethod(exports.DataStream, function (typeOrSelector) {
+            return this.withTypeOrQuery(typeOrSelector);
+        }, "withTypeOrSelector", "withTypeOrQuery", true)
     },
 
     withTypeOrQuery: {
         value: function (typeOrQuery) {
-            var type = typeOrQuery instanceof DataObjectDescriptor && typeOrQuery,
+            var type = typeOrQuery instanceof ObjectDescriptor && typeOrQuery,
                 query = type && DataQuery.withTypeAndCriteria(type) || typeOrQuery,
                 stream = new this();
             stream.query = query;

--- a/data/service/expression-data-mapping.js
+++ b/data/service/expression-data-mapping.js
@@ -1,6 +1,7 @@
 var DataMapping = require("./data-mapping").DataMapping,
     assign = require("frb/assign"),
     compile = require("frb/compile-evaluator"),
+    DataService = require("data/service/data-service").DataService,
     ObjectDescriptorReference = require("core/meta/object-descriptor-reference").ObjectDescriptorReference,
     parse = require("frb/parse"),
     Map = require("collections/map"),
@@ -452,7 +453,16 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
                 propertyDescriptor = rule && this.objectDescriptor.propertyDescriptorForName(propertyName),
                 isRelationship = propertyDescriptor && !propertyDescriptor.definition && propertyDescriptor.valueDescriptor,
                 isDerived = propertyDescriptor && !!propertyDescriptor.definition,
-                scope = this._scope;
+                scope = this._scope,
+                debug = DataService.debugProperties.has(propertyName),
+                trace = DataService.traceProperties.has(propertyName);
+
+            if (trace) {
+                console.log("DataService.fetchObjectProperty", object, propertyName);
+            }
+            if (debug) {
+                debugger;
+            }
 
             scope.value = data;
 

--- a/data/service/expression-data-mapping.js
+++ b/data/service/expression-data-mapping.js
@@ -475,7 +475,7 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
             }).then(function () {
                 self._setObjectValueForPropertyDescriptor(object, data, propertyDescriptor);
                 return null;
-            });ƒ
+            });
         }
     },
 

--- a/data/service/expression-data-mapping.js
+++ b/data/service/expression-data-mapping.js
@@ -467,7 +467,7 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
     _resolveRelationship: {
         value: function (object, propertyDescriptor, rule, scope) {
             var self = this,
-                hasInverse = !!rule.inversePropertyName,
+                hasInverse = !!propertyDescriptor.inversePropertyName || !!rule.inversePropertyName,
                 data;
             return rule.evaluate(scope).then(function (result) {
                 data = result;
@@ -475,15 +475,17 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
             }).then(function () {
                 self._setObjectValueForPropertyDescriptor(object, data, propertyDescriptor);
                 return null;
-            });
+            });ƒ
         }
     },
 
     _assignInversePropertyValue: {
         value: function (data, object, propertyDescriptor, rule) {
-            var self = this;
+            var self = this,
+                inversePropertyName = propertyDescriptor.inversePropertyName || rule.inversePropertyName;
+
             return propertyDescriptor.valueDescriptor.then(function (objectDescriptor) {
-                var inversePropertyDescriptor = objectDescriptor.propertyDescriptorForName(rule.inversePropertyName);
+                var inversePropertyDescriptor = objectDescriptor.propertyDescriptorForName(inversePropertyName);
                 
                 if (data) {
                     self._setObjectsValueForPropertyDescriptor(data, object, inversePropertyDescriptor);
@@ -826,20 +828,6 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
             }
         }
     },
-
-    _assignObjectAsInverseProperty: {
-        value: function (object, valueDescriptor, data, inversePropertyName) {
-            var inversePropertyDescriptor = valueDescriptor.propertyDescriptorForName(inversePropertyName),
-                i, n;
-
-            if (inversePropertyDescriptor.cardinality === 1) {
-                for (i = 0, n = data ? data.length : 0; i < n; ++i) {
-                    data[i][inversePropertyName] = object;
-                }
-            }
-        }
-    },
-
     /***************************************************************************
      * Rules
      */

--- a/data/service/expression-data-mapping.js
+++ b/data/service/expression-data-mapping.js
@@ -461,8 +461,8 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
 
             // Check if property is included in the DataService.debugProperties collection. Intended for debugging.
             if (debug) {
-                console.log("ExpressionDataMapping.mapRawDataToObjectProperty", object, propertyName);
-                console.log("To debug ExpressionDataMapping.mapRawDataToObjectProperty for " + propertyName + ", place a breakpoint at this line in your browser's developer tools.");
+                console.debug("ExpressionDataMapping.mapRawDataToObjectProperty", object, propertyName);
+                console.debug("To debug ExpressionDataMapping.mapRawDataToObjectProperty for " + propertyName + ", set a breakpoint here.");
             }
 
             scope.value = data;

--- a/data/service/expression-data-mapping.js
+++ b/data/service/expression-data-mapping.js
@@ -457,11 +457,14 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
                 debug = DataService.debugProperties.has(propertyName),
                 trace = DataService.traceProperties.has(propertyName);
 
+
+            // Check if property is included in the DataService.traceProperties or 
+            // DataService.debugProperties collections. Intended for debugging
             if (trace) {
                 console.log("DataService.fetchObjectProperty", object, propertyName);
             }
             if (debug) {
-                debugger;
+                debugger; // jshint ignore:line
             }
 
             scope.value = data;

--- a/data/service/expression-data-mapping.js
+++ b/data/service/expression-data-mapping.js
@@ -358,7 +358,9 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
         },
         set: function (value) {
             this._schemaDescriptor = value;
-            this._schemaDescriptorReference = new ObjectDescriptorReference().initWithValue(value);
+            if (value) {
+                this._schemaDescriptorReference = new ObjectDescriptorReference().initWithValue(value);
+            }
         }
     },
 

--- a/data/service/expression-data-mapping.js
+++ b/data/service/expression-data-mapping.js
@@ -631,7 +631,7 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
             if (isRelationship && rule.converter) {
                 this._prepareObjectToRawDataRule(rule);
                 result = this._revertRelationshipToRawData(data, propertyDescriptor, rule, scope);
-            } else if (rule.converter) {
+            } else if (rule.converter || rule.reverter) {
                 result = this._revertPropertyToRawData(data, propertyName, rule, scope);
             } else /*if (propertyDescriptor)*/ { //relaxing this for now
                 data[propertyName] = rule.expression(scope);
@@ -1029,8 +1029,19 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
                 rule = MappingRule.withRawRuleAndPropertyName(rawRule, propertyName, addOneWayBindings);
 
             rule.propertyDescriptor = propertyDescriptor;
-            rule.converter = rawRule.converter || this._defaultConverter(rule.sourcePath, rule.targetPath, isObjectMappingRule);
-            rule.isReverter = !addOneWayBindings;
+            if (rawRule.converter && addOneWayBindings) {
+                rule.converter = rawRule.converter;
+            } else if (rawRule.converter && !addOneWayBindings) {
+                rule.reverter = rawRule.converter;
+            } else if (rawRule.reverter && addOneWayBindings) {
+                rule.reverter = rawRule.reverter;
+            } else if (rawRule.reverter && !addOneWayBindings) {
+                rule.converter = rawRule.reverter;
+            } else if (addOneWayBindings) {
+                rule.converter = this._defaultConverter(rule.sourcePath, rule.targetPath, isObjectMappingRule);
+            } else {
+                rule.reverter = this._defaultConverter(rule.sourcePath, rule.targetPath, isObjectMappingRule);
+            }
             return rule;
         }
     },

--- a/data/service/expression-data-mapping.js
+++ b/data/service/expression-data-mapping.js
@@ -456,17 +456,13 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
                 isRelationship = propertyDescriptor && !propertyDescriptor.definition && propertyDescriptor.valueDescriptor,
                 isDerived = propertyDescriptor && !!propertyDescriptor.definition,
                 scope = this._scope,
-                debug = DataService.debugProperties.has(propertyName),
-                trace = DataService.traceProperties.has(propertyName);
+                debug = DataService.debugProperties.has(propertyName);
 
 
-            // Check if property is included in the DataService.traceProperties or 
-            // DataService.debugProperties collections. Intended for debugging
-            if (trace) {
-                console.log("DataService.fetchObjectProperty", object, propertyName);
-            }
+            // Check if property is included in the DataService.debugProperties collection. Intended for debugging.
             if (debug) {
-                debugger; // jshint ignore:line
+                console.log("ExpressionDataMapping.mapRawDataToObjectProperty", object, propertyName);
+                console.log("To debug ExpressionDataMapping.mapRawDataToObjectProperty for " + propertyName + ", place a breakpoint at this line in your browser's developer tools.");
             }
 
             scope.value = data;

--- a/data/service/mapping-rule.js
+++ b/data/service/mapping-rule.js
@@ -1,6 +1,7 @@
 var Montage = require("montage").Montage,
     compile = require("frb/compile-evaluator"),
-    parse = require("frb/parse");
+    parse = require("frb/parse"),
+    deprecate = require("core/deprecate");
 
 
 var ONE_WAY_BINDING = "<-";
@@ -45,8 +46,18 @@ exports.MappingRule = Montage.specialize(/** @lends MappingRule.prototype */ {
      *
      * @type {string}
      */
-    inversePropertyName: {
+    
+    _inversePropertyName: {
         value: undefined
+    },
+
+    inversePropertyName: {
+        get: deprecate.deprecateMethod(void 0, function () {
+            return this._inversePropertyName;
+        }, "MappingRule.inversePropertyName", "PropertyDescriptor.inversePropertyName", true),
+        set: deprecate.deprecateMethod(void 0, function (value) {
+            this._inversePropertyName = value;
+        }, "MappingRule.inversePropertyName", "PropertyDescriptor.inversePropertyName", true)
     },
 
 

--- a/data/service/mapping-rule.js
+++ b/data/service/mapping-rule.js
@@ -62,17 +62,6 @@ exports.MappingRule = Montage.specialize(/** @lends MappingRule.prototype */ {
 
 
     /**
-     * Flag defining the direction of the conversion. If true, .expression
-     * will be evaluated in reverse (evaluate the expression against the
-     * destination & assign it to the source).
-     * @type {boolean}
-     */
-    isReverter: {
-        value: undefined
-    },
-
-
-    /**
      * The descriptor for the property that this rule applies to
      * @type {PropertyDescriptor}
      */
@@ -97,6 +86,17 @@ exports.MappingRule = Montage.specialize(/** @lends MappingRule.prototype */ {
             }
             return this._requirements;
         }
+    },
+
+    /**
+     * A converter that takes in the the output of #expression and returns the destination value.
+     * When a reverter is specified the conversion use the revert method when mapping from
+     * right to left.
+     * 
+     * @type {Converter}
+     */
+    reverter: {
+        value: undefined
     },
 
     _parseRequirementsFromSyntax: {
@@ -180,9 +180,9 @@ exports.MappingRule = Montage.specialize(/** @lends MappingRule.prototype */ {
     evaluate: {
         value: function (scope) {
             var value = this.expression(scope);
-            return this.converter ? this.isReverter ?
-                                    this.converter.revert(value) :
-                                    this.converter.convert(value) :
+            return this.converter ? this.converter.convert(value) :
+                                    this.reverter ? 
+                                    this.reverter.revert(value) :
                                     value;
         }
     },

--- a/data/service/raw-data-service.js
+++ b/data/service/raw-data-service.js
@@ -305,6 +305,24 @@ exports.RawDataService = DataService.specialize(/** @lends RawDataService.protot
     },
 
     /**
+     *
+     * Resets the object to its last known state.
+     *
+     * @method
+     * @argument {Object} object   - The object to reset.
+     * @returns {external:Promise} - A promise fulfilled when the object has
+     * been reset to its last known state.
+     *
+     */
+    resetDataObject: {
+        value: function (object) {
+            var snapshot = this.snapshotForObject(object),
+                result = this._mapRawDataToObject(snapshot, object);
+            return result || Promise.resolve(object);
+        }
+    },
+
+    /**
      * Subclasses should override this method to save a data object when that
      * object's raw data would be useful to perform the save.
      *

--- a/test/spec/data/data-stream.js
+++ b/test/spec/data/data-stream.js
@@ -1,5 +1,7 @@
 var DataStream = require("montage/data/service/data-stream").DataStream,
-    Montage = require("montage").Montage;
+    DataQuery = require("montage/data/model/data-query").DataQuery,
+    Montage = require("montage").Montage,
+    ObjectDescriptor = require("montage/core/meta/object-descriptor").ObjectDescriptor;
 
 describe("A DataStream", function() {
 
@@ -23,7 +25,20 @@ describe("A DataStream", function() {
     }
 
     it("can be created", function () {
+        var type = new ObjectDescriptor(),
+            query = DataQuery.withTypeAndCriteria(type, {}),
+            stream;
         expect(new DataStream()).toBeDefined();
+        
+        stream = DataStream.withTypeOrSelector(type);
+        expect(stream).toBeDefined();
+        expect(stream.query).toBeDefined();
+        expect(stream.query.type).toBe(type);
+
+        stream = DataStream.withTypeOrSelector(query);
+        expect(stream).toBeDefined();
+        expect(stream.query).toBe(query);
+        expect(stream.query.type).toBe(type);
     });
 
     it("has a an initially empty data array", function () {

--- a/test/spec/data/expression-data-mapping.js
+++ b/test/spec/data/expression-data-mapping.js
@@ -118,6 +118,7 @@ describe("An Expression Data Mapping", function() {
     plotSummaryModuleReference = new ModuleReference().initWithIdAndRequire("spec/data/logic/model/plot-summary", require);
     plotSummaryObjectDescriptor = new ModuleObjectDescriptor().initWithModuleAndExportName(plotSummaryModuleReference, "PlotSummary");
     plotSummaryObjectDescriptor.addPropertyDescriptor(new PropertyDescriptor().initWithNameObjectDescriptorAndCardinality("summary", plotSummaryObjectDescriptor, 1));
+    plotSummaryObjectDescriptor.addPropertyDescriptor(new PropertyDescriptor().initWithNameObjectDescriptorAndCardinality("movie", movieObjectDescriptor, 1));
     plotSummaryPropertyDescriptor = new PropertyDescriptor().initWithNameObjectDescriptorAndCardinality("plotSummary", movieObjectDescriptor, 1);
     plotSummaryPropertyDescriptor.valueDescriptor = plotSummaryObjectDescriptor;
     movieObjectDescriptor.addPropertyDescriptor(plotSummaryPropertyDescriptor);
@@ -156,7 +157,8 @@ describe("An Expression Data Mapping", function() {
     summaryConverter.service = plotSummaryService;
     movieMapping.addObjectMappingRule("plotSummary", {
         "<-": "{movie_id: id}",
-        converter: summaryConverter
+        converter: summaryConverter,
+        inversePropertyName: "movie"
     });
     movieMapping.addRawDataMappingRule("category_id", {"<-": "category.id"});
     movieMapping.addObjectMappingRule("releaseDate", {
@@ -268,6 +270,28 @@ describe("An Expression Data Mapping", function() {
 
             //Properties defined in own descriptor
             expect(movie.country).toBeDefined(); 
+            done();
+        });
+    });
+
+    it("can map inverse for fetch with updateObjectProperties", function (done) {
+        var movie = mainService.createDataObject(movieObjectDescriptor),
+            data = {
+                name: "Star Wars",
+                category_id: 1,
+                budget: "14000000.00",
+                is_featured: "true",
+                release_date: "05/25/1977",
+                fcc_rating: "pg",
+                country_id: 1
+            };
+        
+        return actionMovieMapping.mapRawDataToObject(data, movie).then(function () {
+            //Properties defined in parent descriptor
+            return mainService.updateObjectProperties(movie, "plotSummary");
+        }).then(function () {
+            expect(movie.plotSummary).toBeDefined();
+            expect(movie.plotSummary.movie).toBe(movie);
             done();
         });
     });

--- a/test/spec/data/logic/model/prop.js
+++ b/test/spec/data/logic/model/prop.js
@@ -1,0 +1,17 @@
+var Montage = require("montage").Montage;
+
+/**
+ * @class Prop
+ * @extends Montage
+ */
+exports.Prop = Montage.specialize({
+
+    movie: {
+        value: undefined
+    },
+
+    name: {
+        value: undefined
+    }
+
+});

--- a/test/spec/data/logic/service/prop-service.js
+++ b/test/spec/data/logic/service/prop-service.js
@@ -1,0 +1,21 @@
+var RawDataService = require("montage/data/service/raw-data-service").RawDataService,
+    CategoryNames = ["Action"];
+
+exports.PropService = RawDataService.specialize(/** @lends PropService.prototype */ {
+
+    _data: {
+        value: [
+            {name: "Falcon"},
+            {name: "Lightsaber"}
+        ]
+    },
+
+    fetchRawData: {
+        value: function (stream) {
+            console.log("PropService.fetchRawData");
+            this.addRawData(stream, this._data);
+            this.rawDataDone(stream);
+        }
+    }
+
+});


### PR DESCRIPTION
This PR fixes 2 issues.

1. Add `isUniquing` to `DataService.deserializeSelf()`

2. Assign an inverseProperty before assigning the requested relationship. 
For example, say you have a relationship from Foo to Bar where: 
- `Foo.bars` is an array of `Bar` objects 
- Each item in `Foo.bars` is assigned the`Foo` as `Bar.foo`

As in the following mapping
```javascript
{
    "root": {
        "prototype": "montage/data/service/expression-data-mapping",
        "values": {
            "rawDataPrimaryKeys":["id"],
            "objectDescriptor": {"@": "FooDescriptor"},
            "objectMapping": {
                "rules": {
                    "bars": {
                        "<-": "{id: id}",
                        "converter": {"@": "barsConverter"},
                        "inversePropertyName": "foo"
                    }
                }
            }
        }
    },

    "FooDescriptor": {
        "object": "data/descriptors/foo.mjson"
    },

    "barsConverter": {
        "prototype": "montage/data/converter/raw-property-value-to-object-converter",
        "values": {
            "convertExpression": "id == id"
        }
    }
}
```

The mapping establishes the contract that when `Foo.bars` is fetched, it is only returned once each item in `Foo.bars` has `item.foo`. However, the promise returned by `DataTrigger.updateObjectProperty()` resolves as soon as the value is set. So if we assign `Foo.bars` before assigning `bar.foo`, the following occurs:
```javascript
mainService.updateObjectProperties(aFoo, "bars").then(function () {
          // items in aFoo.bars do not yet have a foo property
});
```

This PR ensures that `bar.foo` is assigned before `Foo.bars`