### PR TITLE
Allow undefined arguments to be passed to Object.assign

### DIFF
--- a/core/shim/object.js
+++ b/core/shim/object.js
@@ -81,9 +81,11 @@ if (!Object.assign) {
             }
             for (s = 1, ss = arguments.length; s < ss; ++s) {
                 source = arguments[s];
-                keys = source ? Object.keys(source) : [];
-                for (k = 0, kk = keys.length; k < kk; ++k) {
-                    target[keys[k]] = source[keys[k]];
+                if (source) {
+                    keys = Object.keys(source);
+                    for (k = 0, kk = keys.length; k < kk; ++k) {
+                        target[keys[k]] = source[keys[k]];
+                    }
                 }
             }
             return target;

--- a/core/shim/object.js
+++ b/core/shim/object.js
@@ -81,7 +81,7 @@ if (!Object.assign) {
             }
             for (s = 1, ss = arguments.length; s < ss; ++s) {
                 source = arguments[s];
-                keys = Object.keys(source);
+                keys = source ? Object.keys(source) : [];
                 for (k = 0, kk = keys.length; k < kk; ++k) {
                     target[keys[k]] = source[keys[k]];
                 }

--- a/test/spec/core/core-spec.js
+++ b/test/spec/core/core-spec.js
@@ -658,4 +658,19 @@ describe("core/core-spec", function () {
             expect(delegate.methodToBeCalled).toHaveBeenCalled();
         });
     });
+
+    describe("Object shim", function () {
+
+        it("should accept undefined arguments to assign()", function () {
+            var object = {aProperty: 23},
+                error = null;
+            try {
+                Object.assign(object, undefined);
+            } catch (e) {
+                error = e;
+            }
+            expect(error).toBeNull();
+        });
+    });
+
 });


### PR DESCRIPTION
`Object.assign()` should not throw if given undefined or null arguments, per MDN. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign (last line of description section as of this writing)

his PR updates the object polyfill accordingly. 