### PR TITLE
Force localizer to use mr as default require

### DIFF
--- a/core/localizer.js
+++ b/core/localizer.js
@@ -263,7 +263,7 @@ var Localizer = exports.Localizer = Montage.specialize( /** @lends Localizer.pro
     },
 
     _require: {
-        value: global.require
+        value: global.mr
     },
 
     /**


### PR DESCRIPTION
localizer is designed to run with mr, however, it is
possible for global.require to be overridden by another
module when localizer is loaded.