### PR TITLE
Support npm 3+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
   #- COMMAND=integration MONTAGE_VERSION=. MOP_VERSION=latest
   - COMMAND=integration MONTAGE_VERSION=. MOP_VERSION="#master"
 before_install:
-  - "npm set legacy-bundling=true"
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ script: npm run $COMMAND
 env:
   - COMMAND=test
   - COMMAND=test:karma-travis
-  #- COMMAND=integration MONTAGE_VERSION=. MOP_VERSION=latest
-  - COMMAND=integration MONTAGE_VERSION=. MOP_VERSION="#master"
+  - COMMAND=integration MONTAGE_VERSION=. MOP_VERSION="#feature/npm3"
 before_install:
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js:
-  - "4"
+  - 4
+  - 6
+  - 8
+  - 10
 script: npm run $COMMAND
 env:
   - COMMAND=test

--- a/montage.js
+++ b/montage.js
@@ -799,34 +799,8 @@
                     hash: params.montageHash
                 })
                 .then(function (montageRequire) {
-                    // load the promise package so we can inject the bootstrapped
-                    // promise library back into it
-                    var promiseLocation;
-                    if (params.promiseLocation) {
-                        promiseLocation = URL.resolve(Require.getLocation(), params.promiseLocation);
-                    } else {
-                        //promiseLocation = URL.resolve(montageLocation, "packages/mr/packages/q");
-                        //node tools/build --features="core timers call_get" --browser
-                        promiseLocation = URL.resolve(montageLocation, "node_modules/bluebird");
-                    }
-
-                    var result = [
-                        montageRequire,
-                        montageRequire.loadPackage({
-                            location: promiseLocation,
-                            hash: params.promiseHash
-                        })
-                    ];
-
-                    return result;
-                })
-                .spread(function (montageRequire, promiseRequire) {
                     montageRequire.inject("core/mini-url", URL);
                     montageRequire.inject("core/promise", {Promise: Promise});
-                    promiseRequire.inject("bluebird", Promise);
-
-                    // This prevents bluebird to be loaded twice by mousse's code
-                    promiseRequire.inject("js/browser/bluebird", Promise);
 
                     // install the linter, which loads on the first error
                     config.lint = function (module) {

--- a/node.js
+++ b/node.js
@@ -72,12 +72,11 @@ function getMontageMontageDeserializer() {
         return getMontageMontageDeserializer._promise;
     }
 
-    return (getMontageMontageDeserializer._promise = MontageBoot.loadPackage(
-            PATH.join(__dirname, "."), {mainPackageLocation: PATH.join(__dirname, "../")})
+    return (getMontageMontageDeserializer._promise = MontageBoot.loadPackage(PATH.join(__dirname, "."))
         .then(function (mr) {
             return mr.async("./core/serialization/deserializer/montage-deserializer")
             .then(function (MontageDeserializerModule) {
-                return (MontageBoot.MontageDeserializer = 
+                return (MontageBoot.MontageDeserializer =
                     MontageDeserializerModule.MontageDeserializer
                 );
             });

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "frb": "~4.0.x",
     "htmlparser2": "~3.0.5",
     "q-io": "^1.13.3",
-    "mr": "^17.0.11",
+    "mr": "montagejs/mr#feature/npm3",
     "weak-map": "^1.0.5",
     "lodash.kebabcase": "^4.1.1",
     "lodash.camelcase": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "montage",
-  "version": "17.2.1",
+  "version": "18.0.0-rc1",
   "description": "Build your next application with a browser based platform that really gets the web.",
   "license": "BSD-3-Clause",
   "repository": {
@@ -9,8 +9,8 @@
   },
   "main": "montage",
   "engines": {
-    "node": "<=4.9.1",
-    "npm": "<=2.15.11"
+    "node": ">=4",
+    "npm": ">=2"
   },
   "overlay": {
     "browser": {
@@ -53,7 +53,7 @@
     "frb": "~4.0.x",
     "htmlparser2": "~3.0.5",
     "q-io": "^1.13.3",
-    "mr": "montagejs/mr#feature/npm3",
+    "mr": "18.0.0-rc1",
     "weak-map": "^1.0.5",
     "lodash.kebabcase": "^4.1.1",
     "lodash.camelcase": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "montage",
-  "version": "18.0.0-rc1",
+  "version": "18.0.0-rc2",
   "description": "Build your next application with a browser based platform that really gets the web.",
   "license": "BSD-3-Clause",
   "repository": {
@@ -53,7 +53,7 @@
     "frb": "~4.0.x",
     "htmlparser2": "~3.0.5",
     "q-io": "^1.13.3",
-    "mr": "18.0.0-rc1",
+    "mr": "18.0.0-rc2",
     "weak-map": "^1.0.5",
     "lodash.kebabcase": "^4.1.1",
     "lodash.camelcase": "^4.3.0",


### PR DESCRIPTION
This is a partial application of #1928 which contains only changes needed for npm 3 support. #1928 its sister PRs in mr and mop introduced too many changes to review all at once.

See montagejs/mr#145 for details on how this impacts existing apps.