### PR TITLE
Remove creation of extra promises from reviver

### DIFF
--- a/core/serialization/deserializer/montage-interpreter.js
+++ b/core/serialization/deserializer/montage-interpreter.js
@@ -130,8 +130,6 @@ var MontageContext = Montage.specialize({
                 objects = this._objects,
                 object;
 
-
-
             if (label in objects) {
                 return objects[label];
             } else if (label in serialization) {
@@ -208,12 +206,8 @@ var MontageContext = Montage.specialize({
                 result;
 
             if (typeof reviver.didReviveObjects === "function") {
-                result = reviver.didReviveObjects(this._objects, this);
-                if (Promise.is(result)) {
-                    return result.then(function() {
-                        return self._objects;
-                    });
-                }
+                reviver.didReviveObjects(this._objects, this);
+                return self._objects;
             }
 
             return this._objects;

--- a/test/spec/serialization/reviver-spec.js
+++ b/test/spec/serialization/reviver-spec.js
@@ -41,12 +41,20 @@ describe("reviver", function() {
                             return;
                         },
                         setObjectLabel: function() {}
-                    };
+                    },
+                    revived;
 
-                reviver.reviveRootObject({}, context, "external").catch(function (err) {
+                try {
+                    revived = reviver.reviveRootObject({}, context, "external")
+                } catch (err) {
+                    revived = Promise.reject(err);
+                }
+
+                revived.then(function () {
+                    throw new Error("expected to throw");
+                }, function (err) {
                     expect(err).toBeDefined();
-                    done();
-                });
+                }).finally(done);
             });
         });
 


### PR DESCRIPTION
Currently the reviver takes care of ensuring all of its APIs return promises, even when a value can be revived synchronously. The reviver is really only used by the montage deserializer, and in the future we want to be able to add a sync option to the deserializer to delay the instantiation phase of MJSON compilation. This PR moves the responsibility of promisifying up to the deserializer, so that adding a sync option will be simpler. Along the way, we also avoid creating extra promises where we don't need to.