### PR TITLE
Fix HtmlFragment attribute removal

### DIFF
--- a/ui/html-fragment.reel/html-fragment.js
+++ b/ui/html-fragment.reel/html-fragment.js
@@ -87,11 +87,11 @@ var HtmlFragment = exports.HtmlFragment = Component.specialize(/** @lends HtmlFr
                             l--;
                         } else {
                             childAttributes = child.attributes;
-                            shouldRemoveAttribute = false;
                             allowedAttributesForTag = allowedAttributes[childTagName] ||
                                 allowedAttributes['*'];
                             
                             for (ii = 0, ll = childAttributes.length; ii < ll; ii++) {
+                                shouldRemoveAttribute = false;
                                 attribute = childAttributes[ii];
                                 attributeName = attribute.name;
                                 attributeValue = attribute.value;


### PR DESCRIPTION


`HtmlFragment#_sanitizeNode()` failed to reset `shouldRemoveAttribute` when considering the next attribute in the attributes array. This caused all attributes after a removed attribute to be removed as well. 

For example, `src` and `title` are allowed attributes and `class` is not. If the `attributes` array is `["src", "class", "title"]`, `title` would be removed because it comes after class. Similarly, if the array was  `["class", "src", "title"]`, all 3 attributes would be removed.
